### PR TITLE
Date Time Parsing Improvements

### DIFF
--- a/zulia-common/src/main/java/io/zulia/util/ZuliaDateUtil.java
+++ b/zulia-common/src/main/java/io/zulia/util/ZuliaDateUtil.java
@@ -2,22 +2,89 @@ package io.zulia.util;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Year;
+import java.time.YearMonth;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+import java.time.format.SignStyle;
+import java.time.temporal.ChronoField;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 public class ZuliaDateUtil {
-	public static Long getDateAsLong(String dateString) {
-		try {
-			if (dateString.contains(":")) {
-				return Instant.parse(dateString).toEpochMilli();
-			}
-			else {
-				LocalDate parse = LocalDate.parse(dateString, DateTimeFormatter.ISO_LOCAL_DATE);
-				return parse.atStartOfDay().toInstant(ZoneOffset.UTC).toEpochMilli();
-			}
-		}
-		catch (Exception e) {
-			return null;
-		}
+
+	public static final DateTimeFormatter YEAR_MONTH_DAY_TIME = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4).appendLiteral('-')
+			.appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('-').appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER)
+			.appendLiteral('T').append(ISO_LOCAL_TIME).appendOffsetId().toFormatter();
+
+	public static final DateTimeFormatter YEAR_MONTH_DAY = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4).appendLiteral('-')
+			.appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('-').appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER)
+			.toFormatter();
+
+	public static final DateTimeFormatter YEAR_MONTH = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4).appendLiteral('-')
+			.appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).toFormatter();
+
+	public static final DateTimeFormatter YEAR_ONLY = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4).toFormatter();
+
+	public record DateBounds(long begin, long end) {
+
 	}
+
+	public static DateBounds getParseDate(String dateString) {
+
+		if (dateString.indexOf('/') != -1) {
+			dateString = dateString.replace('/', '-');
+		}
+
+		if (dateString.contains(":")) {
+
+			try {
+				long epochMilli = YEAR_MONTH_DAY_TIME.parse(dateString, Instant::from).toEpochMilli();
+				// if contains timestamp there is no range
+				return new DateBounds(epochMilli, epochMilli);
+			}
+			catch (DateTimeParseException e) {
+				System.out.println(e.getMessage());
+				return null;
+			}
+		}
+		else {
+			LocalDate date;
+			try {
+				date = LocalDate.parse(dateString, YEAR_MONTH_DAY);
+				LocalDateTime startOfDayOnDate = date.atStartOfDay();
+				long begin = startOfDayOnDate.toInstant(ZoneOffset.UTC).toEpochMilli();
+				long end = startOfDayOnDate.plusDays(1).toInstant(ZoneOffset.UTC).toEpochMilli() - 1;
+				return new DateBounds(begin, end);
+			}
+			catch (DateTimeParseException ignored) {
+			}
+			try {
+				date = YearMonth.from(YEAR_MONTH.parse(dateString)).atDay(1);
+				LocalDateTime startOfDayOnDate = date.atStartOfDay();
+				long begin = startOfDayOnDate.toInstant(ZoneOffset.UTC).toEpochMilli();
+				long end = startOfDayOnDate.plusMonths(1).toInstant(ZoneOffset.UTC).toEpochMilli() - 1;
+				return new DateBounds(begin, end);
+			}
+			catch (DateTimeParseException ignored) {
+
+			}
+			try {
+				date = Year.from(YEAR_ONLY.parse(dateString)).atDay(1);
+				LocalDateTime startOfDayOnDate = date.atStartOfDay();
+				long begin = startOfDayOnDate.toInstant(ZoneOffset.UTC).toEpochMilli();
+				long end = startOfDayOnDate.plusYears(1).toInstant(ZoneOffset.UTC).toEpochMilli() - 1;
+				return new DateBounds(begin, end);
+			}
+			catch (DateTimeParseException ignored) {
+				return null;
+			}
+
+		}
+
+	}
+
 }

--- a/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/processors/ZuliaPointQueryNodeProcessor.java
+++ b/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/processors/ZuliaPointQueryNodeProcessor.java
@@ -106,8 +106,18 @@ public class ZuliaPointQueryNodeProcessor extends QueryNodeProcessorImpl {
 							return new MatchNoDocsQueryNode();
 						}
 
