### PR TITLE
add snappy compression for stored BSON documents and metadata

### DIFF
--- a/zulia-analyzer/src/main/java/io/zulia/server/config/ServerIndexConfig.java
+++ b/zulia-analyzer/src/main/java/io/zulia/server/config/ServerIndexConfig.java
@@ -211,6 +211,10 @@ public class ServerIndexConfig {
 		return indexSettings.getRamBufferMB();
 	}
 
+	public boolean isCompressionEnabled() {
+		return !indexSettings.getDisableCompression();
+	}
+
 	public Set<String> getMatchingFields(String field) {
 		return getMatchingIndexFields(field, true);
 	}

--- a/zulia-client/src/main/java/io/zulia/client/command/UpdateIndex.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/UpdateIndex.java
@@ -46,6 +46,8 @@ public class UpdateIndex extends SimpleCommand<UpdateIndexRequest, UpdateIndexRe
 	private Integer ramBufferMB;
 	private Integer numberOfReplicas;
 
+	private Boolean disableCompression;
+
 	private final UpdateIndexSettings.Operation.Builder analyzerSettingsOperation = UpdateIndexSettings.Operation.newBuilder();
 	private List<ZuliaIndex.AnalyzerSettings> analyzerSettingsList = Collections.emptyList();
 
@@ -311,6 +313,15 @@ public class UpdateIndex extends SimpleCommand<UpdateIndexRequest, UpdateIndexRe
 		return this;
 	}
 
+	public Boolean getDisableCompression() {
+		return disableCompression;
+	}
+
+	public UpdateIndex setDisableCompression(Boolean disableCompression) {
+		this.disableCompression = disableCompression;
+		return this;
+	}
+
 	public Integer getNumberOfReplicas() {
 		return numberOfReplicas;
 	}
@@ -480,6 +491,11 @@ public class UpdateIndex extends SimpleCommand<UpdateIndexRequest, UpdateIndexRe
 		if (ramBufferMB != null) {
 			updateIndexSettings.setSetRamBufferMB(true);
 			updateIndexSettings.setRamBufferMB(ramBufferMB);
+		}
+
+		if (disableCompression != null) {
+			updateIndexSettings.setSetDisableCompression(true);
+			updateIndexSettings.setDisableCompression(disableCompression);
 		}
 
 		updateIndexSettings.setMetaUpdateOperation(metaDataOperation);

