### PR TITLE
Indexing While Searching Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ across servers.
 * Distributed
 * Pure Java
 * Open Source
-* Based on Lucene 9.x
+* Based on Lucene 10.x
 
 ## Zulia supports:
 

--- a/zulia-ai/src/main/java/io/zulia/ai/features/stat/FeatureStatGenerator.java
+++ b/zulia-ai/src/main/java/io/zulia/ai/features/stat/FeatureStatGenerator.java
@@ -4,10 +4,10 @@ import com.datadoghq.sketch.ddsketch.DDSketch;
 import com.datadoghq.sketch.ddsketch.DDSketches;
 
 public class FeatureStatGenerator {
-	
+
 	private final int numberOfFeatures;
 	private final DDSketch[] featureSketches;
-	
+
 	public FeatureStatGenerator(int numberOfFeatures) {
 		this.numberOfFeatures = numberOfFeatures;
 		this.featureSketches = new DDSketch[numberOfFeatures];
@@ -15,25 +15,25 @@ public class FeatureStatGenerator {
 			featureSketches[i] = DDSketches.unboundedDense(0.0001);
 		}
 	}
-	
+
 	public void addExample(double[] features) {
 		if (features.length != numberOfFeatures) {
-			throw new IllegalArgumentException("Number of features <" + numberOfFeatures + "> does not match features array size <" + features.length + ">");
+			throw new IllegalArgumentException("Number of features " + numberOfFeatures + " does not match features array size " + features.length);
 		}
 		for (int i = 0; i < numberOfFeatures; i++) {
 			featureSketches[i].accept(features[i]);
 		}
 	}
-	
+
 	public void addExample(float[] features) {
 		if (features.length != numberOfFeatures) {
-			throw new IllegalArgumentException("Number of features <" + numberOfFeatures + "> does not match features array size <" + features.length + ">");
+			throw new IllegalArgumentException("Number of features " + numberOfFeatures + " does not match features array size " + features.length);
 		}
 		for (int i = 0; i < numberOfFeatures; i++) {
 			featureSketches[i].accept(features[i]);
 		}
 	}
-	
+
 	public FeatureStat[] computeFeatureStats() {
 		FeatureStat[] featureStats = new FeatureStat[numberOfFeatures];
 		for (int i = 0; i < numberOfFeatures; i++) {
@@ -53,5 +53,5 @@ public class FeatureStatGenerator {
 		}
 		return featureStats;
 	}
-	
+
 }

--- a/zulia-analyzer/src/main/java/io/zulia/server/analysis/ZuliaPerFieldAnalyzer.java
+++ b/zulia-analyzer/src/main/java/io/zulia/server/analysis/ZuliaPerFieldAnalyzer.java
@@ -129,7 +129,7 @@ public class ZuliaPerFieldAnalyzer extends DelegatingAnalyzerWrapper {
 					src = new StandardTokenizer();
 				}
 				else {
-					throw new RuntimeException("Unknown tokenizer type <" + tokenizer);
+					throw new RuntimeException("Unknown tokenizer type " + tokenizer);
 				}
 
 				return new TokenStreamComponents(src, getFilteredStream(src));
@@ -219,7 +219,7 @@ public class ZuliaPerFieldAnalyzer extends DelegatingAnalyzerWrapper {
 						tok = new GermanNormalizationFilter(lastTok);
 					}
 					else {
-						throw new RuntimeException("Unknown filter type <" + filter + ">");
+						throw new RuntimeException("Unknown filter type " + filter);
 					}
 					lastTok = tok;
 				}

--- a/zulia-client/src/main/java/io/zulia/client/command/Fetch.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/Fetch.java
@@ -25,6 +25,8 @@ public class Fetch extends SimpleCommand<FetchRequest, FetchResult> implements S
 	private Set<String> documentFields = Collections.emptySet();
 	private Set<String> documentMaskedFields = Collections.emptySet();
 
+	private Boolean realtime;
+
 	public Fetch(String uniqueId, String indexName) {
 		this.uniqueId = uniqueId;
 		this.indexName = indexName;
@@ -91,6 +93,15 @@ public class Fetch extends SimpleCommand<FetchRequest, FetchResult> implements S
 		return this;
 	}
 
+	public Boolean getRealtime() {
+		return realtime;
+	}
+
+	public Fetch setRealtime(boolean realtime) {
+		this.realtime = realtime;
+		return this;
+	}
+
 	@Override
 	public FetchRequest getRequest() {
 		FetchRequest.Builder fetchRequestBuilder = FetchRequest.newBuilder();
@@ -108,6 +119,9 @@ public class Fetch extends SimpleCommand<FetchRequest, FetchResult> implements S
 		}
 		if (associatedFetchType != null) {
 			fetchRequestBuilder.setAssociatedFetchType(associatedFetchType);
+		}
+		if (realtime != null) {
+			fetchRequestBuilder.setRealtime(realtime);
 		}
 
 		fetchRequestBuilder.addAllDocumentFields(documentFields);

--- a/zulia-client/src/main/java/io/zulia/client/command/GetFields.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/GetFields.java
@@ -16,6 +16,7 @@ import static io.zulia.message.ZuliaServiceGrpc.ZuliaServiceBlockingStub;
 public class GetFields extends SimpleCommand<ZuliaServiceOuterClass.GetFieldNamesRequest, GetFieldsResult> implements SingleIndexRoutableCommand {
 
 	private final String indexName;
+	private Boolean realtime;
 
 	public GetFields(String indexName) {
 		this.indexName = indexName;
@@ -26,9 +27,23 @@ public class GetFields extends SimpleCommand<ZuliaServiceOuterClass.GetFieldName
 		return indexName;
 	}
 
+	public Boolean getRealtime() {
+		return realtime;
+	}
+
+	public GetFields setRealtime(boolean realtime) {
+		this.realtime = realtime;
+		return this;
+	}
+
+
 	@Override
 	public ZuliaServiceOuterClass.GetFieldNamesRequest getRequest() {
-		return ZuliaServiceOuterClass.GetFieldNamesRequest.newBuilder().setIndexName(indexName).build();
+		ZuliaServiceOuterClass.GetFieldNamesRequest.Builder builder = ZuliaServiceOuterClass.GetFieldNamesRequest.newBuilder();
+		if (realtime != null) {
+			builder.setRealtime(realtime);
+		}
+		return builder.setIndexName(indexName).build();
 	}
 
 	@Override

--- a/zulia-client/src/main/java/io/zulia/client/command/GetTerms.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/GetTerms.java
@@ -2,6 +2,7 @@ package io.zulia.client.command;
 
 import io.zulia.client.command.base.SimpleCommand;
 import io.zulia.client.command.base.SingleIndexRoutableCommand;
+import io.zulia.client.command.builder.Search;
 import io.zulia.client.pool.ZuliaConnection;
 import io.zulia.client.result.GetTermsResult;
 import io.zulia.message.ZuliaServiceOuterClass;
@@ -24,6 +25,7 @@ public class GetTerms extends SimpleCommand<GetTermsRequest, GetTermsResult> imp
 	private String termMatch;
 	private Integer amount;
 	private List<String> includeTerms;
+	private Boolean realtime;
 
 	public GetTerms(String indexName, String fieldName) {
 		this.indexName = indexName;
@@ -120,6 +122,17 @@ public class GetTerms extends SimpleCommand<GetTermsRequest, GetTermsResult> imp
 		return this;
 	}
 
+	public Boolean getRealtime() {
+		return realtime;
+	}
+
+	public GetTerms setRealtime(boolean realtime) {
+		this.realtime = realtime;
+		return this;
+	}
+
+
+
 	@Override
 	public GetTermsRequest getRequest() {
 		GetTermsRequest.Builder getTermsRequestBuilder = GetTermsRequest.newBuilder().setIndexName(indexName).setFieldName(fieldName);
@@ -146,6 +159,9 @@ public class GetTerms extends SimpleCommand<GetTermsRequest, GetTermsResult> imp
 		}
 		if (includeTerms != null) {
 			getTermsRequestBuilder.addAllIncludeTerm(includeTerms);
+		}
+		if (realtime != null) {
+			getTermsRequestBuilder.setRealtime(realtime);
 		}
 		return getTermsRequestBuilder.build();
 	}

--- a/zulia-client/src/main/java/io/zulia/client/command/builder/Search.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/builder/Search.java
@@ -25,7 +25,6 @@ public class Search extends SimpleCommand<QueryRequest, SearchResult> implements
 	private final ZuliaQuery.FacetRequest.Builder facetRequest = ZuliaQuery.FacetRequest.newBuilder();
 	private final ZuliaQuery.SortRequest.Builder sortRequest = ZuliaQuery.SortRequest.newBuilder();
 
-
 	public Search(String... indexes) {
 		this(Arrays.asList(indexes));
 	}
@@ -266,6 +265,15 @@ public class Search extends SimpleCommand<QueryRequest, SearchResult> implements
 
 	public String getSearchLabel() {
 		return queryRequest.getSearchLabel();
+	}
+
+	public Search setRealtime(boolean realtime) {
+		queryRequest.setRealtime(realtime);
+		return this;
+	}
+
+	public boolean getRealtime() {
+		return queryRequest.getRealtime();
 	}
 
 	@Override

