### PR TITLE
Add client connection listener handling and move logging

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/command/builder/NumericStat.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/builder/NumericStat.java
@@ -3,12 +3,10 @@ package io.zulia.client.command.builder;
 import io.zulia.message.ZuliaQuery.StatRequest;
 
 import java.util.List;
-import java.util.logging.Logger;
 
 public class NumericStat implements StatBuilder {
 
 	private final StatRequest.Builder statRequestBuilder;
-	private static final Logger LOG = Logger.getLogger(NumericStat.class.getName());
 
 	public NumericStat(String numericField) {
 		statRequestBuilder = StatRequest.newBuilder().setNumericField(numericField);

--- a/zulia-client/src/main/java/io/zulia/client/config/ZuliaPoolConfig.java
+++ b/zulia-client/src/main/java/io/zulia/client/config/ZuliaPoolConfig.java
@@ -1,6 +1,8 @@
 package io.zulia.client.config;
 
 import io.zulia.ZuliaRESTConstants;
+import io.zulia.client.pool.ConnectionListener;
+import io.zulia.client.pool.LoggingConnectionListener;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,6 +21,8 @@ public class ZuliaPoolConfig {
 	private boolean routingEnabled;
 	private boolean nodeUpdateEnabled;
 	private int nodeUpdateInterval;
+
+	private ConnectionListener connectionListener = new LoggingConnectionListener();
 
 	public final static int DEFAULT_DEFAULT_RETRIES = 0;
 	public final static int DEFAULT_MEMBER_UPDATE_INTERVAL = 10000;
@@ -140,4 +144,11 @@ public class ZuliaPoolConfig {
 		return this;
 	}
 
+	public ConnectionListener getConnectionListener() {
+		return connectionListener;
+	}
+
+	public void setConnectionListener(ConnectionListener connectionListener) {
+		this.connectionListener = connectionListener;
+	}
 }

--- a/zulia-client/src/main/java/io/zulia/client/pool/ConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ConnectionListener.java
@@ -1,0 +1,12 @@
+package io.zulia.client.pool;
+
+public interface ConnectionListener {
+
+	void connectionBeforeOpen(ZuliaConnection zuliaConnection);
+
+	void connectionOpened(ZuliaConnection zuliaConnection);
+
+	void connectionBeforeClose(ZuliaConnection zuliaConnection);
+
+	void connectionClosed(ZuliaConnection zuliaConnection);
+}

--- a/zulia-client/src/main/java/io/zulia/client/pool/ConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ConnectionListener.java
@@ -9,4 +9,8 @@ public interface ConnectionListener {
 	void connectionBeforeClose(ZuliaConnection zuliaConnection);
 
 	void connectionClosed(ZuliaConnection zuliaConnection);
+
+	void exceptionClosing(ZuliaConnection zuliaConnection, Exception e);
+
+	void restClientCreated(String server, int restPort);
 }

--- a/zulia-client/src/main/java/io/zulia/client/pool/LoggingConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/LoggingConnectionListener.java
@@ -1,0 +1,37 @@
+package io.zulia.client.pool;
+
+import io.zulia.message.ZuliaBase;
+
+import java.util.logging.Logger;
+
+public class LoggingConnectionListener implements ConnectionListener {
+	private static final Logger LOG = Logger.getLogger(LoggingConnectionListener.class.getName());
+
+	@Override
+	public void connectionBeforeOpen(ZuliaConnection zuliaConnection) {
+		ZuliaBase.Node node = zuliaConnection.getNode();
+		LOG.info("Opening connection #" + zuliaConnection.getConnectionNumberForNode() + " to " + node.getServerAddress() + ":" + node.getServicePort()
+				+ " connection id: " + zuliaConnection.getConnectionId());
+	}
+
+	@Override
+	public void connectionOpened(ZuliaConnection zuliaConnection) {
+		ZuliaBase.Node node = zuliaConnection.getNode();
+		LOG.info("Opened connection #" + zuliaConnection.getConnectionNumberForNode() + " to " + node.getServerAddress() + ":" + node.getServicePort()
+				+ " connection id: " + zuliaConnection.getConnectionId());
+	}
+
+	@Override
+	public void connectionBeforeClose(ZuliaConnection zuliaConnection) {
+		ZuliaBase.Node node = zuliaConnection.getNode();
+		LOG.info("Closing connection #" + zuliaConnection.getConnectionNumberForNode() + " to <" + node.getServerAddress() + ":" + node.getServicePort()
+				+ "> id: " + zuliaConnection.getConnectionId());
+	}
+
+	@Override
+	public void connectionClosed(ZuliaConnection zuliaConnection) {
+		ZuliaBase.Node node = zuliaConnection.getNode();
+		LOG.info("Closed connection #" + zuliaConnection.getConnectionNumberForNode() + " to <" + node.getServerAddress() + ":" + node.getServicePort()
+				+ "> id: " + zuliaConnection.getConnectionId());
+	}
+}

--- a/zulia-client/src/main/java/io/zulia/client/pool/LoggingConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/LoggingConnectionListener.java
@@ -2,6 +2,7 @@ package io.zulia.client.pool;
 
 import io.zulia.message.ZuliaBase;
 
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class LoggingConnectionListener implements ConnectionListener {
@@ -33,5 +34,17 @@ public class LoggingConnectionListener implements ConnectionListener {
 		ZuliaBase.Node node = zuliaConnection.getNode();
 		LOG.info("Closed connection #" + zuliaConnection.getConnectionNumberForNode() + " to <" + node.getServerAddress() + ":" + node.getServicePort()
 				+ "> id: " + zuliaConnection.getConnectionId());
+	}
+
+	@Override
+	public void exceptionClosing(ZuliaConnection zuliaConnection, Exception e) {
+		ZuliaBase.Node node = zuliaConnection.getNode();
+		LOG.log(Level.SEVERE, "Exception closing connection #" + zuliaConnection.getConnectionNumberForNode() + " to <" + node.getServerAddress() + ":"
+				+ node.getServicePort() + "> id: " + zuliaConnection.getConnectionId(), e);
+	}
+
+	@Override
+	public void restClientCreated(String server, int restPort) {
+		LOG.info("Created OkHttp client for server <" + server + "> on port <" + restPort + ">");
 	}
 }

--- a/zulia-client/src/main/java/io/zulia/client/pool/NoOpConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/NoOpConnectionListener.java
@@ -20,4 +20,9 @@ public class NoOpConnectionListener implements ConnectionListener {
 	public void connectionClosed(ZuliaConnection zuliaConnection) {
 
 	}
+
+	@Override
+	public void exceptionClosing(ZuliaConnection zuliaConnection, Exception e) {
+
+	}
 }

--- a/zulia-client/src/main/java/io/zulia/client/pool/NoOpConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/NoOpConnectionListener.java
@@ -1,0 +1,23 @@
+package io.zulia.client.pool;
+
+public class NoOpConnectionListener implements ConnectionListener {
+	@Override
+	public void connectionBeforeOpen(ZuliaConnection zuliaConnection) {
+
+	}
+
+	@Override
+	public void connectionOpened(ZuliaConnection zuliaConnection) {
+
+	}
+
+	@Override
+	public void connectionBeforeClose(ZuliaConnection zuliaConnection) {
+
+	}
+
+	@Override
+	public void connectionClosed(ZuliaConnection zuliaConnection) {
+
+	}
+}

--- a/zulia-client/src/main/java/io/zulia/client/pool/ZuliaConnection.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ZuliaConnection.java
@@ -5,7 +5,6 @@ import io.grpc.ManagedChannelBuilder;
 import io.zulia.message.ZuliaBase.Node;
 import io.zulia.message.ZuliaServiceGrpc;
 
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class ZuliaConnection {
@@ -81,12 +80,11 @@ public class ZuliaConnection {
 				channel.shutdownNow();
 			}
 		}
-		catch (Exception e) {
-			LOG.log(Level.SEVERE, "Exception closing: ", e);
+		finally {
+			channel = null;
+			blockingStub = null;
+			asyncStub = null;
 		}
-		channel = null;
-		blockingStub = null;
-		asyncStub = null;
 
 	}
 

--- a/zulia-client/src/main/java/io/zulia/client/pool/ZuliaConnectionFactory.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ZuliaConnectionFactory.java
@@ -49,7 +49,12 @@ public class ZuliaConnectionFactory extends BasePooledObjectFactory<ZuliaConnect
 		if (connectionListener != null) {
 			connectionListener.connectionBeforeClose(zuliaConnection);
 		}
-		zuliaConnection.close();
+		try {
+			zuliaConnection.close();
+		}
+		catch (Exception e) {
+			connectionListener.exceptionClosing(zuliaConnection, e);
+		}
 		if (connectionListener != null) {
 			connectionListener.connectionClosed(zuliaConnection);
 		}

--- a/zulia-client/src/main/java/io/zulia/client/pool/ZuliaConnectionFactory.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ZuliaConnectionFactory.java
@@ -5,32 +5,53 @@ import org.apache.commons.pool2.BasePooledObjectFactory;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 public class ZuliaConnectionFactory extends BasePooledObjectFactory<ZuliaConnection> {
 
 	private final boolean compressedConnection;
 	private final Node node;
+	private final ConnectionListener connectionListener;
 
-	public ZuliaConnectionFactory(Node node, boolean compressedConnection) {
+	private static final AtomicLong connectionId = new AtomicLong();
+
+	private final AtomicLong connectionForNodeGen;
+
+	public ZuliaConnectionFactory(Node node, boolean compressedConnection, ConnectionListener connectionListener) {
 		this.compressedConnection = compressedConnection;
 		this.node = node;
+		this.connectionListener = connectionListener;
+		this.connectionForNodeGen = new AtomicLong();
 	}
 
 	@Override
 	public ZuliaConnection create() {
-		ZuliaConnection lc = new ZuliaConnection(node);
-		lc.open(compressedConnection);
-		return lc;
+		ZuliaConnection zuliaConnection = new ZuliaConnection(node, compressedConnection, connectionId.getAndIncrement(),
+				connectionForNodeGen.getAndIncrement());
+		if (connectionListener != null) {
+			connectionListener.connectionBeforeOpen(zuliaConnection);
+		}
+		zuliaConnection.open();
+		if (connectionListener != null) {
+			connectionListener.connectionOpened(zuliaConnection);
+		}
+		return zuliaConnection;
 	}
 
 	@Override
 	public PooledObject<ZuliaConnection> wrap(ZuliaConnection obj) {
-		{
-			return new DefaultPooledObject<>(obj);
-		}
+		return new DefaultPooledObject<>(obj);
 	}
 
 	@Override
 	public void destroyObject(PooledObject<ZuliaConnection> p) {
-		p.getObject().close();
+		ZuliaConnection zuliaConnection = p.getObject();
+		if (connectionListener != null) {
+			connectionListener.connectionBeforeClose(zuliaConnection);
+		}
+		zuliaConnection.close();
+		if (connectionListener != null) {
+			connectionListener.connectionClosed(zuliaConnection);
+		}
 	}
 }

--- a/zulia-client/src/main/java/io/zulia/client/pool/ZuliaPool.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ZuliaPool.java
@@ -35,6 +35,7 @@ public class ZuliaPool {
 
 	private static final Logger LOG = Logger.getLogger(ZuliaPool.class.getName());
 
+
 	protected class ZuliaNodeUpdateThread extends Thread {
 
 		ZuliaNodeUpdateThread() {
@@ -74,6 +75,7 @@ public class ZuliaPool {
 	private final ConcurrentHashMap<String, ZuliaRESTClient> zuliaRestPoolMap;
 	private final ConcurrentHashMap<String, Node> nodeKeyToNode;
 
+	private final ConnectionListener connectionListener;
 	private boolean isClosed;
 	private List<Node> nodes;
 	private IndexRouting indexRouting;
@@ -86,6 +88,8 @@ public class ZuliaPool {
 		routingEnabled = zuliaPoolConfig.isRoutingEnabled();
 		nodeUpdateInterval = zuliaPoolConfig.getNodeUpdateInterval();
 		compressedConnection = zuliaPoolConfig.isCompressedConnection();
+
+		connectionListener = zuliaPoolConfig.getConnectionListener();
 
 		zuliaConnectionPoolMap = new ConcurrentHashMap<>();
 		zuliaRestPoolMap = new ConcurrentHashMap<>();
@@ -212,7 +216,7 @@ public class ZuliaPool {
 						GenericObjectPoolConfig<ZuliaConnection> poolConfig = new GenericObjectPoolConfig<>(); //
 						poolConfig.setMaxIdle(maxIdle);
 						poolConfig.setMaxTotal(maxConnections);
-						return new GenericObjectPool<>(new ZuliaConnectionFactory(finalSelectedNode, compressedConnection), poolConfig);
+						return new GenericObjectPool<>(new ZuliaConnectionFactory(finalSelectedNode, compressedConnection, connectionListener), poolConfig);
 					});
 
 					boolean valid = true;


### PR DESCRIPTION
Add client connection listener handling and move logging into LoggingConnectionListener.  ZuliaPoolConfig now has the option to set a ConnectionListener to NoOpConnectionListener, LoggingConnectionListener, or a custom handler.