-						PointQueryNode lowerNode = new PointQueryNode(field, lowerBounds != null ? lowerBounds.begin() : null, numberFormat);
-						PointQueryNode upperNode = new PointQueryNode(field, upperBounds != null ? upperBounds.end() : null, numberFormat);
+						Long lowerLong = null;
+						if (lowerBounds != null) {
+							lowerLong = termRangeNode.isLowerInclusive() ? lowerBounds.begin() : lowerBounds.end();
+						}
+
+						Long upperLong = null;
+						if (upperBounds != null) {
+							upperLong = termRangeNode.isUpperInclusive() ? upperBounds.end() : upperBounds.begin();
+						}
+
+						PointQueryNode lowerNode = new PointQueryNode(field, lowerLong, numberFormat);
+						PointQueryNode upperNode = new PointQueryNode(field, upperLong, numberFormat);
 
 						return new ZuliaPointRangeQueryNode(lowerNode, upperNode, termRangeNode.isLowerInclusive(), termRangeNode.isUpperInclusive(),
 								indexFieldInfo);

--- a/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
@@ -431,6 +431,11 @@ public class StartStopTest {
 		Assertions.assertEquals(totalRecords, searchResult.getTotalHits());
 
 		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012-8-4 TO 2014}"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(9L * totalRecords / 10, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
 		s.addQuery(new FilterQuery("date:2012"));
 		searchResult = zuliaWorkPool.search(s);
 		Assertions.assertEquals(totalRecords / 2, searchResult.getTotalHits());
@@ -474,6 +479,11 @@ public class StartStopTest {
 		s.addQuery(new FilterQuery("date:[2014-10 TO 2014-11-01]"));
 		searchResult = zuliaWorkPool.search(s);
 		Assertions.assertEquals(totalRecords / 10, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:{2014-10 TO 2014-11-01]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(0, searchResult.getTotalHits());
 
 		s = new Search(FACET_TEST_INDEX);
 		s.addQuery(new FilterQuery("date:2014-10"));

--- a/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
@@ -404,6 +404,110 @@ public class StartStopTest {
 	}
 
 	@Test
+	@Order(3)
+	public void testDates() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		Search s;
+		SearchResult searchResult;
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012 TO 2014]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012-08-04 TO 2014]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012-08-04 TO 2014-10-04]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012-8-4 TO 2014/10/4]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:2012"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 2, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012 TO 2012-08-04]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 2, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012 TO 2012-8-4]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 2, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012 TO 2012/08/04]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 2, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012 TO 2012-08-03]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(0, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:2012-08-04"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 2, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:\"2012/08/04\"")); // must be quoted or escaped
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 2, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:2012\\/08\\/04")); // must be quoted or escaped
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 2, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2014-10 TO 2014-11-01]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 10, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:2014-10"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 10, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2014-10-04 TO 2014-10-05]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(totalRecords / 10, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012-08-03T11:59:00.000Z TO 2012-08-04T00:00:00.000Z]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(30, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012/08/03T11:59:00.000Z TO 2012-08-04T00:00:00.000Z]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(30, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012-08-03T00:00:00.000Z TO 2012-08-03T11:59:99.999Z]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(0, searchResult.getTotalHits());
+
+		s = new Search(FACET_TEST_INDEX);
+		s.addQuery(new FilterQuery("date:[2012-08-03T00:00:00.000Z TO 2012/08/03T11:59:99.999Z]"));
+		searchResult = zuliaWorkPool.search(s);
+		Assertions.assertEquals(0, searchResult.getTotalHits());
+
+	}
+
+	@Test
 	@Order(4)
 	public void reindex() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();


### PR DESCRIPTION
Change date time parsing to allow dates and date time with days and months that are not two digits wide (i.e. allow 2020-1-1 instead of just 2020-01-01)

Change date time parsing to allow '/' in place of '-' in dates (note that outside of range queries the date string must be quoted or the / must be escaped)  (i.e. date:"2020/01/01" or date:2020\/01/01)

Allowing partial dates to be treated as a range i.e. date:2020-01 translates to date:[2020-01-01T00:00:00.000Z TO 2020-01-31T11:59:59.999Z].
Note that previously date:2020-01-01 would have translated to exactly 2020-01-01T00:00:00.000Z, and now it is translated to any time in the that day.

Add some test cases to test parsing and querying