### PR TITLE
Switch shard hashing to use a better hash function

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/pool/IndexRouting.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/IndexRouting.java
@@ -59,8 +59,12 @@ public class IndexRouting {
 		if (shardMapping.isEmpty()) {
 			return null;
 		}
-
-		int shardNumber = ShardUtil.findShardForUniqueId(uniqueId, numberOfShards);
+		
+		int shardNumber = 0;
+		if (numberOfShards > 1) {
+			shardNumber = ShardUtil.findShardForUniqueId(uniqueId, numberOfShards);
+		}
+		
 		return shardMapping.get(shardNumber);
 	}
 

--- a/zulia-common/src/main/java/io/zulia/util/ShardUtil.java
+++ b/zulia-common/src/main/java/io/zulia/util/ShardUtil.java
@@ -2,6 +2,18 @@ package io.zulia.util;
 
 public class ShardUtil {
 	public static int findShardForUniqueId(String uniqueId, int numOfShards) {
-		return Math.abs(uniqueId.hashCode()) % numOfShards;
+		return (int) Math.abs(djb2Hash(uniqueId)) % numOfShards;
 	}
+	
+	public static long djb2Hash(String str) {
+		
+		long hash = 5381;
+		
+		for (int i = 0; i < str.length(); i++) {
+			hash = ((hash << 5) + hash) + str.charAt(i);
+		}
+		
+		return hash;
+	}
+	
 }


### PR DESCRIPTION
Breaking change that requires reindexing for Zulia clusters with shards:  Switch shard hashing to use a better hash function than the built in java hashcode().  Shortcircuit computing the hash if only one shard.