### PR TITLE
Add CompleteResult as a wrapper around ScoredResult to improve usability

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/command/BatchDelete.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/BatchDelete.java
@@ -3,6 +3,7 @@ package io.zulia.client.command;
 import io.zulia.client.command.base.SimpleCommand;
 import io.zulia.client.pool.ZuliaConnection;
 import io.zulia.client.result.BatchDeleteResult;
+import io.zulia.client.result.CompleteResult;
 import io.zulia.client.result.SearchResult;
 import io.zulia.message.ZuliaServiceOuterClass;
 import io.zulia.message.ZuliaServiceOuterClass.DeleteResponse;
@@ -11,7 +12,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import static io.zulia.message.ZuliaQuery.ScoredResult;
 import static io.zulia.message.ZuliaServiceGrpc.ZuliaServiceBlockingStub;
 import static io.zulia.message.ZuliaServiceOuterClass.BatchDeleteRequest;
 
@@ -30,8 +30,8 @@ public class BatchDelete extends SimpleCommand<ZuliaServiceOuterClass.BatchDelet
 
 	public BatchDelete deleteDocumentFromQueryResult(SearchResult queryResult) {
 
-		for (ScoredResult sr : queryResult.getResults()) {
-			Delete delete = new DeleteDocument(sr.getUniqueId(), sr.getIndexName());
+		for (CompleteResult completeResult : queryResult.getCompleteResults()) {
+			Delete delete = new DeleteDocument(completeResult.getUniqueId(), completeResult.getIndexName());
 			deletes.add(delete);
 		}
 

--- a/zulia-client/src/main/java/io/zulia/client/command/BatchFetch.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/BatchFetch.java
@@ -3,8 +3,8 @@ package io.zulia.client.command;
 import io.zulia.client.command.base.SimpleCommand;
 import io.zulia.client.pool.ZuliaConnection;
 import io.zulia.client.result.BatchFetchResult;
+import io.zulia.client.result.CompleteResult;
 import io.zulia.client.result.SearchResult;
-import io.zulia.message.ZuliaQuery;
 import io.zulia.message.ZuliaServiceGrpc.ZuliaServiceBlockingStub;
 import io.zulia.message.ZuliaServiceOuterClass.BatchFetchRequest;
 import io.zulia.message.ZuliaServiceOuterClass.FetchResponse;
@@ -15,7 +15,6 @@ import java.util.Iterator;
 import java.util.List;
 
 import static io.zulia.message.ZuliaQuery.FetchType;
-import static io.zulia.message.ZuliaQuery.ScoredResult;
 
 /**
  * Fetches multiple documents in a single call
@@ -47,13 +46,13 @@ public class BatchFetch extends SimpleCommand<BatchFetchRequest, BatchFetchResul
 	}
 
 	public BatchFetch addFetchDocumentsFromResults(SearchResult qr) {
-		return addFetchDocumentsFromResults(qr.getResults());
+		return addFetchDocumentsFromResults(qr.getCompleteResults());
 	}
 
-	public BatchFetch addFetchDocumentsFromResults(Collection<ZuliaQuery.ScoredResult> scoredResults) {
+	public BatchFetch addFetchDocumentsFromResults(Collection<CompleteResult> completeResults) {
 
-		for (ScoredResult scoredResult : scoredResults) {
-			Fetch f = new Fetch(scoredResult.getUniqueId(), scoredResult.getIndexName());
+		for (CompleteResult completeResult : completeResults) {
+			Fetch f = new Fetch(completeResult.getUniqueId(), completeResult.getIndexName());
 			f.setResultFetchType(FetchType.FULL);
 			f.setAssociatedFetchType(FetchType.NONE);
 			fetchList.add(f);

--- a/zulia-client/src/main/java/io/zulia/client/pool/ZuliaWorkPool.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ZuliaWorkPool.java
@@ -232,6 +232,10 @@ public class ZuliaWorkPool extends ZuliaBaseWorkPool {
 		searchAll(search, queryResult -> queryResult.getResults().forEach(scoredResultHandler));
 	}
 
+	public void searchAllAsCompleteResult(Search search, Consumer<CompleteResult> completeResultHandler) throws Exception {
+		searchAll(search, queryResult -> queryResult.getCompleteResults().forEach(completeResultHandler));
+	}
+
 	public void searchAll(Search search, Consumer<SearchResult> resultHandler) throws Exception {
 
 		if (search.getAmount() <= 0) {

--- a/zulia-client/src/main/java/io/zulia/client/result/CompleteResult.java
+++ b/zulia-client/src/main/java/io/zulia/client/result/CompleteResult.java
@@ -1,0 +1,88 @@
+package io.zulia.client.result;
+
+import io.zulia.message.ZuliaQuery;
+import io.zulia.util.ResultHelper;
+import io.zulia.util.ZuliaUtil;
+import org.bson.Document;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/***
+ * Wrapper around ScoredResult to make it more convenient to use
+ */
+public class CompleteResult {
+
+	private Document document;
+	private Document metadata;
+
+	private final ZuliaQuery.ScoredResult scoredResult;
+
+	public CompleteResult(ZuliaQuery.ScoredResult scoredResult) {
+		this.scoredResult = scoredResult;
+	}
+
+	public String getUniqueId() {
+		return this.scoredResult.getUniqueId();
+	}
+
+	public float getScore() {
+		return this.scoredResult.getScore();
+	}
+
+	public int getLuceneShardId() {
+		return this.scoredResult.getLuceneShardId();
+	}
+
+	public String getIndexName() {
+		return this.scoredResult.getIndexName();
+	}
+
+	public int getShard() {
+		return this.scoredResult.getShard();
+	}
+
+	public int getResultIndex() {
+		return this.scoredResult.getResultIndex();
+	}
+
+	public ZuliaQuery.SortValues getSortValues() {
+		return this.scoredResult.getSortValues();
+	}
+
+	public long getTimestamp() {
+		return this.scoredResult.getTimestamp();
+	}
+
+	public Document getDocument() {
+		if (document == null) {
+			document = ResultHelper.getDocumentFromScoredResult(scoredResult);
+		}
+		return document;
+	}
+
+	public List<ZuliaQuery.HighlightResult> getHighlightResultList() {
+		return this.scoredResult.getHighlightResultList();
+	}
+
+	public List<String> getHighlightsForField(String field) {
+		List<String> fragments = new ArrayList<>();
+		for (ZuliaQuery.HighlightResult highlightResult : this.scoredResult.getHighlightResultList()) {
+			if (field.equals(highlightResult.getField())) {
+				fragments.addAll(highlightResult.getFragmentsList());
+			}
+		}
+		return fragments;
+	}
+
+	public List<ZuliaQuery.AnalysisResult> getAnalysisResultList() {
+		return this.scoredResult.getAnalysisResultList();
+	}
+
+	public Document getMetadata() {
+		if (metadata == null) {
+			metadata = ZuliaUtil.byteStringToMongoDocument(scoredResult.getResultDocument().getMetadata());
+		}
+		return metadata;
+	}
+}

--- a/zulia-client/src/main/java/io/zulia/client/result/SearchResult.java
+++ b/zulia-client/src/main/java/io/zulia/client/result/SearchResult.java
@@ -34,13 +34,34 @@ public class SearchResult extends Result {
 		return !queryResponse.getResultsList().isEmpty();
 	}
 
+	/**
+	 * use getCompleteResults instead
+	 * @return
+	 */
+	@Deprecated
 	public List<ScoredResult> getResults() {
 		return queryResponse.getResultsList();
 	}
 
+	public List<CompleteResult> getCompleteResults() {
+		return queryResponse.getResultsList().stream().map(CompleteResult::new).toList();
+	}
+
+	/**
+	 * use getFirstCompleteResult instead
+	 * @return
+	 */
+	@Deprecated()
 	public ScoredResult getFirstResult() {
 		if (hasResults()) {
 			return getResults().get(0);
+		}
+		return null;
+	}
+
+	public CompleteResult getFirstCompleteResult() {
+		if (hasResults()) {
+			return new CompleteResult(queryResponse.getResultsList().get(0));
 		}
 		return null;
 	}
@@ -105,7 +126,7 @@ public class SearchResult extends Result {
 
 	public Document getFirstDocument() {
 		if (hasResults()) {
-			Document doc = ResultHelper.getDocumentFromScoredResult(getResults().get(0));
+			Document doc = getFirstCompleteResult().getDocument();
 			if (doc != null) {
 				return doc;
 			}

--- a/zulia-client/src/test/java/io/zulia/client/WikiExamples.java
+++ b/zulia-client/src/test/java/io/zulia/client/WikiExamples.java
@@ -20,6 +20,7 @@ import io.zulia.client.config.ClientIndexConfig;
 import io.zulia.client.config.ZuliaPoolConfig;
 import io.zulia.client.pool.ZuliaWorkPool;
 import io.zulia.client.result.AssociatedResult;
+import io.zulia.client.result.CompleteResult;
 import io.zulia.client.result.FetchResult;
 import io.zulia.client.result.GetFieldsResult;
 import io.zulia.client.result.GetNodesResult;
@@ -331,8 +332,8 @@ public class WikiExamples {
 		long totalHits = searchResult.getTotalHits();
 
 		System.out.println("Found <" + totalHits + "> hits");
-		for (ZuliaQuery.ScoredResult sr : searchResult.getResults()) {
-			System.out.println("Matching document <" + sr.getUniqueId() + "> with score <" + sr.getScore() + ">");
+		for (CompleteResult completeResult : searchResult.getCompleteResults()) {
+			System.out.println("Matching document <" + completeResult.getUniqueId() + "> with score <" + completeResult.getScore() + ">");
 		}
 	}
 
@@ -361,9 +362,9 @@ public class WikiExamples {
 		long totalHits = searchResult.getTotalHits();
 
 		System.out.println("Found <" + totalHits + "> hits");
-		for (ZuliaQuery.ScoredResult sr : searchResult.getResults()) {
-			Document doc = ResultHelper.getDocumentFromScoredResult(sr);
-			System.out.println("Matching document <" + sr.getUniqueId() + "> with score <" + sr.getScore() + "> from index <" + sr.getIndexName() + ">");
+		for (CompleteResult completeResult : searchResult.getCompleteResults()) {
+			Document doc = completeResult.getDocument();
+			System.out.println("Matching document <" + completeResult.getUniqueId() + "> with score <" + completeResult.getScore() + "> from index <" + completeResult.getIndexName() + ">");
 			System.out.println(" full document <" + doc + ">");
 		}
 	}
@@ -542,8 +543,10 @@ public class WikiExamples {
 			}
 
 			// variation 3b - when score is needed, searching multiple indexes and index name is needed, or fetch type is NONE/META
-			for (ZuliaQuery.ScoredResult result : searchResult.getResults()) {
-
+			for (CompleteResult result : searchResult.getCompleteResults()) {
+				System.out.println("Result for <" + result.getIndexName() + "> with score <" + result.getScore() + ">");
+				//if fetch type is FULL
+				Document document = result.getDocument();
 			}
 		});
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/AliasTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/AliasTest.java
@@ -191,7 +191,7 @@ public class AliasTest {
 	}
 
 	@AfterAll
-	public void shutdown() throws Exception {
+	public static void shutdown() throws Exception {
 		TestHelper.stopNodes();
 		zuliaWorkPool.shutdown();
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/FieldWildcardTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/FieldWildcardTest.java
@@ -148,7 +148,7 @@ public class FieldWildcardTest {
 	}
 
 	@AfterAll
-	public void shutdown() throws Exception {
+	public static void shutdown() throws Exception {
 		TestHelper.stopNodes();
 		zuliaWorkPool.shutdown();
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/HierarchicalFacetTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/HierarchicalFacetTest.java
@@ -336,7 +336,7 @@ public class HierarchicalFacetTest {
 	}
 
 	@AfterAll
-	public void shutdown() throws Exception {
+	public static void shutdown() throws Exception {
 		TestHelper.stopNodes();
 		zuliaWorkPool.shutdown();
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/IndexTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/IndexTest.java
@@ -341,7 +341,7 @@ public class IndexTest {
 	}
 
 	@AfterAll
-	public void shutdown() throws Exception {
+	public static void shutdown() throws Exception {
 		TestHelper.stopNodes();
 		zuliaWorkPool.shutdown();
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/SimpleJsonTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/SimpleJsonTest.java
@@ -171,7 +171,7 @@ public class SimpleJsonTest {
 	}
 
 	@AfterAll
-	public void shutdown() throws Exception {
+	public static void shutdown() throws Exception {
 		TestHelper.stopNodes();
 		zuliaWorkPool.shutdown();
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/SimpleTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/SimpleTest.java
@@ -299,7 +299,7 @@ public class SimpleTest {
 	}
 
 	@AfterAll
-	public void shutdown() throws Exception {
+	public static void shutdown() throws Exception {
 		TestHelper.stopNodes();
 		zuliaWorkPool.shutdown();
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
@@ -13,6 +13,7 @@ import io.zulia.client.command.builder.Sort;
 import io.zulia.client.command.builder.TermQuery;
 import io.zulia.client.config.ClientIndexConfig;
 import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.CompleteResult;
 import io.zulia.client.result.GetIndexConfigResult;
 import io.zulia.client.result.SearchResult;
 import io.zulia.doc.ResultDocBuilder;
@@ -20,7 +21,6 @@ import io.zulia.fields.FieldConfigBuilder;
 import io.zulia.message.ZuliaIndex.FacetAs.DateHandling;
 import io.zulia.message.ZuliaQuery;
 import io.zulia.message.ZuliaQuery.FacetCount;
-import io.zulia.util.ZuliaUtil;
 import org.bson.Document;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
@@ -224,7 +224,7 @@ public class StartStopTest {
 
 		double lowScore = -1;
 		double highScore = -1;
-		for (ZuliaQuery.ScoredResult result : searchResult.getResults()) {
+		for (CompleteResult result : searchResult.getCompleteResults()) {
 			Assertions.assertTrue(result.getScore() > 0);
 			if (lowScore < 0 || result.getScore() < lowScore) {
 				lowScore = result.getScore();
@@ -235,7 +235,7 @@ public class StartStopTest {
 		search.addSort(new Sort(ZuliaConstants.SCORE_FIELD).descending());
 		searchResult = zuliaWorkPool.search(search);
 
-		for (ZuliaQuery.ScoredResult result : searchResult.getResults()) {
+		for (CompleteResult result : searchResult.getCompleteResults()) {
 			Assertions.assertTrue(result.getScore() > 0);
 			if (highScore < 0 || result.getScore() > highScore) {
 				highScore = result.getScore();
@@ -584,9 +584,9 @@ public class StartStopTest {
 
 			SearchResult sr = zuliaWorkPool.search(s);
 
-			for (ZuliaQuery.ScoredResult result : sr.getResults()) {
+			for (CompleteResult result : sr.getCompleteResults()) {
 
-				Document metadata = ZuliaUtil.byteStringToMongoDocument(result.getResultDocument().getMetadata());
+				Document metadata = result.getMetadata();
 				Assertions.assertEquals("someValue", metadata.getString("test"));
 			}
 
@@ -596,9 +596,9 @@ public class StartStopTest {
 
 			sr = zuliaWorkPool.search(s);
 
-			for (ZuliaQuery.ScoredResult result : sr.getResults()) {
+			for (CompleteResult result : sr.getCompleteResults()) {
 
-				Document metadata = ZuliaUtil.byteStringToMongoDocument(result.getResultDocument().getMetadata());
+				Document metadata =  result.getMetadata();
 				Assertions.assertEquals("someValue", metadata.getString("test"));
 			}
 
@@ -652,7 +652,7 @@ public class StartStopTest {
 	}
 
 	@AfterAll
-	public void shutdown() throws Exception {
+	public static void shutdown() throws Exception {
 		TestHelper.stopNodes();
 		zuliaWorkPool.shutdown();
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/StatTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/StatTest.java
@@ -380,7 +380,7 @@ public class StatTest {
 	}
 
 	@AfterAll
-	public void shutdown() throws Exception {
+	public static void shutdown() throws Exception {
 		TestHelper.stopNodes();
 		zuliaWorkPool.shutdown();
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/VectorTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/VectorTest.java
@@ -111,9 +111,9 @@ public class VectorTest {
 		searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(3, searchResult.getTotalHits());
 
-		Assertions.assertEquals("1",searchResult.getResults().get(0).getUniqueId());
-		Assertions.assertEquals("4",searchResult.getResults().get(1).getUniqueId());
-		Assertions.assertEquals("2",searchResult.getResults().get(2).getUniqueId());
+		Assertions.assertEquals("1",searchResult.getCompleteResults().get(0).getUniqueId());
+		Assertions.assertEquals("4",searchResult.getCompleteResults().get(1).getUniqueId());
+		Assertions.assertEquals("2",searchResult.getCompleteResults().get(2).getUniqueId());
 
 
 		search = new Search(VECTOR_TEST);
@@ -123,7 +123,7 @@ public class VectorTest {
 		search.setAmount(10);
 		searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(1, searchResult.getTotalHits());
-		Assertions.assertEquals("1",searchResult.getResults().get(0).getUniqueId());
+		Assertions.assertEquals("1",searchResult.getCompleteResults().get(0).getUniqueId());
 
 		search = new Search(VECTOR_TEST);
 		search.addQuery(new VectorTopNQuery(new float[] { 1.0f, 0.0f, 0.0f, 0.0f }, 3, "v").addPreFilterQuery(new FilterQuery("blue").addQueryField("description")));
@@ -131,8 +131,8 @@ public class VectorTest {
 		search.setAmount(10);
 		searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(2, searchResult.getTotalHits());
-		Assertions.assertEquals("1",searchResult.getResults().get(0).getUniqueId());
-		Assertions.assertEquals("6",searchResult.getResults().get(1).getUniqueId());
+		Assertions.assertEquals("1",searchResult.getCompleteResults().get(0).getUniqueId());
+		Assertions.assertEquals("6",searchResult.getCompleteResults().get(1).getUniqueId());
 
 
 	}
@@ -153,7 +153,7 @@ public class VectorTest {
 	}
 
 	@AfterAll
-	public void shutdown() throws Exception {
+	public static void shutdown() throws Exception {
 		TestHelper.stopNodes();
 		zuliaWorkPool.shutdown();
 	}


### PR DESCRIPTION
* Added CompleteResult as a wrapper around ScoredResult to improve usability
* Deprecated getFirstResult and getResults in SearchResult, use getCompleteResults and getCompleteFirstResult instead