--- a/zulia-client/src/main/java/io/zulia/client/config/ClientIndexConfig.java
+++ b/zulia-client/src/main/java/io/zulia/client/config/ClientIndexConfig.java
@@ -38,6 +38,8 @@ public class ClientIndexConfig {
 	private Integer ramBufferMB;
 	private Integer numberOfReplicas;
 
+	private Boolean disableCompression;
+
 	private TreeMap<String, FieldConfig> fieldMap;
 	private TreeMap<String, AnalyzerSettings> analyzerSettingsMap;
 
@@ -102,6 +104,11 @@ public class ClientIndexConfig {
 		return numberOfShards;
 	}
 
+	public ClientIndexConfig setNumberOfShards(Integer numberOfShards) {
+		this.numberOfShards = numberOfShards;
+		return this;
+	}
+
 	public Integer getRamBufferMB() {
 		return ramBufferMB;
 	}
@@ -111,8 +118,12 @@ public class ClientIndexConfig {
 		return this;
 	}
 
-	public ClientIndexConfig setNumberOfShards(Integer numberOfShards) {
-		this.numberOfShards = numberOfShards;
+	public Boolean getDisableCompression() {
+		return disableCompression;
+	}
+
+	public ClientIndexConfig setDisableCompression(Boolean disableCompression) {
+		this.disableCompression = disableCompression;
 		return this;
 	}
 
@@ -337,6 +348,10 @@ public class ClientIndexConfig {
 			isb.setRamBufferMB(ramBufferMB);
 		}
 
+		if (disableCompression != null) {
+			isb.setDisableCompression(disableCompression);
+		}
+
 		if (meta != null) {
 			isb.setMeta(ZuliaUtil.mongoDocumentToByteString(meta));
 		}
@@ -394,6 +409,7 @@ public class ClientIndexConfig {
 
 		this.indexWeight = indexSettings.getIndexWeight();
 		this.ramBufferMB = indexSettings.getRamBufferMB();
+		this.disableCompression = indexSettings.getDisableCompression();
 
 		this.meta = ZuliaUtil.byteStringToMongoDocument(indexSettings.getMeta());
 

--- a/zulia-common/src/main/proto/zulia_base.proto
+++ b/zulia-common/src/main/proto/zulia_base.proto
@@ -7,6 +7,7 @@ message IdInfo {
     uint64 timestamp = 2;
     uint32 majorVersion = 3;
     uint32 minorVersion = 4;
+    bool compressedDoc = 5;
 }
 
 enum MasterSlaveSettings {

--- a/zulia-common/src/main/proto/zulia_index.proto
+++ b/zulia-common/src/main/proto/zulia_index.proto
@@ -59,6 +59,8 @@ message IndexSettings {
 
     repeated FieldMapping fieldMapping = 21;
 
+    bool disableCompression = 22;
+
 }
 
 
@@ -117,6 +119,10 @@ message UpdateIndexSettings {
 
     repeated FieldMapping fieldMapping = 29;
     Operation fieldMappingOperation = 30; // keyed by alias
+
+    bool setDisableCompression = 31;
+    bool disableCompression = 32;
+
 }
 
 

--- a/zulia-server/build.gradle.kts
+++ b/zulia-server/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     implementation("org.mongodb:mongodb-driver-sync:$mongoDriverVersion")
 
     implementation("org.apache.commons:commons-compress:1.22")
-    implementation("org.xerial.snappy:snappy-java:1.1.9.1")
+    implementation("org.xerial.snappy:snappy-java:1.1.10.0")
     implementation(platform("software.amazon.awssdk:bom:$amazonVersion"))
     implementation("software.amazon.awssdk:s3")
 

--- a/zulia-server/src/main/java/io/zulia/server/index/DocumentScoredDocLeafHandler.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/DocumentScoredDocLeafHandler.java
@@ -19,6 +19,7 @@ import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.highlight.TextFragment;
 import org.apache.lucene.util.BytesRef;
+import org.xerial.snappy.Snappy;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -119,6 +120,9 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 			if (meta) {
 				if (metaDocValues != null && metaDocValues.advanceExact(localDocId)) {
 					byte[] metaBytes = BytesRefUtil.getByteArray(metaDocValues.binaryValue());
+					if (idInfo.getCompressedDoc()) {
+						metaBytes = Snappy.uncompress(metaBytes);
+					}
 					rdBuilder.setMetadata(ByteString.copyFrom(metaBytes));
 				}
 			}
@@ -126,6 +130,9 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 			if (full) {
 				if (fullDocValues != null && fullDocValues.advanceExact(localDocId)) {
 					byte[] docBytes = BytesRefUtil.getByteArray(fullDocValues.binaryValue());
+					if (idInfo.getCompressedDoc()) {
+						docBytes = Snappy.uncompress(docBytes);
+					}
 					rdBuilder.setDocument(ByteString.copyFrom(docBytes));
 
 					if (needsHighlight || needsAnalysis || needsDocFiltering) {

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
@@ -553,6 +553,10 @@ public class ZuliaIndexManager {
 				existingSettings.setIndexWeight(updateIndexSettings.getIndexWeight());
 			}
 
+			if (updateIndexSettings.getSetDisableCompression()) {
+				existingSettings.setDisableCompression(updateIndexSettings.getDisableCompression());
+			}
+
 			Operation metaUpdateOperation = updateIndexSettings.getMetaUpdateOperation();
 			if (metaUpdateOperation.getEnable()) {
 				Document existingMeta = ZuliaUtil.byteStringToMongoDocument(existingSettings.getMeta());

--- a/zulia-server/src/test/java/io/zulia/server/test/node/IndexTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/IndexTest.java
@@ -55,6 +55,7 @@ public class IndexTest {
 							.setPinToCache(true));
 
 			indexConfig.setIndexName(INDEX_TEST);
+			indexConfig.setDisableCompression(true);
 			indexConfig.setNumberOfShards(1);
 
 			zuliaWorkPool.createIndex(indexConfig);
@@ -69,6 +70,8 @@ public class IndexTest {
 		{
 
 			ClientIndexConfig indexConfigFromServer = zuliaWorkPool.getIndexConfig(INDEX_TEST).getIndexConfig();
+
+			Assertions.assertTrue(indexConfigFromServer.getDisableCompression());
 
 			Assertions.assertEquals(4, indexConfigFromServer.getFieldConfigMap().size());
 
@@ -139,6 +142,7 @@ public class IndexTest {
 					new Search(INDEX_TEST).setSearchLabel("searching for cash").addQuery(new ScoredQuery("title:cash")).setPinToCache(true));
 			indexConfig.addFieldMapping(new FieldMapping("title").addMappedFields("category").includeSelf());
 			indexConfig.addFieldMapping(new FieldMapping("test").addMappedFields("title", "category"));
+			indexConfig.setDisableCompression(false);
 
 			zuliaWorkPool.createIndex(indexConfig);
 
@@ -146,6 +150,9 @@ public class IndexTest {
 
 		{
 			ClientIndexConfig indexConfigFromServer = zuliaWorkPool.getIndexConfig(INDEX_TEST).getIndexConfig();
+
+			Assertions.assertFalse(indexConfigFromServer.getDisableCompression());
+
 			Assertions.assertEquals(indexConfigFromServer.getFieldConfigMap().size(), 3);
 
 			List<String> defaultSearchFields = indexConfigFromServer.getDefaultSearchFields();
@@ -163,6 +170,7 @@ public class IndexTest {
 		{
 			UpdateIndex updateIndex = new UpdateIndex(INDEX_TEST);
 			updateIndex.setIndexWeight(4);
+			updateIndex.setDisableCompression(true);
 
 			FieldConfigBuilder newField = FieldConfigBuilder.createString("newField").indexAs(DefaultAnalyzers.LC_KEYWORD).sort();
 			updateIndex.mergeFieldConfig(newField);
@@ -176,6 +184,7 @@ public class IndexTest {
 			ClientIndexConfig indexConfigFromServer = zuliaWorkPool.getIndexConfig(INDEX_TEST).getIndexConfig();
 
 			Assertions.assertEquals(4, indexConfigFromServer.getIndexWeight());
+			Assertions.assertTrue(indexConfigFromServer.getDisableCompression());
 			Assertions.assertEquals(4, indexConfigFromServer.getFieldConfigMap().size());
 			ZuliaIndex.FieldConfig newField = indexConfigFromServer.getFieldConfig("newField");
 			Assertions.assertEquals(1, newField.getSortAsCount());

--- a/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
@@ -74,6 +74,7 @@ public class StartStopTest {
 		indexConfig.setIndexName(FACET_TEST_INDEX);
 		indexConfig.setNumberOfShards(1);
 		indexConfig.setShardCommitInterval(20); //force some commits
+		indexConfig.setDisableCompression(true);
 
 		//optional meta
 		indexConfig.setMeta(new Document().append("createTime", new Date()).append("myLabel", "greatLabel"));
@@ -386,6 +387,7 @@ public class StartStopTest {
 		indexConfig.addFieldConfig(FieldConfigBuilder.createBool("testBool").index().facet().sort());
 		indexConfig.setIndexName(FACET_TEST_INDEX);
 		indexConfig.setNumberOfShards(1);
+		indexConfig.setDisableCompression(false); // default values, just for clarity
 
 		zuliaWorkPool.createIndex(indexConfig);
 


### PR DESCRIPTION
add snappy compression for stored BSON documents and metadata by default.  enable it to be turned off via an index flag in create/update index
Closes #108 