### PR TITLE
Strict Number Parsing

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/processors/ZuliaPointQueryNodeProcessor.java
+++ b/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/processors/ZuliaPointQueryNodeProcessor.java
@@ -17,7 +17,7 @@ import org.apache.lucene.queryparser.flexible.standard.nodes.PointQueryNode;
 import org.apache.lucene.queryparser.flexible.standard.nodes.TermRangeQueryNode;
 
 import java.text.NumberFormat;
-import java.text.ParseException;
+import java.text.ParsePosition;
 import java.util.List;
 import java.util.Locale;
 
@@ -104,11 +104,12 @@ public class ZuliaPointQueryNodeProcessor extends QueryNodeProcessorImpl {
 
 	private static Number parseNumber(String text, NumberFormat numberFormat, FieldType fieldType) {
 		Number number = null;
-		if (text.length() > 0) {
+		if (!text.isEmpty()) {
 			if (FieldTypeUtil.isNumericFieldType(fieldType)) {
 
-				try {
-					number = numberFormat.parse(text);
+				ParsePosition parsePosition = new ParsePosition(0);
+				number = numberFormat.parse(text, parsePosition);
+				if (parsePosition.getIndex() == text.length()) {
 
 					if (FieldTypeUtil.isNumericIntFieldType(fieldType)) {
 						number = number.intValue();
@@ -123,9 +124,10 @@ public class ZuliaPointQueryNodeProcessor extends QueryNodeProcessorImpl {
 						number = number.doubleValue();
 					}
 				}
-				catch (ParseException e) {
-
+				else {
+					number = null;
 				}
+
 			}
 			else if (FieldTypeUtil.isBooleanFieldType(fieldType)) {
 				number = BooleanUtil.getStringAsBooleanInt(text);

--- a/zulia-server/src/test/java/io/zulia/server/test/node/NumericSetTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/NumericSetTest.java
@@ -293,6 +293,12 @@ public class NumericSetTest {
 		search.addQuery(new FilterQuery("doubleField:[" + numberFormat.format(2.01) + " TO " + numberFormat.format(2444.0) + "]")); // gives 2,444 in US locale
 		searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(2, searchResult.getTotalHits());
+
+		search = new Search(NUMERIC_SET_TEST);
+		search.addQuery(new FilterQuery(
+				"intField,doubleField:[" + numberFormat.format(2.01) + " TO " + numberFormat.format(2444.0) + "]")); // intField is ignored for the double value
+		searchResult = zuliaWorkPool.search(search);
+		Assertions.assertEquals(2, searchResult.getTotalHits());
 	}
 
 	@Test

--- a/zulia-server/src/test/java/io/zulia/server/test/node/T.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/T.java
@@ -1,0 +1,2 @@
+package io.zulia.server.test.node;public class T {
+}


### PR DESCRIPTION
update numeric parsing to be more strict and add test cases.
* floating points can no longer be used to search integer fields (i.e. intField:100.434 will not work)
* values such as 100a will be not be parsed as 100 (i.e. intField:100a will not work)
* values like intField:10.1332/3232.323.1 will no longer search for intField:10