--- a/zulia-client/src/main/java/io/zulia/client/pool/JULLoggingConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/JULLoggingConnectionListener.java
@@ -27,27 +27,27 @@ public class JULLoggingConnectionListener implements ConnectionListener {
 	@Override
 	public void connectionBeforeClose(ZuliaConnection zuliaConnection) {
 		ZuliaBase.Node node = zuliaConnection.getNode();
-		LOG.info("Closing connection #" + zuliaConnection.getConnectionNumberForNode() + " to <" + node.getServerAddress() + ":" + node.getServicePort()
-				+ "> id: " + zuliaConnection.getConnectionId());
+		LOG.info("Closing connection #" + zuliaConnection.getConnectionNumberForNode() + " to " + node.getServerAddress() + ":" + node.getServicePort()
+				+ " id: " + zuliaConnection.getConnectionId());
 	}
 
 	@Override
 	public void connectionClosed(ZuliaConnection zuliaConnection) {
 		ZuliaBase.Node node = zuliaConnection.getNode();
-		LOG.info("Closed connection #" + zuliaConnection.getConnectionNumberForNode() + " to <" + node.getServerAddress() + ":" + node.getServicePort()
-				+ "> id: " + zuliaConnection.getConnectionId());
+		LOG.info("Closed connection #" + zuliaConnection.getConnectionNumberForNode() + " to " + node.getServerAddress() + ":" + node.getServicePort()
+				+ " id: " + zuliaConnection.getConnectionId());
 	}
 
 	@Override
 	public void exceptionClosing(ZuliaConnection zuliaConnection, Exception e) {
 		ZuliaBase.Node node = zuliaConnection.getNode();
-		LOG.log(Level.SEVERE, "Exception closing connection #" + zuliaConnection.getConnectionNumberForNode() + " to <" + node.getServerAddress() + ":"
-				+ node.getServicePort() + "> id: " + zuliaConnection.getConnectionId(), e);
+		LOG.log(Level.SEVERE, "Exception closing connection #" + zuliaConnection.getConnectionNumberForNode() + " to " + node.getServerAddress() + ":"
+				+ node.getServicePort() + " id: " + zuliaConnection.getConnectionId(), e);
 	}
 
 	@Override
 	public void restClientCreated(String server, int restPort) {
-		LOG.info("Created OkHttp client for server <" + server + "> on port <" + restPort + ">");
+		LOG.info("Created OkHttp client for server " + server + ":" + restPort);
 	}
 
 	@Override

--- a/zulia-client/src/main/java/io/zulia/client/pool/Slf4jLoggingConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/Slf4jLoggingConnectionListener.java
@@ -26,27 +26,27 @@ public class Slf4jLoggingConnectionListener implements ConnectionListener {
 	@Override
 	public void connectionBeforeClose(ZuliaConnection zuliaConnection) {
 		ZuliaBase.Node node = zuliaConnection.getNode();
-		LOG.info("Closing connection #{} to <{}:{}> id: {}", zuliaConnection.getConnectionNumberForNode(), node.getServerAddress(), node.getServicePort(),
+		LOG.info("Closing connection #{} to {}:{} id: {}", zuliaConnection.getConnectionNumberForNode(), node.getServerAddress(), node.getServicePort(),
 				zuliaConnection.getConnectionId());
 	}
 
 	@Override
 	public void connectionClosed(ZuliaConnection zuliaConnection) {
 		ZuliaBase.Node node = zuliaConnection.getNode();
-		LOG.info("Closed connection #{} to <{}:{}> id: {}", zuliaConnection.getConnectionNumberForNode(), node.getServerAddress(), node.getServicePort(),
+		LOG.info("Closed connection #{} to {}:{} id: {}", zuliaConnection.getConnectionNumberForNode(), node.getServerAddress(), node.getServicePort(),
 				zuliaConnection.getConnectionId());
 	}
 
 	@Override
 	public void exceptionClosing(ZuliaConnection zuliaConnection, Exception e) {
 		ZuliaBase.Node node = zuliaConnection.getNode();
-		LOG.error("Exception closing connection #{} to <{}:{}> id: {}", zuliaConnection.getConnectionNumberForNode(), node.getServerAddress(),
+		LOG.error("Exception closing connection #{} to {}:{} id: {}", zuliaConnection.getConnectionNumberForNode(), node.getServerAddress(),
 				node.getServicePort(), zuliaConnection.getConnectionId(), e);
 	}
 
 	@Override
 	public void restClientCreated(String server, int restPort) {
-		LOG.info("Created OkHttp client for server <{}> on port <{}>", server, restPort);
+		LOG.info("Created OkHttp client for server {}:{}", server, restPort);
 	}
 
 	@Override

--- a/zulia-client/src/main/java/io/zulia/client/rest/ZuliaRESTClient.java
+++ b/zulia-client/src/main/java/io/zulia/client/rest/ZuliaRESTClient.java
@@ -62,8 +62,8 @@ public class ZuliaRESTClient implements AutoCloseable {
 				.ifFailure(new FailureHandler<>()).getBody();
 	}
 
-	public FieldsDTO getFields(String indexName) {
-		return unirestInstance.get(ZuliaRESTConstants.FIELDS_URL).queryString(ZuliaRESTConstants.INDEX, indexName).asObject(FieldsDTO.class)
+	public FieldsDTO getFields(String indexName, boolean realtime) {
+		return unirestInstance.get(ZuliaRESTConstants.FIELDS_URL).queryString(ZuliaRESTConstants.INDEX, indexName).queryString("realtime", realtime).asObject(FieldsDTO.class)
 				.ifFailure(new FailureHandler<>()).getBody();
 	}
 
@@ -72,9 +72,9 @@ public class ZuliaRESTClient implements AutoCloseable {
 		unirestInstance.close();
 	}
 
-	public Document fetchRecord(String indexName, String uniqueId) {
+	public Document fetchRecord(String indexName, String uniqueId, boolean realtime) {
 		String json = unirestInstance.get(ZuliaRESTConstants.FETCH_URL + "/{indexName}/{uniqueId}").routeParam("indexName", indexName)
-				.routeParam("uniqueId", uniqueId).asString().ifFailure(new FailureHandler<>()).getBody();
+				.routeParam("uniqueId", uniqueId).queryString("realtime", realtime).asString().ifFailure(new FailureHandler<>()).getBody();
 		return Document.parse(json);
 	}
 
@@ -82,13 +82,13 @@ public class ZuliaRESTClient implements AutoCloseable {
 		return unirestInstance.get(ZuliaRESTConstants.STATS_URL).asObject(StatsDTO.class).ifFailure(new FailureHandler<>()).getBody();
 	}
 
-	public TermsResponseDTO getTerms(String indexName, String fieldName) {
-		return getTerms(indexName, fieldName, null);
+	public TermsResponseDTO getTerms(String indexName, String fieldName, boolean realtime) {
+		return getTerms(indexName, fieldName, null, realtime);
 	}
 
-	public TermsResponseDTO getTerms(String indexName, String fieldName, TermsRESTOptions termsOptions) {
+	public TermsResponseDTO getTerms(String indexName, String fieldName, TermsRESTOptions termsOptions, boolean realtime) {
 		return unirestInstance.get(ZuliaRESTConstants.TERMS_URL).queryString(ZuliaRESTConstants.INDEX, indexName)
-				.queryString(ZuliaRESTConstants.FIELDS, fieldName).queryString(termsOptions != null ? termsOptions.getParameters() : null)
+				.queryString(ZuliaRESTConstants.FIELDS, fieldName).queryString(termsOptions != null ? termsOptions.getParameters() : null).queryString("realtime", realtime)
 				.asObject(TermsResponseDTO.class).ifFailure(new FailureHandler<>()).getBody();
 	}
 
@@ -257,6 +257,10 @@ public class ZuliaRESTClient implements AutoCloseable {
 		}
 		if (searchRest.getHighlights() != null && !searchRest.getHighlights().isEmpty()) {
 			request = request.queryString(ZuliaRESTConstants.HIGHLIGHT, searchRest.getHighlights());
+		}
+
+		if (searchRest.isRealtime() != null) {
+			request = request.queryString(ZuliaRESTConstants.REALTIME, searchRest.isRealtime());
 		}
 
 		return request.asObject(SearchResultsDTO.class).ifFailure(new FailureHandler<>()).getBody();

--- a/zulia-client/src/main/java/io/zulia/client/rest/options/SearchREST.java
+++ b/zulia-client/src/main/java/io/zulia/client/rest/options/SearchREST.java
@@ -20,6 +20,7 @@ public class SearchREST {
 	private Collection<String> sort;
 	private Collection<String> highlights;
 	private String cursor;
+	private Boolean realtime;
 
 	public SearchREST(String index) {
 		this.indexNames = List.of(index);
@@ -183,10 +184,19 @@ public class SearchREST {
 		return this;
 	}
 
+	public SearchREST setRealtime(Boolean realtime) {
+		this.realtime = realtime;
+		return this;
+	}
+
+	public Boolean isRealtime() {
+		return realtime;
+	}
+
 	@Override
 	public String toString() {
-		return "SearchRest{" + "indexNames=" + indexNames + ", query='" + query + '\'' + ", queryFields=" + queryFields + ", filterQueries=" + filterQueries
-				+ ", fields=" + fields + ", rows=" + rows + ", facet=" + facet + ", drillDowns=" + drillDowns + ", defaultOperator='" + defaultOperator + '\''
-				+ ", mm=" + mm + ", sort=" + sort + ", highlights=" + highlights + ", cursor='" + cursor + '\'' + '}';
+		return "SearchREST{" + "indexNames=" + indexNames + ", query='" + query + '\'' + ", queryFields=" + queryFields + ", filterQueries=" + filterQueries
+				+ ", fields=" + fields + ", rows=" + rows + ", facet=" + facet + ", drillDowns=" + drillDowns + ", defaultOperator=" + defaultOperator + ", mm="
+				+ mm + ", sort=" + sort + ", highlights=" + highlights + ", cursor='" + cursor + '\'' + ", realtime=" + realtime + '}';
 	}
 }

--- a/zulia-client/src/main/java/io/zulia/fields/Mapper.java
+++ b/zulia-client/src/main/java/io/zulia/fields/Mapper.java
@@ -43,7 +43,7 @@ public class Mapper<T> extends GsonDocumentMapper<T> {
 
 		List<Field> allFields = AnnotationUtil.getNonStaticFields(clazz, true);
 
-		UniqueIdFieldInfo uf = null;
+		UniqueIdFieldInfo<T> uf = null;
 		for (Field f : allFields) {
 			f.setAccessible(true);
 

--- a/zulia-client/src/main/java/io/zulia/fields/UniqueIdFieldInfo.java
+++ b/zulia-client/src/main/java/io/zulia/fields/UniqueIdFieldInfo.java
@@ -25,7 +25,7 @@ public class UniqueIdFieldInfo<T> {
 			}
 
 		}
-		throw new RuntimeException("Unique id field <" + field.getName() + "> must not be null");
+		throw new RuntimeException("Unique id field " + field.getName() + " must not be null");
 	}
 
 	public void populate(T newInstance, Document savedDocument) throws Exception {

--- a/zulia-common/src/main/java/io/zulia/ZuliaRESTConstants.java
+++ b/zulia-common/src/main/java/io/zulia/ZuliaRESTConstants.java
@@ -44,6 +44,7 @@ public interface ZuliaRESTConstants {
 	String END_TERM = "endTerm";
 	String DEFAULT_OP = "defaultOp";
 	String DRILL_DOWN = "drillDown";
+	String REALTIME = "realtime";
 	
 	String SIMILARITY = "sim";
 	String START = "start";

--- a/zulia-common/src/main/proto/zulia_service.proto
+++ b/zulia-common/src/main/proto/zulia_service.proto
@@ -75,6 +75,7 @@ message QueryRequest {
     MasterSlaveSettings masterSlaveSettings = 17;
     bool pinToCache = 18;
     string searchLabel = 19;
+    bool realtime = 20;
 }
 
 message QueryResponse {
@@ -134,6 +135,7 @@ message FetchRequest {
     repeated string documentFields = 6;
     repeated string documentMaskedFields = 7;
     MasterSlaveSettings masterSlaveSettings = 8;
+    bool realtime = 9;
 }
 
 message FetchResponse {
@@ -217,6 +219,7 @@ message GetIndexesResponse {
 message GetNumberOfDocsRequest {
     string indexName = 1;
     MasterSlaveSettings masterSlaveSettings = 2;
+    bool realtime = 3;
 }
 
 message InternalGetNumberOfDocsRequest {
@@ -248,6 +251,7 @@ message OptimizeResponse {
 message GetFieldNamesRequest {
     string indexName = 1;
     MasterSlaveSettings masterSlaveSettings = 2;
+    bool realtime = 3;
 }
 
 message InternalGetFieldNamesRequest {
@@ -276,6 +280,7 @@ message GetTermsRequest {
 
     FuzzyTerm fuzzyTerm = 11;
     MasterSlaveSettings masterSlaveSettings = 12;
+    bool realtime = 13;
 }
 
 message InternalGetTermsRequest {

--- a/zulia-data/src/main/java/io/zulia/data/input/FileDataInputStream.java
+++ b/zulia-data/src/main/java/io/zulia/data/input/FileDataInputStream.java
@@ -18,10 +18,10 @@ public class FileDataInputStream implements DataInputStream {
 		dataStreamMeta = DataStreamMeta.fromFullPath(filePath);
 		file = new File(filePath);
 		if (!file.exists()) {
-			throw new FileNotFoundException("File <" + filePath + "> does not exist");
+			throw new FileNotFoundException("File " + filePath + " does not exist");
 		}
 		if (file.isDirectory()) {
-			throw new IOException("File <" + filePath + "> is a directory");
+			throw new IOException("File " + filePath + " is a directory");
 		}
 	}
 

--- a/zulia-data/src/main/java/io/zulia/data/output/FileDataOutputStream.java
+++ b/zulia-data/src/main/java/io/zulia/data/output/FileDataOutputStream.java
@@ -27,10 +27,10 @@ public class FileDataOutputStream implements DataOutputStream {
 		this.dataStreamMeta = DataStreamMeta.fromPath(path);
 		this.file = path.toFile();
 		if (!overwrite && file.exists()) {
-			throw new FileNotFoundException("File <" + file + "> exists and overwrite is false");
+			throw new FileNotFoundException("File " + file + " exists and overwrite is false");
 		}
 		if (file.isDirectory()) {
-			throw new IOException("Cannot write file.  File <" + file + "> is a directory");
+			throw new IOException("Cannot write file.  File " + file + " is a directory");
 		}
 	}
 	
@@ -39,10 +39,10 @@ public class FileDataOutputStream implements DataOutputStream {
 		this.dataStreamMeta = DataStreamMeta.fromFile(file);
 		this.file = file;
 		if (!overwrite && file.exists()) {
-			throw new FileNotFoundException("File <" + file + "> exists and overwrite is false");
+			throw new FileNotFoundException("File " + file + " exists and overwrite is false");
 		}
 		if (file.isDirectory()) {
-			throw new IOException("Cannot write file.  File <" + file + "> is a directory");
+			throw new IOException("Cannot write file.  File " + file + " is a directory");
 		}
 	}
 	
@@ -50,10 +50,10 @@ public class FileDataOutputStream implements DataOutputStream {
 		this.dataStreamMeta = DataStreamMeta.fromFullPath(filePath);
 		this.file = new File(filePath);
 		if (!overwrite && this.file.exists()) {
-			throw new FileNotFoundException("File <" + filePath + "> exists and overwrite is false");
+			throw new FileNotFoundException("File " + filePath + " exists and overwrite is false");
 		}
 		if (this.file.isDirectory()) {
-			throw new IOException("Cannot write file.  File <" + filePath + "> is a directory");
+			throw new IOException("Cannot write file.  File " + filePath + " is a directory");
 		}
 	}
 	

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/DefaultDelimitedListHandler.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/DefaultDelimitedListHandler.java
@@ -15,6 +15,7 @@ public class DefaultDelimitedListHandler implements DelimitedListHandler {
 		this.listDelimiter = listDelimiter;
 	}
 
+	@SuppressWarnings("unchecked")
 	public <T> List<T> cellValueToList(Class<T> clazz, String cellValue) {
 		if (cellValue != null) {
 			Stream<String> listStream = Splitter.on(listDelimiter).splitToStream(cellValue);
@@ -34,7 +35,7 @@ public class DefaultDelimitedListHandler implements DelimitedListHandler {
 				return (List<T>) listStream.map(Double::parseDouble).toList();
 			}
 			else {
-				throw new IllegalArgumentException("Unsupported clazz <" + clazz + ">");
+				throw new IllegalArgumentException("Unsupported clazz " + clazz);
 			}
 		}
 		return null;

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelRecord.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelRecord.java
@@ -33,7 +33,7 @@ public class ExcelRecord implements SpreadsheetRecord {
 		if (headerMapping.hasHeader(field)) {
 			return headerMapping.getHeaderIndex(field);
 		}
-		throw new IllegalStateException("Field <" + field + "> does not exist in header");
+		throw new IllegalStateException("Field " + field + " does not exist in header");
 	}
 
 	public SequencedSet<String> getHeaders() {

--- a/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/SpreadsheetTargetFactory.java
+++ b/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/SpreadsheetTargetFactory.java
@@ -55,8 +55,8 @@ public class SpreadsheetTargetFactory {
 			return ExcelTarget.withConfig(excelDataSourceConfig);
 		}
 		else {
-			throw new IllegalArgumentException("Failed to determine file type from content type <" + dataOutputStream.getMeta()
-							.contentType() + "> with filename <" + dataOutputStream.getMeta().fileName() + ">");
+			throw new IllegalArgumentException("Failed to determine file type from content type " + dataOutputStream.getMeta()
+							.contentType() + " with filename " + dataOutputStream.getMeta().fileName());
 		}
 	}
 }

--- a/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/delimited/formatter/DefaultCSVWriter.java
+++ b/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/delimited/formatter/DefaultCSVWriter.java
@@ -7,11 +7,6 @@ public class DefaultCSVWriter<T extends AbstractWriter<?>> implements Spreadshee
 	
 	@Override
 	public void writeType(T reference, Object value) {
-		if (value != null) {
-			reference.addValue(value);
-		}
-		else {
-			reference.addValue(null);
-		}
+		reference.addValue(value);
 	}
 }

--- a/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/SetQueryHelper.java
+++ b/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/SetQueryHelper.java
@@ -28,13 +28,13 @@ public class SetQueryHelper {
 		String sortField = indexFieldInfo.getInternalSortFieldName();
 
 		if (fieldType == null) {
-			throw new IllegalArgumentException("Field <" + field + "> is not indexed");
+			throw new IllegalArgumentException("Field " + field + " is not indexed");
 		}
 		else {
 			if (FieldTypeUtil.isNumericIntFieldType(fieldType)) {
 				List<Integer> integerValueList = intSupplier.get();
 				if (integerValueList.isEmpty()) {
-					throw new IllegalArgumentException("No integer values for integer field <" + field + "> for numeric set query");
+					throw new IllegalArgumentException("No integer values for integer field " + field + " for numeric set query");
 				}
 
 				Query pointQuery = IntPoint.newSetQuery(searchField, integerValueList);
@@ -47,7 +47,7 @@ public class SetQueryHelper {
 			else if (FieldTypeUtil.isNumericLongFieldType(fieldType)) {
 				List<Long> longValueList = longSupplier.get();
 				if (longValueList.isEmpty()) {
-					throw new IllegalArgumentException("No long values for long field <" + field + "> for numeric set query");
+					throw new IllegalArgumentException("No long values for long field " + field + " for numeric set query");
 				}
 
 				Query pointQuery = LongPoint.newSetQuery(searchField, longValueList);
@@ -73,7 +73,7 @@ public class SetQueryHelper {
 			else if (FieldTypeUtil.isNumericDoubleFieldType(fieldType)) {
 				List<Double> doubleValueList = doubleSupplier.get();
 				if (doubleValueList.isEmpty()) {
-					throw new IllegalArgumentException("No double values for double field <" + field + "> for numeric set query");
+					throw new IllegalArgumentException("No double values for double field " + field + " for numeric set query");
 				}
 
 				Query pointQuery = DoublePoint.newSetQuery(searchField, doubleValueList);
@@ -84,7 +84,7 @@ public class SetQueryHelper {
 				return new IndexOrDocValuesQuery(pointQuery, SortedNumericDocValuesField.newSlowSetQuery(sortField, pointsArray));
 			}
 		}
-		throw new IllegalArgumentException("No field type of <" + fieldType + "> is not supported for numeric set queries");
+		throw new IllegalArgumentException("No field type of " + fieldType + " is not supported for numeric set queries");
 	}
 
 	public static Query getTermInSetQuery(List<String> terms, String field, IndexFieldInfo indexFieldInfo) {
@@ -105,6 +105,6 @@ public class SetQueryHelper {
 			return new TermInSetQuery(field, termBytesRef);
 		}
 		throw new IllegalArgumentException(
-				"Field type of <" + indexFieldInfo.getFieldType() + "> is not supported for term queries.  Only STRING is supported.");
+				"Field type of " + indexFieldInfo.getFieldType() + " is not supported for term queries.  Only STRING is supported.");
 	}
 }

--- a/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/ZuliaFlexibleQueryParser.java
+++ b/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/ZuliaFlexibleQueryParser.java
@@ -42,7 +42,7 @@ public class ZuliaFlexibleQueryParser implements ZuliaParser {
 
 				}
 				catch (Exception e) {
-					throw new IllegalArgumentException("Invalid queryText field boost <" + field + ">");
+					throw new IllegalArgumentException("Invalid queryText field boost " + field);
 				}
 			}
 

--- a/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/node/ZuliaNumericSetQueryNode.java
+++ b/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/node/ZuliaNumericSetQueryNode.java
@@ -37,7 +37,7 @@ public class ZuliaNumericSetQueryNode extends ZuliaFieldableQueryNode {
 
 	public Query getQuery() {
 		Objects.requireNonNull(getField(), "Field must not be null for numeric set queries");
-		Objects.requireNonNull(getIndexFieldInfo(), "Field <" + getField() + "> must be indexed for numeric set queries");
+		Objects.requireNonNull(getIndexFieldInfo(), "Field " + getField() + " must be indexed for numeric set queries");
 		return SetQueryHelper.getNumericSetQuery(getField().toString(), getIndexFieldInfo(), intTerms(), longTerms(), floatTerms(), doubleTerms());
 	}
 

--- a/zulia-server/src/main/java/io/zulia/server/cmd/zuliad/StartNodeCmd.java
+++ b/zulia-server/src/main/java/io/zulia/server/cmd/zuliad/StartNodeCmd.java
@@ -55,8 +55,8 @@ public class StartNodeCmd implements Callable<Integer> {
 				/_____\\__,_|_|_|\\__,_|""";
 
 		ZuliaCommonCmd.printOrange(zuliaArt);
-		System.out.println("  Zulia (" + ZuliaVersion.getVersion() + ") based on Lucene " + Version.LATEST);
 		System.out.println();
+		LOG.info("Zulia ({}) based on Lucene {}", ZuliaVersion.getVersion(), Version.LATEST);
 
 		ZuliaNode zuliaNode = new ZuliaNode(zuliaConfig, nodeService);
 

--- a/zulia-server/src/main/java/io/zulia/server/cmd/zuliad/ZuliaDConfig.java
+++ b/zulia-server/src/main/java/io/zulia/server/cmd/zuliad/ZuliaDConfig.java
@@ -53,7 +53,7 @@ public class ZuliaDConfig {
 			config = prefix + File.separator + config;
 		}
 
-		LOG.info("Loading config <{}>", config);
+		LOG.info("Loading config {}", config);
 
 		try (FileReader fr = new FileReader(config)) {
 
@@ -78,15 +78,15 @@ public class ZuliaDConfig {
 
 		File dataFile = dataPath.toFile();
 		if (!dataFile.exists()) {
-			throw new FileNotFoundException("Data dir <" + dataDir + "> does not exist");
+			throw new FileNotFoundException("Data dir " + dataDir + " does not exist");
 		}
 		else {
-			LOG.info("Using data directory <{}>", dataFile.getAbsolutePath());
+			LOG.info("Using data directory {}", dataFile.getAbsolutePath());
 		}
 
 		if (zuliaConfig.getServerAddress() == null) {
 			zuliaConfig.setServerAddress(ServerNameHelper.getLocalServer());
-			LOG.warn("Server address is not defined.  Autodetected server name <{}>", zuliaConfig.getServerAddress());
+			LOG.warn("Server address is not defined.  Autodetected server name {}", zuliaConfig.getServerAddress());
 		}
 
 		if (zuliaConfig.isCluster()) {

--- a/zulia-server/src/main/java/io/zulia/server/connection/client/InternalClient.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/client/InternalClient.java
@@ -73,7 +73,7 @@ public class InternalClient {
 
 		if (!internalConnectionPoolMap.containsKey(nodeKey)) {
 
-			LOG.info("Adding connection pool for node <{}>", nodeKey);
+			LOG.info("Adding connection pool for node {}", nodeKey);
 
 			GenericObjectPool<InternalRpcConnection> pool = new GenericObjectPool<>(
 					new InternalRpcConnectionFactory(node.getServerAddress(), node.getServicePort()));
@@ -84,21 +84,21 @@ public class InternalClient {
 			internalConnectionPoolMap.putIfAbsent(nodeKey, pool);
 		}
 		else {
-			LOG.info("Already loaded connection for node <{}>", nodeKey);
+			LOG.info("Already loaded connection for node {}", nodeKey);
 		}
 	}
 
 	public void removeNode(Node node) {
 		String nodeKey = getNodeKey(node);
 
-		LOG.info("Removing connection pool for node <{}>", nodeKey);
+		LOG.info("Removing connection pool for node {}", nodeKey);
 		GenericObjectPool<InternalRpcConnection> connectionPool = internalConnectionPoolMap.remove(nodeKey);
 
 		if (connectionPool != null) {
 			connectionPool.close();
 		}
 		else {
-			LOG.info("Already closed connection for node <{}>", nodeKey);
+			LOG.info("Already closed connection for node {}", nodeKey);
 		}
 
 	}
@@ -130,12 +130,12 @@ public class InternalClient {
 				}
 			}
 			catch (Exception e) {
-				LOG.error("Failed to return blocking connection to node <{}> pool", nodeKey, e);
+				LOG.error("Failed to return blocking connection to node {} pool", nodeKey, e);
 			}
 		}
 		else {
-			LOG.error("Failed to return blocking connection to node <{}> pool. Pool does not exist.", nodeKey);
-			LOG.error("Current pool members <{}>", internalConnectionPoolMap.keySet());
+			LOG.error("Failed to return blocking connection to node {} pool. Pool does not exist.", nodeKey);
+			LOG.error("Current pool members {}", internalConnectionPoolMap.keySet());
 			if (rpcConnection != null) {
 				rpcConnection.close();
 			}

--- a/zulia-server/src/main/java/io/zulia/server/connection/client/InternalRpcConnection.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/client/InternalRpcConnection.java
@@ -28,7 +28,7 @@ public class InternalRpcConnection {
 
 		blockingStub = ZuliaServiceGrpc.newBlockingStub(channel);
 
-		LOG.info("Connecting to <{}:{}>", memberAddress, servicePort);
+		LOG.info("Connecting to {}:{}", memberAddress, servicePort);
 	}
 
 	public ZuliaServiceBlockingStub getService() {
@@ -38,13 +38,13 @@ public class InternalRpcConnection {
 	public void close() {
 		try {
 			if (channel != null) {
-				LOG.info("Closing connection to <{}:{}>", memberAddress, internalServicePort);
+				LOG.info("Closing connection to {}:{}", memberAddress, internalServicePort);
 				channel.shutdown();
 				try {
 					channel.awaitTermination(15, TimeUnit.SECONDS);
 				}
 				catch (InterruptedException ex) {
-					LOG.warn("connection to <{}:{}> timed out on close", memberAddress, internalServicePort);
+					LOG.warn("connection to {}:{} timed out on close", memberAddress, internalServicePort);
 				}
 
 			}

--- a/zulia-server/src/main/java/io/zulia/server/exceptions/IndexConfigDoesNotExistException.java
+++ b/zulia-server/src/main/java/io/zulia/server/exceptions/IndexConfigDoesNotExistException.java
@@ -1,12 +1,14 @@
 package io.zulia.server.exceptions;
 
+import java.io.Serial;
+
 public class IndexConfigDoesNotExistException extends NotFoundException {
 
 	private static final long serialVersionUID = 1L;
 	private final String indexName;
 
 	public IndexConfigDoesNotExistException(String name) {
-		super("Index config <" + name + "> does not exist");
+		super("Index config " + name + " does not exist");
 		this.indexName = name;
 	}
 

--- a/zulia-server/src/main/java/io/zulia/server/exceptions/ShardDoesNotExistException.java
+++ b/zulia-server/src/main/java/io/zulia/server/exceptions/ShardDoesNotExistException.java
@@ -7,7 +7,7 @@ public class ShardDoesNotExistException extends NotFoundException {
 	private final int shardNumber;
 
 	public ShardDoesNotExistException(String indexName, int shardNumber) {
-		super("Shard does not exist for index <" + indexName + "> with shard <" + shardNumber + ">");
+		super("Shard does not exist for index " + indexName + " with shard " + shardNumber);
 		this.indexName = indexName;
 		this.shardNumber = shardNumber;
 	}

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardDocumentIndexer.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardDocumentIndexer.java
@@ -171,7 +171,7 @@ public class ShardDocumentIndexer {
 		ByteBuffer byteBuffer = ByteBuffer.allocate(((orderedDimOrdinals.size() * 2) + fieldOrdinalCount) * 4);
 
 		IntBuffer ordinalBuffer = byteBuffer.asIntBuffer();
-		for (Integer dimOrdinal : orderedDimOrdinals) {
+		for (int dimOrdinal : orderedDimOrdinals) {
 			IntSet fieldOrdinals = facetDimToOrdinal.get(dimOrdinal);
 			ordinalBuffer.put(dimOrdinal);
 			ordinalBuffer.put(fieldOrdinals.size());
@@ -181,8 +181,7 @@ public class ShardDocumentIndexer {
 		luceneDocument.add(new BinaryDocValuesField(ZuliaFieldConstants.FACET_STORAGE, new BytesRef(byteBuffer.array())));
 	}
 
-	private void addIndexingForStoredField(Document luceneDocument, String storedFieldName, FieldConfig fc, FieldConfig.FieldType fieldType, Object o)
-			throws Exception {
+	private void addIndexingForStoredField(Document luceneDocument, String storedFieldName, FieldConfig fc, FieldConfig.FieldType fieldType, Object o) {
 		for (ZuliaIndex.IndexAs indexAs : fc.getIndexAsList()) {
 
 			String indexedFieldName = indexAs.getIndexFieldName();
@@ -247,13 +246,13 @@ public class ShardDocumentIndexer {
 							break;
 						default:
 							throw new RuntimeException(
-									"Not handled string handling <" + stringHandling + "> for document field <" + storedFieldName + "> / sort field <"
-											+ sortFieldName + ">");
+									"Not handled string handling " + stringHandling + " for document field " + storedFieldName + " / sort field "
+											+ sortFieldName);
 					}
 
 					if (text.length() > 32766) {
 						throw new IllegalArgumentException(
-								"Field <" + sortAs.getSortFieldName() + "> is too large to sort.  Must be less <= 32766 characters and is " + text.length());
+								"Field " + sortAs.getSortFieldName() + " is too large to sort.  Must be less <= 32766 characters and is " + text.length());
 					}
 
 					SortedSetDocValuesField docValue = new SortedSetDocValuesField(sortFieldName, new BytesRef(text));

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardReader.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardReader.java
@@ -568,20 +568,19 @@ public class ShardReader implements AutoCloseable {
 
 		}
 
-		Sort sort = new Sort(sortFields.toArray(new SortField[0]));
-		return sort;
+		return new Sort(sortFields.toArray(new SortField[0]));
 	}
 
 	public ZuliaBase.ResultDocument getSourceDocument(String uniqueId, ZuliaQuery.FetchType resultFetchType, List<String> fieldsToReturn,
-			List<String> fieldsToMask) throws Exception {
+			List<String> fieldsToMask, boolean realtime) throws Exception {
 
-		ShardQuery shardQuery = ShardQuery.queryById(uniqueId, resultFetchType, fieldsToReturn, fieldsToMask);
+		ShardQuery shardQuery = ShardQuery.queryById(uniqueId, resultFetchType, fieldsToReturn, fieldsToMask, realtime);
 
 		ZuliaQuery.ShardQueryResponse segmentResponse = this.queryShard(shardQuery);
 
 		List<ZuliaQuery.ScoredResult> scoredResultList = segmentResponse.getScoredResultList();
 		if (!scoredResultList.isEmpty()) {
-			ZuliaQuery.ScoredResult scoredResult = scoredResultList.iterator().next();
+			ZuliaQuery.ScoredResult scoredResult = scoredResultList.getFirst();
 			if (scoredResult.hasResultDocument()) {
 				return scoredResult.getResultDocument();
 			}

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardReader.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardReader.java
@@ -206,8 +206,8 @@ public class ShardReader implements AutoCloseable {
 		indexSearcher.setSimilarity(similarity);
 
 		if (shardQuery.isDebug()) {
-			LOG.info("Lucene Query for index <{}> segment <{}>: {}", indexName, shardNumber, shardQuery.getQuery());
-			LOG.info("Rewritten Query for index <{}> segment <{}>: {}", indexName, shardNumber, indexSearcher.rewrite(shardQuery.getQuery()));
+			LOG.info("Lucene Query for index {}:s{}: {}", indexName, shardNumber, shardQuery.getQuery());
+			LOG.info("Rewritten Query for index {}:s{}: {}", indexName, shardNumber, indexSearcher.rewrite(shardQuery.getQuery()));
 		}
 
 		int hasMoreAmount = shardQuery.getAmount() + 1;
@@ -383,7 +383,7 @@ public class ShardReader implements AutoCloseable {
 					analyzer = ZuliaPerFieldAnalyzer.getAnalyzerForField(analyzerSettings);
 				}
 				else {
-					throw new RuntimeException("Invalid analyzer name <" + analyzerOverride + ">");
+					throw new RuntimeException("Invalid analyzer name " + analyzerOverride );
 				}
 			}
 
@@ -409,7 +409,7 @@ public class ShardReader implements AutoCloseable {
 			IndexFieldInfo indexFieldInfo = indexConfig.getIndexFieldInfo(indexField);
 
 			if (indexFieldInfo == null) {
-				throw new RuntimeException("Cannot highlight non-indexed field <" + indexField + ">");
+				throw new RuntimeException("Cannot highlight non-indexed field " + indexField );
 			}
 
 			QueryScorer queryScorer = new QueryScorer(q, highlightRequest.getField());

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardReaderManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardReaderManager.java
@@ -20,7 +20,7 @@ public class ShardReaderManager extends ReferenceManager<ShardReader> {
 
 	@Override
 	protected ShardReader refreshIfNeeded(ShardReader referenceToRefresh) throws IOException {
-		// Evaluate last build time for outside decision making
+		// Evaluate last build time for outside decision-making
 		ShardReader next = referenceToRefresh.refreshIfNeeded();
 		if (next != null) {
 			latestShardTime = next.getCreationTime();

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaConcurrentMergeScheduler.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaConcurrentMergeScheduler.java
@@ -1,0 +1,40 @@
+package io.zulia.server.index;
+
+import org.apache.lucene.index.ConcurrentMergeScheduler;
+import org.apache.lucene.index.MergePolicy;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ZuliaConcurrentMergeScheduler extends ConcurrentMergeScheduler {
+
+	private final AtomicInteger mergeCounter;
+
+
+	public ZuliaConcurrentMergeScheduler() {
+		mergeCounter = new AtomicInteger();
+	}
+
+	@Override
+	protected void doMerge(MergeSource mergeSource, MergePolicy.OneMerge merge) throws IOException {
+		long currentMerges = mergeCounter.incrementAndGet();
+
+		try {
+			super.doMerge(mergeSource, merge);
+		}
+		finally {
+			currentMerges = mergeCounter.decrementAndGet();
+		}
+	}
+
+	@Override
+	protected synchronized boolean maybeStall(MergeSource mergeSource) {
+		return true;
+	}
+
+
+
+	public boolean mergeSaturated() {
+		return mergeCounter.get() > this.getMaxMergeCount();
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
@@ -82,7 +82,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
-import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -197,7 +196,7 @@ public class ZuliaIndex {
 				}
 			}
 			catch (Exception e) {
-				LOG.error("Failed to flush shard <{}> for index <{}>", shard.getShardNumber(), indexName, e);
+				LOG.error("Failed to flush index {}:s{}", indexName, shard.getShardNumber(), e);
 			}
 		}
 
@@ -205,7 +204,7 @@ public class ZuliaIndex {
 
 	public void unload(boolean terminate) throws IOException {
 
-		LOG.info("Canceling timers for <{}>", indexName);
+		LOG.info("Canceling timers for {}", indexName);
 		commitTask.cancel();
 		commitTimer.cancel();
 
@@ -213,38 +212,38 @@ public class ZuliaIndex {
 		warmTimer.cancel();
 
 		if (!terminate) {
-			LOG.info("Committing <{}>", indexName);
+			LOG.info("Committing {}", indexName);
 			doCommit(true);
 		}
 
-		LOG.info("Shutting down shard pool for <{}>", indexName);
+		LOG.info("Shutting down shard pool for {}", indexName);
 		shardPool.shutdownNow();
 
 		for (Integer shardNumber : primaryShardMap.keySet()) {
-			LOG.info("Unloading primary shard <{}> for <{}>", shardNumber, indexName);
+			LOG.info("Unloading primary shard {}:s{}", indexName, shardNumber);
 			unloadShard(shardNumber);
-			LOG.info("Unloaded primary shard <{}> for <{}>", shardNumber, indexName);
+			LOG.info("Unloaded primary shard {}:s{}", indexName, shardNumber);
 			if (terminate) {
-				LOG.info("Deleting primary shard <{}> for <{}>", shardNumber, indexName);
+				LOG.info("Deleting primary shard {}:s{}", indexName, shardNumber);
 				Files.walkFileTree(getPathForIndex(shardNumber), new DeletingFileVisitor());
 				Files.walkFileTree(getPathForFacetsIndex(shardNumber), new DeletingFileVisitor());
-				LOG.info("Deleted primary shard <{}> for <{}>", shardNumber, indexName);
+				LOG.info("Deleted primary shard {}:s{}", indexName, shardNumber);
 			}
 		}
 
 		LOG.info("Deleting replicas");
 		for (Integer shardNumber : replicaShardMap.keySet()) {
-			LOG.info("Unloading replica shard <{}> for <{}>", shardNumber, indexName);
+			LOG.info("Unloading replica shard {}:s{}", indexName, shardNumber);
 			unloadShard(shardNumber);
-			LOG.info("Unloaded replica shard <{}> for <{}>", shardNumber, indexName);
+			LOG.info("Unloaded replica shard {}:s{}", indexName, shardNumber);
 			if (terminate) {
-				LOG.info("Deleting replica shard <{}> for <{}>", shardNumber, indexName);
+				LOG.info("Deleting replica shard {}:s{}", indexName, shardNumber);
 				Files.walkFileTree(getPathForIndex(shardNumber), new DeletingFileVisitor());
 				Files.walkFileTree(getPathForFacetsIndex(shardNumber), new DeletingFileVisitor());
-				LOG.info("Deleted replica shard <{}> for <{}>", shardNumber, indexName);
+				LOG.info("Deleted replica shard {}:s{}", indexName, shardNumber);
 			}
 		}
-		LOG.info("Shut down shard pool for <{}>", indexName);
+		LOG.info("Shut down shard pool for {}", indexName);
 
 	}
 
@@ -256,11 +255,11 @@ public class ZuliaIndex {
 		ZuliaShard s = new ZuliaShard(shardWriteManager, primary);
 
 		if (primary) {
-			LOG.info("Loaded primary shard <{}> for index <{}>", shardNumber, indexName);
+			LOG.info("Loaded primary shard {}:s{}", indexName, shardNumber);
 			primaryShardMap.put(shardNumber, s);
 		}
 		else {
-			LOG.info("Loaded replica shard <{}> for index <{}>", shardNumber, indexName);
+			LOG.info("Loaded replica shard {}:s{}", indexName, shardNumber);
 			replicaShardMap.put(shardNumber, s);
 		}
 
@@ -279,9 +278,9 @@ public class ZuliaIndex {
 		{
 			ZuliaShard s = primaryShardMap.remove(shardNumber);
 			if (s != null) {
-				LOG.info("{}Closing primary shard <{}> for index <{}>", getLogPrefix(), shardNumber, indexName);
+				LOG.info("{}:{} Closing primary shard {}:s{}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), indexName, shardNumber);
 				s.close();
-				LOG.info("{}Removed primary shard <{}> for index <{}>", getLogPrefix(), shardNumber, indexName);
+				LOG.info("{}:{} Removed primary shard {}:s{}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), indexName, shardNumber);
 
 			}
 		}
@@ -289,9 +288,9 @@ public class ZuliaIndex {
 		{
 			ZuliaShard s = replicaShardMap.remove(shardNumber);
 			if (s != null) {
-				LOG.info("{}Closing replica shard <{}> for index <{}>", getLogPrefix(), shardNumber, indexName);
+				LOG.info("{}:{} Closing replica shard {}:s{}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), indexName, shardNumber);
 				s.close();
-				LOG.info("{}Removed replica shard <{}> for index <{}>", getLogPrefix(), shardNumber, indexName);
+				LOG.info("{}:{} Removed replica shard {}:s{}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), indexName, shardNumber);
 			}
 		}
 
@@ -397,7 +396,7 @@ public class ZuliaIndex {
 		IndexFieldInfo indexFieldInfo = indexConfig.getIndexFieldInfo(field);
 
 		if (indexFieldInfo == null) {
-			throw new RuntimeException("Field <" + field + "> is not indexed");
+			throw new RuntimeException("Field " + field + " is not indexed");
 		}
 
 		return SetQueryHelper.getTermInSetQuery(query.getTermList(), field, indexFieldInfo);
@@ -613,7 +612,7 @@ public class ZuliaIndex {
 				SortFieldInfo sortFieldInfo = indexConfig.getSortFieldInfo(var);
 				FieldConfig.FieldType fieldType = sortFieldInfo.getFieldType();
 				if (fieldType == null) {
-					throw new IllegalArgumentException("Score Function references unknown sort field <" + var + ">");
+					throw new IllegalArgumentException("Score Function references unknown sort field " + var);
 				}
 
 				if (FieldTypeUtil.isStoredAsInt(fieldType)) {
@@ -747,7 +746,7 @@ public class ZuliaIndex {
 
 		if (indexConfig.getNumberOfShards() != 1) {
 			if (!queryRequest.getFetchFull() && (amount > 0)) {
-				amount = (int) (((amount / (float)numberOfShards) + indexConfig.getIndexSettings().getMinShardRequest()) * indexConfig.getIndexSettings()
+				amount = (int) (((amount / (float) numberOfShards) + indexConfig.getIndexSettings().getMinShardRequest()) * indexConfig.getIndexSettings()
 						.getRequestFactor());
 			}
 		}
@@ -1119,8 +1118,8 @@ public class ZuliaIndex {
 		return documentStorage.getAssociatedMetadataForQuery(query);
 	}
 
-	private ResultDocument getSourceDocument(String uniqueId, FetchType resultFetchType, List<String> fieldsToReturn, List<String> fieldsToMask, boolean realtime)
-			throws Exception {
+	private ResultDocument getSourceDocument(String uniqueId, FetchType resultFetchType, List<String> fieldsToReturn, List<String> fieldsToMask,
+			boolean realtime) throws Exception {
 
 		ZuliaShard s = findShardFromUniqueId(uniqueId);
 		return s.getSourceDocument(uniqueId, resultFetchType, fieldsToReturn, fieldsToMask, realtime);
@@ -1216,10 +1215,6 @@ public class ZuliaIndex {
 	@Override
 	public int hashCode() {
 		return indexName.hashCode();
-	}
-
-	private String getLogPrefix() {
-		return zuliaConfig.getServerAddress() + ":" + zuliaConfig.getServicePort() + " ";
 	}
 
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/federator/QueryRequestFederator.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/federator/QueryRequestFederator.java
@@ -71,12 +71,15 @@ public class QueryRequestFederator extends MasterSlaveNodeRequestFederator<Query
 
 		String queryJson = JsonFormat.printer().print(request);
 
+		queryJson = queryJson.replace('\n', ' ').replaceAll("\\s+", " ");
+
 		String searchLabel = request.getSearchLabel();
+
 		if (searchLabel.isEmpty()) {
-			LOG.info("Running id <{}> query <{}>", queryId, queryJson);
+			LOG.info("Running id {} query {}", queryId, queryJson);
 		}
 		else {
-			LOG.info("Running id <{}> with label <{}> query <{}>", queryId, searchLabel, queryJson);
+			LOG.info("Running id {} with label {} query {}", queryId, searchLabel, queryJson);
 		}
 
 		List<InternalQueryResponse> results = send(request);
@@ -112,10 +115,10 @@ public class QueryRequestFederator extends MasterSlaveNodeRequestFederator<Query
 		String resultSize = String.format("%.2f", (qr.getSerializedSize() / 1024.0));
 
 		if (searchLabel.isEmpty()) {
-			LOG.info("{} id <{}> with result size {}KB in {}ms", prefix, queryId, resultSize, time);
+			LOG.info("{} id {} with result size {}KB in {}ms", prefix, queryId, resultSize, time);
 		}
 		else {
-			LOG.info("{} id <{}> with label <{}> with result size {}KB in {}ms", prefix, queryId, searchLabel, resultSize, time);
+			LOG.info("{} id {} with label {} with result size {}KB in {}ms", prefix, queryId, searchLabel, resultSize, time);
 		}
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/field/BooleanFieldIndexer.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/field/BooleanFieldIndexer.java
@@ -30,8 +30,8 @@ public class BooleanFieldIndexer extends FieldIndexer {
 						boolVal = false;
 					}
 					else {
-						throw new Exception("String for Boolean field be 'Yes', 'No', 'Y', 'N', '1', '0', 'True', 'False', 'T', 'F' (case insensitive) for <"
-								+ storedFieldName + "> and found <" + s + ">");
+						throw new Exception("String for Boolean field be 'Yes', 'No', 'Y', 'N', '1', '0', 'True', 'False', 'T', 'F' (case insensitive) for "
+								+ storedFieldName + " and found " + s);
 					}
 				}
 				case Number number -> {
@@ -43,12 +43,12 @@ public class BooleanFieldIndexer extends FieldIndexer {
 						boolVal = true;
 					}
 					else {
-						throw new Exception("Number for Boolean field must be 0 or 1 for <" + storedFieldName + "> and found <" + v + ">");
+						throw new Exception("Number for Boolean field must be 0 or 1 for " + storedFieldName + " and found " + v );
 					}
 				}
 				default -> throw new Exception(
-						"Expecting collection of data type of Boolean, String, or Number for field <" + storedFieldName + "> and found <" + value.getClass()
-								.getSimpleName() + ">");
+						"Expecting collection of data type of Boolean, String, or Number for field " + storedFieldName + " and found " + value.getClass()
+								.getSimpleName());
 			}
 			d.add(new IntPoint(FieldTypeUtil.getIndexField(indexedFieldName, FieldType.BOOL), boolVal ? 1 : 0));
 		}

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/FetchController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/FetchController.java
@@ -27,9 +27,9 @@ import static io.zulia.message.ZuliaServiceOuterClass.FetchResponse;
 		@ApiResponse(responseCode = "404", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
 		@ApiResponse(responseCode = "500", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
 		@ApiResponse(responseCode = "503", content = { @Content(schema = @Schema(implementation = JsonError.class)) }) })
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class FetchController {
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.FETCH_URL)
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
 	public String fetch(@QueryValue(ZuliaRESTConstants.ID) String uniqueId, @QueryValue(ZuliaRESTConstants.INDEX) String indexName,
@@ -37,7 +37,6 @@ public class FetchController {
 		return runFetch(uniqueId, indexName, realtime);
 	}
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.FETCH_URL + "/{indexName}/{uniqueId}")
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
 	public String fetchPath(String uniqueId, String indexName, @Nullable @QueryValue(ZuliaRESTConstants.REALTIME) Boolean realtime) throws Exception {

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/FetchController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/FetchController.java
@@ -1,5 +1,6 @@
 package io.zulia.server.rest.controllers;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Produces;
@@ -31,23 +32,27 @@ public class FetchController {
 	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.FETCH_URL)
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
-	public String fetch(@QueryValue(ZuliaRESTConstants.ID) String uniqueId, @QueryValue(ZuliaRESTConstants.INDEX) String indexName) throws Exception {
-		return runFetch(uniqueId, indexName);
+	public String fetch(@QueryValue(ZuliaRESTConstants.ID) String uniqueId, @QueryValue(ZuliaRESTConstants.INDEX) String indexName,
+			@Nullable @QueryValue(ZuliaRESTConstants.REALTIME) Boolean realtime) throws Exception {
+		return runFetch(uniqueId, indexName, realtime);
 	}
 
 	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.FETCH_URL + "/{indexName}/{uniqueId}")
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
-	public String fetchPath(String uniqueId, String indexName) throws Exception {
-		return runFetch(uniqueId, indexName);
+	public String fetchPath(String uniqueId, String indexName, @Nullable @QueryValue(ZuliaRESTConstants.REALTIME) Boolean realtime) throws Exception {
+		return runFetch(uniqueId, indexName, realtime);
 	}
 
-	private static String runFetch(String uniqueId, String indexName) throws Exception {
+	private static String runFetch(String uniqueId, String indexName, Boolean realtime) throws Exception {
 		ZuliaIndexManager indexManager = ZuliaNodeProvider.getZuliaNode().getIndexManager();
 
 		FetchRequest.Builder fetchRequest = FetchRequest.newBuilder();
 		fetchRequest.setIndexName(indexName);
 		fetchRequest.setUniqueId(uniqueId);
+		if (realtime != null) {
+			fetchRequest.setRealtime(realtime);
+		}
 
 		FetchResponse fetchResponse = indexManager.fetch(fetchRequest.build());
 

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/FieldsController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/FieldsController.java
@@ -1,5 +1,6 @@
 package io.zulia.server.rest.controllers;
 
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Produces;
@@ -35,9 +36,14 @@ public class FieldsController {
 	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.FIELDS_URL)
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
-	public FieldsDTO getFields(@QueryValue(ZuliaRESTConstants.INDEX) final String indexName) throws Exception {
+	public FieldsDTO getFields(@QueryValue(ZuliaRESTConstants.INDEX) final String indexName,
+			@Nullable @QueryValue(ZuliaRESTConstants.REALTIME) final Boolean realtime) throws Exception {
 		ZuliaIndexManager indexManager = ZuliaNodeProvider.getZuliaNode().getIndexManager();
-		GetFieldNamesRequest fieldNamesRequest = GetFieldNamesRequest.newBuilder().setIndexName(indexName).build();
+		GetFieldNamesRequest.Builder fieldNamesRequestBuilder = GetFieldNamesRequest.newBuilder().setIndexName(indexName);
+		if (realtime != null) {
+			fieldNamesRequestBuilder.setRealtime(realtime);
+		}
+		GetFieldNamesRequest fieldNamesRequest = fieldNamesRequestBuilder.build();
 		GetFieldNamesResponse fieldNamesResponse = indexManager.getFieldNames(fieldNamesRequest);
 
 		FieldsDTO fieldsDTO = new FieldsDTO();

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/FieldsController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/FieldsController.java
@@ -31,9 +31,9 @@ import static io.zulia.message.ZuliaServiceOuterClass.GetFieldNamesResponse;
 		@ApiResponse(responseCode = "404", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
 		@ApiResponse(responseCode = "500", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
 		@ApiResponse(responseCode = "503", content = { @Content(schema = @Schema(implementation = JsonError.class)) }) })
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class FieldsController {
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.FIELDS_URL)
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
 	public FieldsDTO getFields(@QueryValue(ZuliaRESTConstants.INDEX) final String indexName,

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/IndexesController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/IndexesController.java
@@ -40,24 +40,22 @@ import static io.zulia.message.ZuliaServiceOuterClass.GetIndexesResponse;
 		@ApiResponse(responseCode = "404", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
 		@ApiResponse(responseCode = "500", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
 		@ApiResponse(responseCode = "503", content = { @Content(schema = @Schema(implementation = JsonError.class)) }) })
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class IndexesController {
 	private final static Logger LOG = LoggerFactory.getLogger(IndexesController.class);
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.INDEXES_URL + "/{index}")
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
 	public String getIndex(String index) throws Exception {
 		return JsonFormat.printer().print(getIndexResponse(index));
 	}
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.INDEX_URL)
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
 	public String getIndexLegacy(@QueryValue(ZuliaRESTConstants.INDEX) String index) throws Exception {
 		return JsonFormat.printer().print(getIndexResponse(index));
 	}
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.INDEXES_URL)
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
 	public IndexesResponseDTO getIndexes() throws Exception {

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/NodesController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/NodesController.java
@@ -41,9 +41,9 @@ import static io.zulia.message.ZuliaServiceOuterClass.GetNodesResponse;
 		@ApiResponse(responseCode = "404", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
 		@ApiResponse(responseCode = "500", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
 		@ApiResponse(responseCode = "503", content = { @Content(schema = @Schema(implementation = JsonError.class)) }) })
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class NodesController {
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.NODES_URL)
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
 	public NodesResponseDTO getNodes(@QueryValue(value = ZuliaRESTConstants.ACTIVE, defaultValue = "false") Boolean active) throws Exception {

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/QueryController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/QueryController.java
@@ -64,12 +64,13 @@ public class QueryController {
 			@Nullable @QueryValue(ZuliaRESTConstants.START) Integer start, @Nullable @QueryValue(ZuliaRESTConstants.HIGHLIGHT) List<String> highlightList,
 			@Nullable @QueryValue(ZuliaRESTConstants.HIGHLIGHT_JSON) List<String> highlightJsonList,
 			@Nullable @QueryValue(ZuliaRESTConstants.ANALYZE_JSON) List<String> analyzeJsonList, @Nullable @QueryValue(ZuliaRESTConstants.CURSOR) String cursor,
-			@QueryValue(value = ZuliaRESTConstants.TRUNCATE, defaultValue = "false") Boolean truncate) throws Exception {
+			@QueryValue(value = ZuliaRESTConstants.TRUNCATE, defaultValue = "false") Boolean truncate,
+			@Nullable @QueryValue(ZuliaRESTConstants.REALTIME) Boolean realtime) throws Exception {
 
 		ZuliaIndexManager indexManager = ZuliaNodeProvider.getZuliaNode().getIndexManager();
 
 		QueryRequest.Builder qrBuilder = buildQueryRequest(indexName, query, queryFields, filterQueries, queryJsonList, fields, fetch, rows, facet, drillDowns,
-				defaultOperator, sort, mm, similarity, debug, dontCache, start, highlightList, highlightJsonList, analyzeJsonList, cursor);
+				defaultOperator, sort, mm, similarity, debug, dontCache, start, highlightList, highlightJsonList, analyzeJsonList, cursor, realtime);
 		QueryResponse qr = indexManager.query(qrBuilder.build());
 		return getJsonResponse(qr, cursor != null, truncate);
 
@@ -95,12 +96,13 @@ public class QueryController {
 			@Nullable @QueryValue(ZuliaRESTConstants.ANALYZE_JSON) List<String> analyzeJsonList,
 			@QueryValue(value = ZuliaRESTConstants.BATCH, defaultValue = "false") Boolean batch,
 			@QueryValue(value = ZuliaRESTConstants.BATCH_SIZE, defaultValue = "500") Integer batchSize,
-			@Nullable @QueryValue(ZuliaRESTConstants.CURSOR) String cursor) throws Exception {
+			@Nullable @QueryValue(ZuliaRESTConstants.CURSOR) String cursor,
+			@Nullable @QueryValue(ZuliaRESTConstants.REALTIME) Boolean realtime) throws Exception {
 
 		ZuliaIndexManager indexManager = ZuliaNodeProvider.getZuliaNode().getIndexManager();
 
 		QueryRequest.Builder qrBuilder = buildQueryRequest(indexName, query, queryFields, filterQueries, queryJsonList, fields, fetch, rows, facet, drillDowns,
-				defaultOperator, sort, mm, similarity, debug, dontCache, start, highlightList, highlightJsonList, analyzeJsonList, cursor);
+				defaultOperator, sort, mm, similarity, debug, dontCache, start, highlightList, highlightJsonList, analyzeJsonList, cursor, realtime);
 
 		LocalDateTime now = LocalDateTime.now();
 		DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-H-mm-ss");
@@ -132,12 +134,13 @@ public class QueryController {
 			@Nullable @QueryValue(ZuliaRESTConstants.DRILL_DOWN) List<String> drillDowns,
 			@Nullable @QueryValue(ZuliaRESTConstants.DEFAULT_OP) String defaultOperator, @Nullable @QueryValue(ZuliaRESTConstants.SORT) List<String> sort,
 			@Nullable @QueryValue(ZuliaRESTConstants.MIN_MATCH) Integer mm, @QueryValue(value = ZuliaRESTConstants.DEBUG, defaultValue = "false") Boolean debug,
-			@Nullable @QueryValue(ZuliaRESTConstants.START) Integer start, @Nullable @QueryValue(ZuliaRESTConstants.CURSOR) String cursor) throws Exception {
+			@Nullable @QueryValue(ZuliaRESTConstants.START) Integer start, @Nullable @QueryValue(ZuliaRESTConstants.CURSOR) String cursor,
+			@Nullable @QueryValue(ZuliaRESTConstants.REALTIME) Boolean realtime) throws Exception {
 
 		ZuliaIndexManager indexManager = ZuliaNodeProvider.getZuliaNode().getIndexManager();
 
 		QueryRequest.Builder qrBuilder = buildQueryRequest(indexName, query, queryFields, filterQueries, queryJsonList, fields, null, 0, facet, drillDowns,
-				defaultOperator, sort, mm, null, debug, null, start, null, null, null, cursor);
+				defaultOperator, sort, mm, null, debug, null, start, null, null, null, cursor, realtime);
 
 		if (facet != null && !facet.isEmpty()) {
 			String response = getFacetCSV(indexManager, qrBuilder);
@@ -211,7 +214,7 @@ public class QueryController {
 	private static QueryRequest.Builder buildQueryRequest(List<String> indexName, String query, List<String> queryFields, List<String> filterQueries,
 			List<String> queryJsonList, List<String> fields, Boolean fetch, Integer rows, List<String> facet, List<String> drillDowns, String defaultOperator,
 			List<String> sort, Integer mm, List<String> similarity, Boolean debug, Boolean dontCache, Integer start, List<String> highlightList,
-			List<String> highlightJsonList, List<String> analyzeJsonList, String cursor) {
+			List<String> highlightJsonList, List<String> analyzeJsonList, String cursor, Boolean realtime) {
 		QueryRequest.Builder qrBuilder = QueryRequest.newBuilder().addAllIndex(indexName);
 		if (cursor != null) {
 			if (!cursor.equals("0")) {
@@ -220,6 +223,10 @@ public class QueryController {
 			if (sort == null || sort.isEmpty()) {
 				throw new IllegalArgumentException("Sort on unique value or value combination is required to use a cursor (i.e. id or title,id)");
 			}
+		}
+
+		if (realtime != null) {
+			qrBuilder.setRealtime(realtime);
 		}
 
 		if (debug != null) {

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/QueryController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/QueryController.java
@@ -13,6 +13,8 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Get;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.http.annotation.QueryValue;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
 import io.zulia.ZuliaRESTConstants;
 import io.zulia.rest.dto.*;
 import io.zulia.server.exceptions.WrappedCheckedException;
@@ -42,6 +44,7 @@ import static io.zulia.message.ZuliaServiceOuterClass.QueryResponse;
  * @author pmeyer
  */
 @Controller(ZuliaRESTConstants.QUERY_URL)
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class QueryController {
 
 	private final static Logger LOG = LoggerFactory.getLogger(QueryController.class);
@@ -259,7 +262,7 @@ public class QueryController {
 				mainQueryBuilder.setDefaultOp(Query.Operator.OR);
 			}
 			else {
-				throw new IllegalArgumentException("Invalid default operator <" + defaultOperator + ">");
+				throw new IllegalArgumentException("Invalid default operator " + defaultOperator);
 			}
 		}
 		mainQueryBuilder.setQueryType(Query.QueryType.SCORE_MUST);
@@ -289,13 +292,13 @@ public class QueryController {
 						fieldSimilarity.setSimilarity(Similarity.TFIDF);
 					}
 					else {
-						throw new IllegalArgumentException("Unknown similarity type <" + simType + ">");
+						throw new IllegalArgumentException("Unknown similarity type " + simType );
 					}
 
 					qrBuilder.addFieldSimilarity(fieldSimilarity);
 				}
 				else {
-					throw new IllegalArgumentException("Similarity <" + sim + "> should be in the form field:simType");
+					throw new IllegalArgumentException("Similarity " + sim + " should be in the form field:simType");
 				}
 			}
 		}
@@ -380,7 +383,7 @@ public class QueryController {
 						count = Integer.parseInt(countString);
 					}
 					catch (Exception e) {
-						throw new IllegalArgumentException("Invalid facet count <" + countString + "> for facet <" + f + ">");
+						throw new IllegalArgumentException("Invalid facet count " + countString + " for facet " + f);
 					}
 				}
 
@@ -540,7 +543,7 @@ public class QueryController {
 								Object subValue = subDoc.get(subKey);
 								if (subValue instanceof List) {
 									if (!((List<?>) subValue).isEmpty()) {
-										if (((List<?>) subValue).get(0) instanceof String) {
+										if (((List<?>) subValue).getFirst() instanceof String) {
 											if (((List<String>) subValue).size() > 10) {
 												List<String> value = ((List<String>) subValue).subList(0, 10);
 												value.add("...[truncated]");

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/StatsController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/StatsController.java
@@ -19,11 +19,11 @@ import java.io.File;
  * @author pmeyer
  */
 @Controller
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class StatsController {
 
 	private static final int MB = 1024 * 1024;
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.STATS_URL)
 	@Produces(ZuliaRESTConstants.UTF8_JSON)
 	public StatsDTO getStats() {

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/TermsController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/TermsController.java
@@ -43,12 +43,13 @@ public class TermsController {
 			@Nullable @QueryValue(ZuliaRESTConstants.TERM_FILTER) final String termFilter,
 			@Nullable @QueryValue(ZuliaRESTConstants.TERM_MATCH) final String termMatch,
 			@Nullable @QueryValue(ZuliaRESTConstants.INCLUDE_TERM) final List<String> includeTerm,
-			@Nullable @QueryValue(ZuliaRESTConstants.FUZZY_TERM_JSON) final String fuzzyTermJson) throws Exception {
+			@Nullable @QueryValue(ZuliaRESTConstants.FUZZY_TERM_JSON) final String fuzzyTermJson,
+			@Nullable @QueryValue(ZuliaRESTConstants.REALTIME) final Boolean realtime) throws Exception {
 
 		ZuliaIndexManager indexManager = ZuliaNodeProvider.getZuliaNode().getIndexManager();
 
 		GetTermsRequest termsRequest = getTermsRequest(indexName, field, amount, minDocFreq, minTermFreq, startTerm, endTerm, termFilter, termMatch,
-				includeTerm, fuzzyTermJson);
+				includeTerm, fuzzyTermJson, realtime);
 		GetTermsResponse terms = indexManager.getTerms(termsRequest);
 
 		TermsResponseDTO termsResponseDTO = new TermsResponseDTO();
@@ -73,12 +74,13 @@ public class TermsController {
 			@Nullable @QueryValue(ZuliaRESTConstants.TERM_FILTER) final String termFilter,
 			@Nullable @QueryValue(ZuliaRESTConstants.TERM_MATCH) final String termMatch,
 			@Nullable @QueryValue(ZuliaRESTConstants.INCLUDE_TERM) final List<String> includeTerm,
-			@Nullable @QueryValue(ZuliaRESTConstants.FUZZY_TERM_JSON) final String fuzzyTermJson) throws Exception {
+			@Nullable @QueryValue(ZuliaRESTConstants.FUZZY_TERM_JSON) final String fuzzyTermJson,
+			@Nullable @QueryValue(ZuliaRESTConstants.REALTIME) final Boolean realtime) throws Exception {
 
 		ZuliaIndexManager indexManager = ZuliaNodeProvider.getZuliaNode().getIndexManager();
 
 		GetTermsRequest termsRequest = getTermsRequest(indexName, field, amount, minDocFreq, minTermFreq, startTerm, endTerm, termFilter, termMatch,
-				includeTerm, fuzzyTermJson);
+				includeTerm, fuzzyTermJson,realtime);
 		GetTermsResponse terms = indexManager.getTerms(termsRequest);
 
 		StringBuilder csvString = new StringBuilder();
@@ -110,7 +112,7 @@ public class TermsController {
 	}
 
 	private static GetTermsRequest getTermsRequest(String indexName, String field, Integer amount, Integer minDocFreq, Integer minTermFreq, String startTerm,
-			String endTerm, String termFilter, String termMatch, List<String> includeTerm, String fuzzyTermJson) {
+			String endTerm, String termFilter, String termMatch, List<String> includeTerm, String fuzzyTermJson, Boolean realtime) {
 		GetTermsRequest.Builder termsBuilder = GetTermsRequest.newBuilder();
 		termsBuilder.setIndexName(indexName);
 		termsBuilder.setFieldName(field);
@@ -153,6 +155,10 @@ public class TermsController {
 				throw new IllegalArgumentException("Failed to parse fuzzy term json: " + e.getMessage());
 			}
 
+		}
+
+		if (realtime != null) {
+			termsBuilder.setRealtime(realtime);
 		}
 		return termsBuilder.build();
 	}

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/TermsController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/TermsController.java
@@ -29,9 +29,10 @@ import static io.zulia.message.ZuliaServiceOuterClass.GetTermsResponse;
  * @author pmeyer
  */
 @Controller
+@ExecuteOn(TaskExecutors.BLOCKING)
 public class TermsController {
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
+
 	@Get(ZuliaRESTConstants.TERMS_URL)
 	@Produces({ ZuliaRESTConstants.UTF8_JSON })
 	public TermsResponseDTO getTermsJson(@QueryValue(ZuliaRESTConstants.INDEX) final String indexName,
@@ -62,7 +63,6 @@ public class TermsController {
 
 	}
 
-	@ExecuteOn(TaskExecutors.BLOCKING)
 	@Get(ZuliaRESTConstants.TERMS_URL + "/csv")
 	@Produces({ ZuliaRESTConstants.UTF8_CSV })
 	public String getTermsCsv(@QueryValue(ZuliaRESTConstants.INDEX) final String indexName, @QueryValue(ZuliaRESTConstants.FIELDS) final String field,

--- a/zulia-server/src/main/java/io/zulia/server/search/QueryCombiner.java
+++ b/zulia-server/src/main/java/io/zulia/server/search/QueryCombiner.java
@@ -88,7 +88,7 @@ public class QueryCombiner {
 					Map<Integer, ShardQueryResponse> shardResponseMap = indexToShardQueryResponseMap.get(indexName);
 
 					if (shardResponseMap.containsKey(shardNumber)) {
-						throw new Exception("Shard <" + shardNumber + "> is repeated for <" + indexName + ">");
+						throw new Exception("Shard " + shardNumber + " is repeated for " + indexName);
 					}
 					else {
 						shardResponseMap.put(shardNumber, sr);
@@ -105,16 +105,16 @@ public class QueryCombiner {
 			Map<Integer, ShardQueryResponse> shardResponseMap = indexToShardQueryResponseMap.get(index.getIndexName());
 
 			if (shardResponseMap == null) {
-				throw new Exception("Missing index <" + index.getIndexName() + "> in response");
+				throw new Exception("Missing index " + index.getIndexName() + "> in response");
 			}
 
 			if (shardResponseMap.size() != numberOfShards) {
-				throw new Exception("Found <" + shardResponseMap.size() + "> expected <" + numberOfShards + ">");
+				throw new Exception("Found " + shardResponseMap.size() + " expected " + numberOfShards);
 			}
 
 			for (int shardNumber = 0; shardNumber < numberOfShards; shardNumber++) {
 				if (!shardResponseMap.containsKey(shardNumber)) {
-					throw new Exception("Missing shard <" + shardNumber + ">");
+					throw new Exception("Missing shard " + shardNumber);
 				}
 			}
 		}
@@ -308,7 +308,7 @@ public class QueryCombiner {
 						if (compare > 0) {
 
 							if (sorting) {
-								String msg = "Result set did not return the most relevant sorted documents for index <" + indexName + ">\n";
+								String msg = "Result set did not return the most relevant sorted documents for index " + indexName + "\n";
 								msg += "    Last for index from shard <" + lastForIndex.getShard() + "> has sort values <" + lastForIndex.getSortValues()
 										+ ">\n";
 								msg += "    Next for shard <" + next.getShard() + ">  has sort values <" + next.getSortValues() + ">\n";
@@ -367,10 +367,9 @@ public class QueryCombiner {
 				}
 				else {
 					if (!currentSortType.equals(indexSortType)) {
-						LOG.error("Sort fields must be defined the same in all indexes searched in a single query");
-						String message = "Cannot sort on field <" + sortField + ">: found type: <" + currentSortType + "> then type: <" + indexSortType + ">";
+						String message = "Sort fields must be defined the same in all indexes searched in a single query.  Cannot sort on field " + sortField
+								+ ": found type: " + currentSortType + " then type: " + indexSortType;
 						LOG.error(message);
-
 						throw new Exception(message);
 					}
 				}

--- a/zulia-server/src/main/java/io/zulia/server/search/ShardQuery.java
+++ b/zulia-server/src/main/java/io/zulia/server/search/ShardQuery.java
@@ -27,11 +27,12 @@ public class ShardQuery {
 	List<ZuliaQuery.HighlightRequest> highlightList;
 	List<ZuliaQuery.AnalysisRequest> analysisRequestList;
 	boolean debug;
+	boolean realtime;
 
 	public ShardQuery(Query query, Map<String, ZuliaBase.Similarity> similarityOverrideMap, int amount, Map<Integer, FieldDoc> shardToAfter,
 			ZuliaQuery.FacetRequest facetRequest, ZuliaQuery.SortRequest sortRequest, QueryCacheKey queryCacheKey, ZuliaQuery.FetchType resultFetchType,
 			List<String> fieldsToReturn, List<String> fieldsToMask, List<ZuliaQuery.HighlightRequest> highlightList,
-			List<ZuliaQuery.AnalysisRequest> analysisRequestList, boolean debug) {
+			List<ZuliaQuery.AnalysisRequest> analysisRequestList, boolean debug, boolean realtime) {
 		this.query = query;
 		this.similarityOverrideMap = similarityOverrideMap;
 		this.amount = amount;
@@ -45,12 +46,14 @@ public class ShardQuery {
 		this.highlightList = highlightList;
 		this.analysisRequestList = analysisRequestList;
 		this.debug = debug;
+		this.realtime = realtime;
 	}
 
-	public static ShardQuery queryById(String uniqueId, ZuliaQuery.FetchType resultFetchType, List<String> fieldsToReturn, List<String> fieldsToMask) {
+	public static ShardQuery queryById(String uniqueId, ZuliaQuery.FetchType resultFetchType, List<String> fieldsToReturn, List<String> fieldsToMask,
+			boolean realtime) {
 		Query query = new ConstantScoreQuery(new TermQuery(new Term(ZuliaFieldConstants.ID_FIELD, uniqueId)));
 		return new ShardQuery(query, null, 1, Collections.emptyMap(), ZuliaQuery.FacetRequest.newBuilder().build(), null, null, resultFetchType, fieldsToReturn,
-				fieldsToMask, Collections.emptyList(), Collections.emptyList(), false);
+				fieldsToMask, Collections.emptyList(), Collections.emptyList(), false, realtime);
 	}
 
 	public Query getQuery() {
@@ -103,5 +106,9 @@ public class ShardQuery {
 
 	public boolean isDebug() {
 		return debug;
+	}
+
+	public boolean isRealtime() {
+		return realtime;
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/search/aggregation/AggregationHandler.java
+++ b/zulia-server/src/main/java/io/zulia/server/search/aggregation/AggregationHandler.java
@@ -68,11 +68,11 @@ public class AggregationHandler {
 				SortFieldInfo numericSortFieldInfo = serverIndexConfig.getSortFieldInfo(numericField);
 				if (numericSortFieldInfo == null) {
 					//TODO fix this message to mention char list and list length
-					throw new IllegalArgumentException("Numeric field <" + numericField + "> must be indexed as a SORTABLE numeric field");
+					throw new IllegalArgumentException("Numeric field " + numericField + " must be indexed as a SORTABLE numeric field");
 				}
 				if (!FieldTypeUtil.isHandledAsNumericFieldType(numericSortFieldInfo.getFieldType())) {
 					//TODO fix this message to mention char list and list length
-					throw new IllegalArgumentException("Numeric field <" + numericField + "> must be indexed as a sortable NUMERIC field");
+					throw new IllegalArgumentException("Numeric field " + numericField + " must be indexed as a sortable NUMERIC field");
 				}
 
 				NumericFieldStatInfo info = new NumericFieldStatInfo(numericField);
@@ -173,7 +173,7 @@ public class AggregationHandler {
 			}
 		}
 		if (fieldStats == null) {
-			throw new IllegalArgumentException("Field <" + field + "> was not given in constructor");
+			throw new IllegalArgumentException("Field " + field + " was not given in constructor");
 		}
 
 		return fieldStats;
@@ -228,7 +228,7 @@ public class AggregationHandler {
 		NumericFieldStatInfo fieldStats = getFieldStatByName(field);
 
 		if (!fieldStats.hasGlobal()) {
-			throw new IllegalArgumentException("Field <" + field + "> has not requested as a global stat in the constructor");
+			throw new IllegalArgumentException("Field " + field + " has not requested as a global stat in the constructor");
 		}
 
 		return fieldStats.getGlobalStats().buildResponse().build();
@@ -238,7 +238,7 @@ public class AggregationHandler {
 		NumericFieldStatInfo fieldStats = getFieldStatByName(field);
 
 		if (!fieldStats.hasFacets()) {
-			throw new IllegalArgumentException("Field <" + field + "> has not requested as a facet stat in the constructor");
+			throw new IllegalArgumentException("Field " + field + " has not requested as a facet stat in the constructor");
 		}
 
 		MapStatOrdinalStorage<?> facetStatStorage = fieldStats.getFacetStatStorage();

--- a/zulia-server/src/test/java/io/zulia/server/test/node/AnalyzerTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/AnalyzerTest.java
@@ -93,7 +93,8 @@ public class AnalyzerTest {
 	@Order(3)
 	public void searchTest() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		Search search = new Search(ANALYZER_TEST_INDEX);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(ANALYZER_TEST_INDEX).setRealtime(true);
 		SearchResult searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(repeatCount * uniqueDocs, searchResult.getTotalHits());
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/CacheTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/CacheTest.java
@@ -212,7 +212,7 @@ public class CacheTest {
 
 		indexRecord(CACHE_TEST, 1000, "an amazing title", "pink and purple", 1000.0);
 
-		search = new Search(CACHE_TEST);
+		search = new Search(CACHE_TEST).setRealtime(true); // force reading change above without commit
 		search.addQuery(new ScoredQuery("rating:[4.0 TO *] AND title:blue"));
 		searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(0, searchResult.getShardsCached());

--- a/zulia-server/src/test/java/io/zulia/server/test/node/FacetTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/FacetTest.java
@@ -113,7 +113,8 @@ public class FacetTest {
 
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 		{
-			Search search = new Search(FACET_TEST_INDEX);
+			//run the first search with realtime to force seeing latest changes without waiting for a commit
+			Search search = new Search(FACET_TEST_INDEX).setRealtime(true);
 			SearchResult searchResult = zuliaWorkPool.search(search);
 			Assertions.assertEquals(13, searchResult.getTotalHits());
 		}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/FieldChangeTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/FieldChangeTest.java
@@ -92,7 +92,8 @@ public class FieldChangeTest {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 		SearchResult searchResult;
 
-		Search search = new Search(INDEX_NAME).setAmount(10);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(INDEX_NAME).setAmount(10).setRealtime(true);
 
 		search.addSort(new Sort("field1"));
 		searchResult = zuliaWorkPool.search(search);

--- a/zulia-server/src/test/java/io/zulia/server/test/node/FieldWildcardTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/FieldWildcardTest.java
@@ -123,7 +123,8 @@ public class FieldWildcardTest {
 	@Order(3)
 	public void searchTest() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		Search search = new Search(WILDCARD_JSON_TEST_INDEX);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(WILDCARD_JSON_TEST_INDEX).setRealtime(true);
 		SearchResult searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(4, searchResult.getTotalHits());
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/HierarchicalFacetTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/HierarchicalFacetTest.java
@@ -123,7 +123,8 @@ public class HierarchicalFacetTest {
 	@Order(3)
 	public void facetTest() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		Search search = new Search(FACET_TEST_INDEX);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(FACET_TEST_INDEX).setRealtime(true);
 		search.addCountFacet(new CountFacet("path"));
 		search.addCountFacet(new CountFacet("date"));
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/NumericSetTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/NumericSetTest.java
@@ -101,7 +101,8 @@ public class NumericSetTest {
 	@Order(3)
 	public void searchTest() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		Search search = new Search(NUMERIC_SET_TEST);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(NUMERIC_SET_TEST).setRealtime(true);
 		SearchResult searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(uniqueDocs, searchResult.getTotalHits());
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/RestTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/RestTest.java
@@ -137,13 +137,13 @@ public class RestTest {
 	@Order(5)
 	public void fieldsTest() {
 		ZuliaRESTClient restClient = restNodeExtension.getRESTClient();
-		FieldsDTO fields = restClient.getFields("index1");
+		FieldsDTO fields = restClient.getFields("index1", true);
 
 		Assertions.assertEquals(2, fields.getFields().size());
 		Assertions.assertTrue(fields.getFields().contains("title"));
 		Assertions.assertTrue(fields.getFields().contains("id"));
 
-		fields = restClient.getFields("index2");
+		fields = restClient.getFields("index2", true);
 
 		Assertions.assertEquals(0, fields.getFields().size());
 
@@ -153,7 +153,7 @@ public class RestTest {
 	@Order(5)
 	public void fetchTest() {
 		ZuliaRESTClient restClient = restNodeExtension.getRESTClient();
-		Document document = restClient.fetchRecord("index1", "123");
+		Document document = restClient.fetchRecord("index1", "123", true);
 		Assertions.assertEquals("test", document.getString("title"));
 		Assertions.assertEquals("some value", document.getString("notIndexed"));
 	}
@@ -170,7 +170,7 @@ public class RestTest {
 	@Order(6)
 	public void termTest() {
 		ZuliaRESTClient restClient = restNodeExtension.getRESTClient();
-		TermsResponseDTO termsResponseDTO = restClient.getTerms("index1", "title");
+		TermsResponseDTO termsResponseDTO = restClient.getTerms("index1", "title", true);
 		Assertions.assertEquals(7, termsResponseDTO.getTerms().size());
 		Assertions.assertEquals("different", termsResponseDTO.getTerms().get(0).term());
 		Assertions.assertEquals("place", termsResponseDTO.getTerms().get(1).term());
@@ -180,15 +180,15 @@ public class RestTest {
 		Assertions.assertEquals("totally", termsResponseDTO.getTerms().get(5).term());
 		Assertions.assertEquals("value", termsResponseDTO.getTerms().get(6).term());
 
-		termsResponseDTO = restClient.getTerms("index1", "title", new TermsRESTOptions().setAmount(1));
+		termsResponseDTO = restClient.getTerms("index1", "title", new TermsRESTOptions().setAmount(1), true);
 		Assertions.assertEquals(1, termsResponseDTO.getTerms().size());
-		Assertions.assertEquals("different", termsResponseDTO.getTerms().get(0).term());
+		Assertions.assertEquals("different", termsResponseDTO.getTerms().getFirst().term());
 
-		termsResponseDTO = restClient.getTerms("index1", "title", new TermsRESTOptions().setAmount(1).setStartTerm("t"));
+		termsResponseDTO = restClient.getTerms("index1", "title", new TermsRESTOptions().setAmount(1).setStartTerm("t"), true);
 		Assertions.assertEquals(1, termsResponseDTO.getTerms().size());
-		Assertions.assertEquals("test", termsResponseDTO.getTerms().get(0).term());
+		Assertions.assertEquals("test", termsResponseDTO.getTerms().getFirst().term());
 
-		termsResponseDTO = restClient.getTerms("index1", "title", new TermsRESTOptions().setTermFilter("test"));
+		termsResponseDTO = restClient.getTerms("index1", "title", new TermsRESTOptions().setTermFilter("test"), true);
 		Assertions.assertEquals(6, termsResponseDTO.getTerms().size());
 		Assertions.assertEquals("different", termsResponseDTO.getTerms().get(0).term());
 		Assertions.assertEquals("place", termsResponseDTO.getTerms().get(1).term());
@@ -270,7 +270,7 @@ public class RestTest {
 					}
 					case "test2.txt/test2.txt_metadata.json" -> {
 						piecesFound[4] = true;
-						Assertions.assertEquals(Document.parse(new String(b)), new Document("aKey", "aValue"));
+						Assertions.assertEquals(new Document("aKey", "aValue"), Document.parse(new String(b)));
 					}
 					default -> throw new Exception("Unexpected file <" + ze.getName());
 				}
@@ -304,7 +304,7 @@ public class RestTest {
 		ZuliaRESTClient restClient = restNodeExtension.getRESTClient();
 		SearchResultsDTO searchResultsDTO;
 
-		searchResultsDTO = restClient.search(new SearchREST("index1"));
+		searchResultsDTO = restClient.search(new SearchREST("index1").setRealtime(true));
 		Assertions.assertEquals(3, searchResultsDTO.getTotalHits());
 
 		searchResultsDTO = restClient.search(new SearchREST("index1"));

--- a/zulia-server/src/test/java/io/zulia/server/test/node/SimpleJsonTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/SimpleJsonTest.java
@@ -122,7 +122,8 @@ public class SimpleJsonTest {
 	@Order(3)
 	public void searchTest() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		Search search = new Search(SIMPLE_JSON_TEST_INDEX);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(SIMPLE_JSON_TEST_INDEX).setRealtime(true);
 		SearchResult searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(4, searchResult.getTotalHits());
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/SimpleTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/SimpleTest.java
@@ -92,7 +92,8 @@ public class SimpleTest {
 	@Order(3)
 	public void searchTest() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		Search search = new Search(SIMPLE_TEST_INDEX);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(SIMPLE_TEST_INDEX).setRealtime(true);
 		SearchResult searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(repeatCount * uniqueDocs, searchResult.getTotalHits());
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/SortTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/SortTest.java
@@ -170,7 +170,8 @@ public class SortTest {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 		SearchResult searchResult;
 
-		Search search = new Search(INDEX_NAME).setAmount(10);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(INDEX_NAME).setAmount(10).setRealtime(true);
 
 		search.addSort(new Sort("title")); //default ascending missing first
 		searchResult = zuliaWorkPool.search(search);

--- a/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/StartStopTest.java
@@ -207,7 +207,8 @@ public class StartStopTest {
 	@Order(3)
 	public void sortScoreBuilder() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		Search search = new Search(FACET_TEST_INDEX).setAmount(10);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(FACET_TEST_INDEX).setAmount(10).setRealtime(true);
 		search.addQuery(new ScoredQuery("issn:\"1234-1234\" OR country:US"));
 		search.addSort(new Sort(ZuliaFieldConstants.SCORE_FIELD).ascending());
 
@@ -238,7 +239,7 @@ public class StartStopTest {
 	}
 
 	@Test
-	@Order(3)
+	@Order(4)
 	public void lengthTestBuilder() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 		Search s = new Search(FACET_TEST_INDEX);
@@ -276,7 +277,7 @@ public class StartStopTest {
 	}
 
 	@Test
-	@Order(3)
+	@Order(5)
 	public void boolTestBuilder() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 		Search s = new Search(FACET_TEST_INDEX).addQuery(new FilterQuery("testBool:true"));
@@ -334,7 +335,7 @@ public class StartStopTest {
 	}
 
 	@Test
-	@Order(3)
+	@Order(6)
 	public void termTestBuilder() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 		Search s = new Search(FACET_TEST_INDEX);
@@ -404,7 +405,7 @@ public class StartStopTest {
 	}
 
 	@Test
-	@Order(3)
+	@Order(7)
 	public void testDates() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 		Search s;
@@ -518,7 +519,7 @@ public class StartStopTest {
 	}
 
 	@Test
-	@Order(4)
+	@Order(8)
 	public void reindex() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 		ClientIndexConfig indexConfig = new ClientIndexConfig();
@@ -556,13 +557,13 @@ public class StartStopTest {
 	}
 
 	@Test
-	@Order(5)
+	@Order(9)
 	public void restart() throws Exception {
 		nodeExtension.restartNodes();
 	}
 
 	@Test
-	@Order(6)
+	@Order(10)
 	public void confirmBuilder() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 		{
@@ -880,7 +881,7 @@ public class StartStopTest {
 	}
 
 	@Test
-	@Order(57)
+	@Order(11)
 	public void confirmTermInSet() throws Exception {
 		//try it again with id being sortable
 		termTestBuilder();

--- a/zulia-server/src/test/java/io/zulia/server/test/node/StatTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/StatTest.java
@@ -421,7 +421,7 @@ public class StatTest {
 				Assertions.assertEquals(2L * repeatCount, facetStats.getValueCount());
 			}
 			else {
-				throw new AssertionFailedError("Unexpected facet <" + facetStats.getFacet() + ">");
+				throw new AssertionFailedError("Unexpected facet " + facetStats.getFacet());
 			}
 		}
 	}
@@ -446,7 +446,7 @@ public class StatTest {
 				Assertions.assertEquals(2L * repeatCount, facetStats.getValueCount());
 			}
 			else {
-				throw new AssertionFailedError("Unexpected facet <" + facetStats.getFacet() + ">");
+				throw new AssertionFailedError("Unexpected facet " + facetStats.getFacet());
 			}
 		}
 	}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/StatTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/StatTest.java
@@ -107,7 +107,8 @@ public class StatTest {
 		Search search;
 		SearchResult searchResult;
 
-		search = new Search(STAT_TEST_INDEX);
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		search = new Search(STAT_TEST_INDEX).setRealtime(true);
 		search.addStat(new NumericStat("rating").setPercentiles(percentiles));
 		search.addQuery(new FilterQuery("title:boring").exclude());
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/TermQueryTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/TermQueryTest.java
@@ -73,7 +73,7 @@ public class TermQueryTest {
 	
 	private void indexRecord(int id, String field1, String field2) throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		String uniqueId = String.valueOf(id) + "-i";
+		String uniqueId = id + "-i";
 		
 		Document mongoDocument = new Document();
 		mongoDocument.put("id", uniqueId);
@@ -92,7 +92,9 @@ public class TermQueryTest {
 	@Order(3)
 	public void searchTest() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		Search search = new Search(TERM_QUERY_TEST);
+
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(TERM_QUERY_TEST).setRealtime(true);
 		SearchResult searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(UNIQUE_DOCS * REPEATS, searchResult.getTotalHits());
 		

--- a/zulia-server/src/test/java/io/zulia/server/test/node/VectorTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/VectorTest.java
@@ -85,7 +85,9 @@ public class VectorTest {
 	@Order(3)
 	public void searchTest() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
-		Search search = new Search(VECTOR_TEST);
+
+		//run the first search with realtime to force seeing latest changes without waiting for a commit
+		Search search = new Search(VECTOR_TEST).setRealtime(true);
 		SearchResult searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(uniqueDocs, searchResult.getTotalHits());
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/shared/TestHelper.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/shared/TestHelper.java
@@ -119,7 +119,7 @@ public class TestHelper {
 	}
 
 	public static void startNodes(boolean startRest) throws Exception {
-		LOG.info("Starting <{}> Nodes", NODE_SERVICE.getNodes().size());
+		LOG.info("Starting {} Nodes", NODE_SERVICE.getNodes().size());
 		int i = 0;
 		for (ZuliaBase.Node node : NODE_SERVICE.getNodes()) {
 			ZuliaConfig zuliaConfig = new ZuliaConfig();
@@ -142,13 +142,13 @@ public class TestHelper {
 
 			ZULIA_NODES.add(zuliaNode);
 		}
-		LOG.info("Started <{}> Nodes", ZULIA_NODES.size());
+		LOG.info("Started {} Nodes", ZULIA_NODES.size());
 
 	}
 
 	public static void createNodes(int nodeCount) {
 		clearData();
-		LOG.info("Creating <{}> Nodes", nodeCount);
+		LOG.info("Creating {} Nodes", nodeCount);
 		int port = 20000;
 
 		//drop nodes and index configs
@@ -162,7 +162,7 @@ public class TestHelper {
 
 	public static void stopNodes() {
 
-		LOG.info("Stopping <{}> Nodes", ZULIA_NODES.size());
+		LOG.info("Stopping {} Nodes", ZULIA_NODES.size());
 		for (ZuliaNode zuliaNode : ZULIA_NODES) {
 			zuliaNode.shutdown();
 		}

--- a/zulia-testing/src/main/java/io/zulia/testing/ZuliaTestRunner.java
+++ b/zulia-testing/src/main/java/io/zulia/testing/ZuliaTestRunner.java
@@ -104,7 +104,7 @@ public class ZuliaTestRunner {
 			ZuliaWorkPool zuliaWorkPool = connectionToConnectionConfig.get(indexConfig.getConnection()).get();
 			Search s = buildSearch(indexConfig.getIndexName(), searchConfig);
 			if (zuliaTestConfig.isLogSearches()) {
-				LOG.info("Running search <{}>:\n{}", searchConfig.getName(), s);
+				LOG.info("Running search {}:\n{}", searchConfig.getName(), s);
 			}
 			SearchResult searchResult = zuliaWorkPool.search(s);
 			QueryResultObject result = buildQueryResultObject(searchResult, searchConfig);
@@ -285,19 +285,19 @@ public class ZuliaTestRunner {
 				jsValue.putMember(countToEntry.getKey(), countToEntry.getValue());
 				if (zuliaTestConfig.isLogSearchResults()) {
 					String json = context.eval("js", "JSON.stringify(" + countToEntry.getKey() + ")").asString();
-					LOG.info("Search result <{}>:\n{}", countToEntry.getKey(), json);
+					LOG.info("Search result {}:\n{}", countToEntry.getKey(), json);
 				}
 			}
 
 			for (TestConfig testConfig : zuliaTestConfig.getTests()) {
-				LOG.info("Running Test <{}>", testConfig.getName());
+				LOG.info("Running Test {}", testConfig.getName());
 
 				TestResult testResult = new TestResult();
 				testResult.setTestId(testConfig.getName());
 				testResult.setTestConfig(testConfig);
 				Value js = context.eval("js", testConfig.getExpr());
 				testResult.setPassed(js.asBoolean());
-				LOG.info("Test <{}> {}", testConfig.getName(), js.asBoolean() ? "Passed" : "Failed");
+				LOG.info("Test {} {}", testConfig.getName(), js.asBoolean() ? "Passed" : "Failed");
 				testResults.add(testResult);
 			}
 

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaDump.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaDump.java
@@ -89,15 +89,15 @@ public class ZuliaDump implements Callable<Integer> {
 		String settingsFilename = indOutputDir + File.separator + index + "_settings.json";
 
 		AtomicInteger count = new AtomicInteger();
-		LOG.info("Dumping index <{}>", index);
+		LOG.info("Dumping index {}", index);
 		ZuliaCmdUtil.writeOutput(recordsFilename, index, q, pageSize, workPool, count, uniqueIds);
-		LOG.info("Finished dumping index <{}>, total: {}", index, count);
+		LOG.info("Finished dumping index {}, total: {}", index, count);
 
 		try (FileWriter fileWriter = new FileWriter(settingsFilename, Charsets.UTF_8)) {
-			LOG.info("Writing settings for index <{}>", index);
+			LOG.info("Writing settings for index {}", index);
 			JsonFormat.Printer printer = JsonFormat.printer();
 			fileWriter.write(printer.print(workPool.getIndexConfig(new GetIndexConfig(index)).getIndexConfig().getIndexSettings()));
-			LOG.info("Finished writing settings for index <{}>", index);
+			LOG.info("Finished writing settings for index {}", index);
 		}
 
 	}
@@ -107,7 +107,7 @@ public class ZuliaDump implements Callable<Integer> {
 		String zuliaDumpDir = outputDir + File.separator + "zuliadump";
 		String indOutputDir = zuliaDumpDir + File.separator + index;
 
-		LOG.info("Starting to dump associated docs for <{}> documents", uniqueIds.size());
+		LOG.info("Starting to dump associated docs for {} documents", uniqueIds.size());
 		AtomicInteger count = new AtomicInteger(0);
 		try (TaskExecutor threadPool = WorkPool.nativePool(4)) {
 			for (String uniqueId : uniqueIds) {
@@ -122,7 +122,7 @@ public class ZuliaDump implements Callable<Integer> {
 					return null;
 				});
 			}
-			LOG.info("Finished dumping associated docs for <{}> documents", uniqueIds.size());
+			LOG.info("Finished dumping associated docs for {} documents", uniqueIds.size());
 		}
 	}
 

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaExport.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaExport.java
@@ -78,9 +78,9 @@ public class ZuliaExport implements Callable<Integer> {
 		String recordsFilename = indOutputDir + File.separator + index + ".json";
 
 		AtomicInteger count = new AtomicInteger();
-		LOG.info("Exporting from index <{}>", index);
+		LOG.info("Exporting from index {}", index);
 		ZuliaCmdUtil.writeOutput(recordsFilename, index, q, pageSize, workPool, count, uniqueIds);
-		LOG.info("Finished exporting from index <{}>, total: {}", index, count);
+		LOG.info("Finished exporting from index {}, total: {}", index, count);
 
 	}
 

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaImport.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaImport.java
@@ -51,13 +51,13 @@ public class ZuliaImport implements Callable<Integer> {
 
 		if (Files.exists(Paths.get(recordsFilename))) {
 			AtomicInteger count = new AtomicInteger();
-			LOG.info("Starting to index records for index <{}>", index);
+			LOG.info("Starting to index records for index {}", index);
 			ZuliaCmdUtil.index(inputDir, recordsFilename, idField, index, zuliaWorkPool, count, threadedArgs.getThreads(),
 					ZuliaCmdUtil.AssociatedFilesHandling.skip);
-			LOG.info("Finished indexing for index <{}> with total records: {}", index, count);
+			LOG.info("Finished indexing for index {} with total records: {}", index, count);
 		}
 		else {
-			System.err.println("File <" + recordsFilename + "> does not exist in the given dir <" + dir + ">");
+			System.err.println("File " + recordsFilename + " does not exist in the given dir " + dir);
 			System.exit(9);
 		}
 

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaRestore.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaRestore.java
@@ -78,7 +78,7 @@ public class ZuliaRestore implements Callable<Integer> {
 						restore(zuliaWorkPool, dir, ind, idField, drop, threads, associatedFilesHandling);
 					}
 					catch (Exception e) {
-						throw new Exception("There was a problem restoring index <" + indexDir.getFileName() + ">");
+						throw new Exception("There was a problem restoring index " + indexDir.getFileName());
 					}
 				}
 			}
@@ -99,26 +99,26 @@ public class ZuliaRestore implements Callable<Integer> {
 				workPool.deleteIndex(index);
 			}
 
-			LOG.info("Creating index <{}>", index);
+			LOG.info("Creating index {}", index);
 			ZuliaIndex.IndexSettings.Builder indexSettingsBuilder = ZuliaIndex.IndexSettings.newBuilder();
 			JsonFormat.parser().merge(Files.readString(settingsPath, Charsets.UTF_8), indexSettingsBuilder);
 			ClientIndexConfig indexConfig = new ClientIndexConfig();
 			indexConfig.configure(indexSettingsBuilder.build());
 			workPool.createIndex(indexConfig);
-			LOG.info("Finished creating index <{}>", index);
+			LOG.info("Finished creating index {}", index);
 
 			AtomicInteger count = new AtomicInteger();
-			LOG.info("Starting to index records for index <{}>", index);
+			LOG.info("Starting to index records for index {}", index);
 			ZuliaCmdUtil.index(inputDir, recordsFilename, idField, index, workPool, count, threads, associatedFilesHandling);
-			LOG.info("Finished indexing for index <{}> with total records: {}", index, count);
+			LOG.info("Finished indexing for index {} with total records: {}", index, count);
 		}
 		else {
 			if (index.endsWith(".json")) {
 				throw new Exception("Please provide the path to the parent directory in --dir option.");
 			}
 			else {
-				throw new Exception("Index <" + index + "> does not exist in the given dir <" + dir
-						+ ">, please provide the path to the parent directory in --dir option.");
+				throw new Exception("Index " + index + " does not exist in the given dir " + dir
+						+ ", please provide the path to the parent directory in --dir option.");
 			}
 		}
 	}

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaTest.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/ZuliaTest.java
@@ -42,11 +42,11 @@ public class ZuliaTest implements Callable<Integer> {
 			Yaml yaml = new Yaml();
 			try (FileInputStream fileInputStream = new FileInputStream(testConfigPath.toFile())) {
 				ZuliaTestConfig zuliaTestConfig = yaml.loadAs(fileInputStream, ZuliaTestConfig.class);
-				LOG.info("Running tests from <{}>", testConfig);
+				LOG.info("Running tests from {}", testConfig);
 				ZuliaTestRunner zuliaTestRunner = new ZuliaTestRunner(zuliaTestConfig);
 				List<TestResult> testResults = zuliaTestRunner.runTests();
 
-				LOG.info("Writing results to <{}>", testOutput);
+				LOG.info("Writing results to {}", testOutput);
 				FileDataOutputStream dataOutputStream = FileDataOutputStream.from(testOutput, true);
 
 				boolean anyFailed = false;
@@ -66,7 +66,7 @@ public class ZuliaTest implements Callable<Integer> {
 
 		}
 		else {
-			System.err.println("Yaml configuration file <" + testConfig + "> does not exist or is not readable");
+			System.err.println("Yaml configuration file " + testConfig + " does not exist or is not readable");
 			System.exit(9);
 		}
 

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/common/ZuliaCmdUtil.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/common/ZuliaCmdUtil.java
@@ -74,27 +74,27 @@ public class ZuliaCmdUtil {
 
 							int c = count.incrementAndGet();
 							if (c % 1000 == 0) {
-								LOG.info("So far written <{}> of <{}> for index <{}>", c, totalHits, index);
+								LOG.info("So far written {} of {} for index {}", c, totalHits, index);
 							}
 
 						}
 						catch (IOException e) {
-							LOG.error("Could not write record <{}> for index <{}>", completeResult.getUniqueId(), index, e);
+							LOG.error("Could not write record {} for index {}", completeResult.getUniqueId(), index, e);
 						}
 						catch (Throwable e) {
-							LOG.error("Could not write output for index <{}>", index, e);
+							LOG.error("Could not write output for index {}", index, e);
 						}
 
 					});
 				});
 			}
 			catch (Throwable t) {
-				LOG.error("Query failed for index <{}>", index, t);
+				LOG.error("Query failed for index {}", index, t);
 			}
 
 		}
 		catch (Throwable e) {
-			LOG.error("Could not write output for index <{}>", index, e);
+			LOG.error("Could not write output for index {}", index, e);
 			throw e;
 		}
 	}
@@ -172,7 +172,7 @@ public class ZuliaCmdUtil {
 														}
 													}
 													catch (Throwable t) {
-														LOG.error("Could not restore associated file <{}>", filename, t);
+														LOG.error("Could not restore associated file {}", filename, t);
 													}
 												}
 
@@ -186,7 +186,7 @@ public class ZuliaCmdUtil {
 												}
 											}
 											catch (Throwable t) {
-												LOG.error("Could not list the individual files for dir <{}>", path.getFileName(), t);
+												LOG.error("Could not list the individual files for dir {}", path.getFileName(), t);
 											}
 										}
 										else {
@@ -202,14 +202,14 @@ public class ZuliaCmdUtil {
 
 								}
 								else {
-									//LOG.error("Could not extract file <{}>", fullPathToFile);
+									//LOG.error("Could not extract file {}", fullPathToFile);
 								}
 
 							}
 
 							int i = count.incrementAndGet();
 							if (i % 10000 == 0) {
-								LOG.info("So far indexed <{}> for index <{}>", i, index);
+								LOG.info("So far indexed {} for index {}", i, index);
 							}
 							return null;
 						}


### PR DESCRIPTION
Change merge thread throttling to indexing throttling. This allows searches to happen (they sometimes require a merge) without being stalled if merge threads are saturated. Add logging of total indexing and amount of documents indexed at a single thread throttle since a restart.


Allow searches that are not real time (see only what has been committed). Non realtime searches allow higher performance during indexing. Searches, fetches (documents only, not associated files), Get Terms, Get Fields all support the real time flag. The default for real time is false. Previous versions of Zulia were realtime=true and not modifiable.


update logging to not use < >.  Logging is now single line for queries and index creation
change micronaut to be blocking at controller level (uses virtual threads in these cases)
change grpc to a named executor

update out of date comment in readme
