### PR TITLE
HTML Stripping Option for Analysis / Zulia Analyzer Refactor

### DIFF
--- a/zulia-analyzer/src/main/java/io/zulia/server/HtmlStrippingWrapper.java
+++ b/zulia-analyzer/src/main/java/io/zulia/server/HtmlStrippingWrapper.java
@@ -1,0 +1,33 @@
+package io.zulia.server;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.AnalyzerWrapper;
+import org.apache.lucene.analysis.charfilter.HTMLStripCharFilter;
+
+import java.io.Reader;
+
+public class HtmlStrippingWrapper extends AnalyzerWrapper {
+
+	private final Analyzer baseAnalyzer;
+
+	public HtmlStrippingWrapper(Analyzer baseAnalyzer) {
+		super(Analyzer.PER_FIELD_REUSE_STRATEGY);
+		this.baseAnalyzer = baseAnalyzer;
+	}
+
+	@Override
+	protected Analyzer getWrappedAnalyzer(String fieldName) {
+		return baseAnalyzer;
+	}
+
+	@Override
+	protected Reader wrapReader(String fieldName, Reader reader) {
+		return new HTMLStripCharFilter(reader);
+	}
+
+	@Override
+	protected Reader wrapReaderForNormalization(String fieldName, Reader reader) {
+		return new HTMLStripCharFilter(reader);
+	}
+
+}

--- a/zulia-analyzer/src/main/java/io/zulia/server/analysis/ZuliaFieldAnalyzer.java
+++ b/zulia-analyzer/src/main/java/io/zulia/server/analysis/ZuliaFieldAnalyzer.java
@@ -1,0 +1,162 @@
+package io.zulia.server.analysis;
+
+import io.zulia.message.ZuliaIndex.AnalyzerSettings;
+import io.zulia.server.analysis.filter.BritishUSFilter;
+import io.zulia.server.analysis.filter.CaseProtectedWordsFilter;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.CharArraySet;
+import org.apache.lucene.analysis.LowerCaseFilter;
+import org.apache.lucene.analysis.StopFilter;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.core.KeywordTokenizer;
+import org.apache.lucene.analysis.core.UpperCaseFilter;
+import org.apache.lucene.analysis.core.WhitespaceTokenizer;
+import org.apache.lucene.analysis.de.GermanNormalizationFilter;
+import org.apache.lucene.analysis.en.EnglishAnalyzer;
+import org.apache.lucene.analysis.en.EnglishMinimalStemFilter;
+import org.apache.lucene.analysis.en.EnglishPossessiveFilter;
+import org.apache.lucene.analysis.en.KStemFilter;
+import org.apache.lucene.analysis.minhash.MinHashFilterFactory;
+import org.apache.lucene.analysis.miscellaneous.ASCIIFoldingFilter;
+import org.apache.lucene.analysis.miscellaneous.WordDelimiterGraphFilter;
+import org.apache.lucene.analysis.shingle.ShingleFilter;
+import org.apache.lucene.analysis.snowball.SnowballFilter;
+import org.apache.lucene.analysis.standard.StandardTokenizer;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.apache.lucene.analysis.miscellaneous.WordDelimiterGraphFilter.CATENATE_ALL;
+
+public class ZuliaFieldAnalyzer extends Analyzer {
+
+	private final AnalyzerSettings analyzerSettings;
+
+	public ZuliaFieldAnalyzer(AnalyzerSettings analyzerSettings) {
+		this.analyzerSettings = analyzerSettings;
+	}
+
+	@Override
+	public int getPositionIncrementGap(String fieldName) {
+		return 100;
+	}
+
+	@Override
+	protected TokenStreamComponents createComponents(String fieldName) {
+
+		AnalyzerSettings.Tokenizer tokenizer = analyzerSettings.getTokenizer();
+		Tokenizer src;
+		if (AnalyzerSettings.Tokenizer.KEYWORD.equals(tokenizer)) {
+			src = new KeywordTokenizer();
+		}
+		else if (AnalyzerSettings.Tokenizer.WHITESPACE.equals(tokenizer)) {
+			src = new WhitespaceTokenizer();
+		}
+		else if (AnalyzerSettings.Tokenizer.STANDARD.equals(tokenizer)) {
+			src = new StandardTokenizer();
+		}
+		else {
+			throw new RuntimeException("Unknown tokenizer type " + tokenizer);
+		}
+
+		return new TokenStreamComponents(src, getFilteredStream(src));
+	}
+
+	@Override
+	protected TokenStream normalize(String fieldName, TokenStream in) {
+		return getFilteredStream(in);
+	}
+
+	private TokenStream getFilteredStream(TokenStream src) {
+		TokenStream tok = src;
+		TokenStream lastTok = src;
+
+		List<AnalyzerSettings.Filter> filterList = analyzerSettings.getFilterList();
+		for (AnalyzerSettings.Filter filter : filterList) {
+			if (AnalyzerSettings.Filter.LOWERCASE.equals(filter)) {
+				tok = new LowerCaseFilter(lastTok);
+			}
+			else if (AnalyzerSettings.Filter.UPPERCASE.equals(filter)) {
+				tok = new UpperCaseFilter(lastTok);
+			}
+			else if (AnalyzerSettings.Filter.ASCII_FOLDING.equals(filter)) {
+				tok = new ASCIIFoldingFilter(lastTok);
+			}
+			else if (AnalyzerSettings.Filter.TWO_TWO_SHINGLE.equals(filter)) {
+				ShingleFilter shingleFilter = new ShingleFilter(lastTok, 2, 2);
+				shingleFilter.setOutputUnigrams(false);
+				tok = shingleFilter;
+			}
+			else if (AnalyzerSettings.Filter.THREE_THREE_SHINGLE.equals(filter)) {
+				ShingleFilter shingleFilter = new ShingleFilter(lastTok, 3, 3);
+				shingleFilter.setOutputUnigrams(false);
+				tok = shingleFilter;
+			}
+			else if (AnalyzerSettings.Filter.FOUR_FOUR_SHINGLE.equals(filter)) {
+				ShingleFilter shingleFilter = new ShingleFilter(lastTok, 4, 4);
+				shingleFilter.setOutputUnigrams(false);
+				tok = shingleFilter;
+			}
+			else if (AnalyzerSettings.Filter.FIVE_FIVE_SHINGLE.equals(filter)) {
+				ShingleFilter shingleFilter = new ShingleFilter(lastTok, 5, 5);
+				shingleFilter.setOutputUnigrams(false);
+				tok = shingleFilter;
+			}
+			else if (AnalyzerSettings.Filter.KSTEM.equals(filter)) {
+				tok = new KStemFilter(lastTok);
+			}
+			else if (AnalyzerSettings.Filter.STOPWORDS.equals(filter)) {
+				CharArraySet stopWordsSet = EnglishAnalyzer.ENGLISH_STOP_WORDS_SET;
+
+				File file = new File(System.getProperty("user.home") + File.separator + ".zulia" + File.separator + "stopwords.txt");
+				if (file.exists()) {
+					try (Stream<String> lines = Files.lines(file.toPath()).map(String::trim)) {
+						List<String> fileLines = lines.collect(Collectors.toList());
+						stopWordsSet = StopFilter.makeStopSet(fileLines);
+					}
+					catch (IOException e) {
+						throw new RuntimeException(e);
+					}
+				}
+
+				tok = new StopFilter(lastTok, stopWordsSet);
+			}
+			else if (AnalyzerSettings.Filter.ENGLISH_MIN_STEM.equals(filter)) {
+				tok = new EnglishMinimalStemFilter(lastTok);
+			}
+			else if (AnalyzerSettings.Filter.SNOWBALL_STEM.equals(filter)) {
+				tok = new SnowballFilter(lastTok, "English");
+			}
+			else if (AnalyzerSettings.Filter.ENGLISH_POSSESSIVE.equals(filter)) {
+				tok = new EnglishPossessiveFilter(lastTok);
+			}
+			else if (AnalyzerSettings.Filter.MINHASH.equals(filter)) {
+				tok = new MinHashFilterFactory(Collections.emptyMap()).create(lastTok);
+			}
+			else if (AnalyzerSettings.Filter.BRITISH_US.equals(filter)) {
+				tok = new BritishUSFilter(lastTok);
+			}
+			else if (AnalyzerSettings.Filter.CONCAT_ALL.equals(filter)) {
+				tok = new WordDelimiterGraphFilter(lastTok, CATENATE_ALL, null);
+			}
+			else if (AnalyzerSettings.Filter.CASE_PROTECTED_WORDS.equals(filter)) {
+				tok = new CaseProtectedWordsFilter(lastTok);
+			}
+			else if (AnalyzerSettings.Filter.GERMAN_NORMALIZATION.equals(filter)) {
+				tok = new GermanNormalizationFilter(lastTok);
+			}
+			else {
+				throw new RuntimeException("Unknown filter type " + filter);
+			}
+			lastTok = tok;
+		}
+		return tok;
+	}
+
+}

--- a/zulia-analyzer/src/main/java/io/zulia/server/analysis/ZuliaPerFieldAnalyzer.java
+++ b/zulia-analyzer/src/main/java/io/zulia/server/analysis/ZuliaPerFieldAnalyzer.java
@@ -3,18 +3,21 @@ package io.zulia.server.analysis;
 import io.zulia.message.ZuliaIndex;
 import io.zulia.message.ZuliaIndex.AnalyzerSettings;
 import io.zulia.message.ZuliaIndex.FieldConfig.FieldType;
+import io.zulia.server.HtmlStrippingWrapper;
 import io.zulia.server.analysis.filter.BritishUSFilter;
 import io.zulia.server.analysis.filter.CaseProtectedWordsFilter;
 import io.zulia.server.config.IndexFieldInfo;
 import io.zulia.server.config.ServerIndexConfig;
 import io.zulia.server.field.FieldTypeUtil;
 import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.AnalyzerWrapper;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.DelegatingAnalyzerWrapper;
 import org.apache.lucene.analysis.LowerCaseFilter;
 import org.apache.lucene.analysis.StopFilter;
 import org.apache.lucene.analysis.TokenStream;
 import org.apache.lucene.analysis.Tokenizer;
+import org.apache.lucene.analysis.charfilter.HTMLStripCharFilter;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
 import org.apache.lucene.analysis.core.UpperCaseFilter;
@@ -34,6 +37,7 @@ import org.apache.lucene.analysis.standard.StandardTokenizer;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashMap;
@@ -72,7 +76,10 @@ public class ZuliaPerFieldAnalyzer extends DelegatingAnalyzerWrapper {
 
 			if (FieldTypeUtil.isStringFieldType(fieldType)) {
 				if (analyzerSettings != null) {
-					a = getAnalyzerForField(analyzerSettings);
+					a = new ZuliaFieldAnalyzer(analyzerSettings);
+					if (analyzerSettings.getStripHTML()) {
+						a = new HtmlStrippingWrapper(a);
+					}
 				}
 				else {
 					a = new KeywordAnalyzer();
@@ -85,6 +92,7 @@ public class ZuliaPerFieldAnalyzer extends DelegatingAnalyzerWrapper {
 			else {
 				a = new KeywordAnalyzer();
 			}
+
 
 			newFieldAnalyzers.put(indexFieldName, a);
 			newFieldAnalyzers.put(FieldTypeUtil.getListLengthIndexField(indexFieldName), new WhitespaceAnalyzer());
@@ -105,129 +113,6 @@ public class ZuliaPerFieldAnalyzer extends DelegatingAnalyzerWrapper {
 		return "ZuliaPerFieldAnalyzerWrapper(" + fieldAnalyzers + ", default=" + defaultAnalyzer + ")";
 	}
 
-	public static Analyzer getAnalyzerForField(AnalyzerSettings analyzerSettings) {
 
-		return new Analyzer() {
-
-			@Override
-			public int getPositionIncrementGap(String fieldName) {
-				return 100;
-			}
-
-			@Override
-			protected TokenStreamComponents createComponents(String fieldName) {
-
-				AnalyzerSettings.Tokenizer tokenizer = analyzerSettings.getTokenizer();
-				Tokenizer src;
-				if (AnalyzerSettings.Tokenizer.KEYWORD.equals(tokenizer)) {
-					src = new KeywordTokenizer();
-				}
-				else if (AnalyzerSettings.Tokenizer.WHITESPACE.equals(tokenizer)) {
-					src = new WhitespaceTokenizer();
-				}
-				else if (AnalyzerSettings.Tokenizer.STANDARD.equals(tokenizer)) {
-					src = new StandardTokenizer();
-				}
-				else {
-					throw new RuntimeException("Unknown tokenizer type " + tokenizer);
-				}
-
-				return new TokenStreamComponents(src, getFilteredStream(src));
-			}
-
-			@Override
-			protected TokenStream normalize(String fieldName, TokenStream in) {
-				return getFilteredStream(in);
-			}
-
-			private TokenStream getFilteredStream(TokenStream src) {
-				TokenStream tok = src;
-				TokenStream lastTok = src;
-
-				List<AnalyzerSettings.Filter> filterList = analyzerSettings.getFilterList();
-				for (AnalyzerSettings.Filter filter : filterList) {
-					if (AnalyzerSettings.Filter.LOWERCASE.equals(filter)) {
-						tok = new LowerCaseFilter(lastTok);
-					}
-					else if (AnalyzerSettings.Filter.UPPERCASE.equals(filter)) {
-						tok = new UpperCaseFilter(lastTok);
-					}
-					else if (AnalyzerSettings.Filter.ASCII_FOLDING.equals(filter)) {
-						tok = new ASCIIFoldingFilter(lastTok);
-					}
-					else if (AnalyzerSettings.Filter.TWO_TWO_SHINGLE.equals(filter)) {
-						ShingleFilter shingleFilter = new ShingleFilter(lastTok, 2, 2);
-						shingleFilter.setOutputUnigrams(false);
-						tok = shingleFilter;
-					}
-					else if (AnalyzerSettings.Filter.THREE_THREE_SHINGLE.equals(filter)) {
-						ShingleFilter shingleFilter = new ShingleFilter(lastTok, 3, 3);
-						shingleFilter.setOutputUnigrams(false);
-						tok = shingleFilter;
-					}
-					else if (AnalyzerSettings.Filter.FOUR_FOUR_SHINGLE.equals(filter)) {
-						ShingleFilter shingleFilter = new ShingleFilter(lastTok, 4, 4);
-						shingleFilter.setOutputUnigrams(false);
-						tok = shingleFilter;
-					}
-					else if (AnalyzerSettings.Filter.FIVE_FIVE_SHINGLE.equals(filter)) {
-						ShingleFilter shingleFilter = new ShingleFilter(lastTok, 5, 5);
-						shingleFilter.setOutputUnigrams(false);
-						tok = shingleFilter;
-					}
-					else if (AnalyzerSettings.Filter.KSTEM.equals(filter)) {
-						tok = new KStemFilter(lastTok);
-					}
-					else if (AnalyzerSettings.Filter.STOPWORDS.equals(filter)) {
-						CharArraySet stopWordsSet = EnglishAnalyzer.ENGLISH_STOP_WORDS_SET;
-
-						File file = new File(System.getProperty("user.home") + File.separator + ".zulia" + File.separator + "stopwords.txt");
-						if (file.exists()) {
-							try (Stream<String> lines = Files.lines(file.toPath()).map(String::trim)) {
-								List<String> fileLines = lines.collect(Collectors.toList());
-								stopWordsSet = StopFilter.makeStopSet(fileLines);
-							}
-							catch (IOException e) {
-								throw new RuntimeException(e);
-							}
-						}
-
-						tok = new StopFilter(lastTok, stopWordsSet);
-					}
-					else if (AnalyzerSettings.Filter.ENGLISH_MIN_STEM.equals(filter)) {
-						tok = new EnglishMinimalStemFilter(lastTok);
-					}
-					else if (AnalyzerSettings.Filter.SNOWBALL_STEM.equals(filter)) {
-						tok = new SnowballFilter(lastTok, "English");
-					}
-					else if (AnalyzerSettings.Filter.ENGLISH_POSSESSIVE.equals(filter)) {
-						tok = new EnglishPossessiveFilter(lastTok);
-					}
-					else if (AnalyzerSettings.Filter.MINHASH.equals(filter)) {
-						tok = new MinHashFilterFactory(Collections.emptyMap()).create(lastTok);
-					}
-					else if (AnalyzerSettings.Filter.BRITISH_US.equals(filter)) {
-						tok = new BritishUSFilter(lastTok);
-					}
-					else if (AnalyzerSettings.Filter.CONCAT_ALL.equals(filter)) {
-						tok = new WordDelimiterGraphFilter(lastTok, CATENATE_ALL, null);
-					}
-					else if (AnalyzerSettings.Filter.CASE_PROTECTED_WORDS.equals(filter)) {
-						tok = new CaseProtectedWordsFilter(lastTok);
-					}
-					else if (AnalyzerSettings.Filter.GERMAN_NORMALIZATION.equals(filter)) {
-						tok = new GermanNormalizationFilter(lastTok);
-					}
-					else {
-						throw new RuntimeException("Unknown filter type " + filter);
-					}
-					lastTok = tok;
-				}
-				return tok;
-			}
-
-		};
-
-	}
 
 }

--- a/zulia-analyzer/src/main/java/io/zulia/server/config/ServerIndexConfigData.java
+++ b/zulia-analyzer/src/main/java/io/zulia/server/config/ServerIndexConfigData.java
@@ -187,6 +187,9 @@ public class ServerIndexConfigData {
 
 		aMap.put(DefaultAnalyzers.STANDARD,
 				AnalyzerSettings.newBuilder().setName(DefaultAnalyzers.STANDARD).addFilter(Filter.LOWERCASE).addFilter(Filter.STOPWORDS).build());
+		aMap.put(DefaultAnalyzers.STANDARD_HTML,
+				AnalyzerSettings.newBuilder().setName(DefaultAnalyzers.STANDARD_HTML).addFilter(Filter.LOWERCASE).addFilter(Filter.STOPWORDS).setStripHTML(true)
+						.build());
 		aMap.put(DefaultAnalyzers.KEYWORD, AnalyzerSettings.newBuilder().setName(DefaultAnalyzers.KEYWORD).setTokenizer(Tokenizer.KEYWORD).build());
 		aMap.put(DefaultAnalyzers.LC_KEYWORD,
 				AnalyzerSettings.newBuilder().setName(DefaultAnalyzers.LC_KEYWORD).setTokenizer(Tokenizer.KEYWORD).addFilter(Filter.LOWERCASE).build());

--- a/zulia-common/src/main/java/io/zulia/DefaultAnalyzers.java
+++ b/zulia-common/src/main/java/io/zulia/DefaultAnalyzers.java
@@ -11,12 +11,13 @@ public class DefaultAnalyzers {
 	public static final String LC_KEYWORD = "lcKeyword";
 	public static final String LC_CONCAT_ALL = "lcConcatAll";
 	public static final String STANDARD = "standard";
+	public static final String STANDARD_HTML = "standardHtml";
 	public static final String MIN_STEM = "minStem";
 	public static final String KSTEMMED = "kstem";
 	public static final String LSH = "lsh";
 	public static final String TWO_TWO_SHINGLE = "twoTwoShingle";
 	public static final String THREE_THREE_SHINGLE = "threeThreeShingle";
 
-	public static Set<String> ALL_ANALYZERS = Set.of(KEYWORD, LC_KEYWORD, LC_CONCAT_ALL, STANDARD, MIN_STEM, KSTEMMED, LSH, TWO_TWO_SHINGLE,
+	public static Set<String> ALL_ANALYZERS = Set.of(KEYWORD, LC_KEYWORD, LC_CONCAT_ALL, STANDARD, STANDARD_HTML, MIN_STEM, KSTEMMED, LSH, TWO_TWO_SHINGLE,
 			THREE_THREE_SHINGLE);
 }

--- a/zulia-common/src/main/proto/zulia_index.proto
+++ b/zulia-common/src/main/proto/zulia_index.proto
@@ -198,7 +198,7 @@ message AnalyzerSettings {
     Tokenizer tokenizer = 2; //STANDARD default
     repeated Filter filter = 3;
     Similarity similarity = 4; //BM25 default
-
+    bool stripHTML = 5;
 }
 
 

--- a/zulia-server/src/main/java/io/zulia/server/index/AnalysisHandler.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/AnalysisHandler.java
@@ -22,7 +22,7 @@ import java.util.List;
  *
  * @author mdavis
  */
-public class AnalysisHandler {
+public class AnalysisHandler implements AutoCloseable {
 	private final AnalysisRequest analysisRequest;
 	private final String indexField;
 	private final String storedFieldName;
@@ -198,4 +198,12 @@ public class AnalysisHandler {
 		return null;
 	}
 
+
+	@Override
+	public void close() throws Exception {
+		// if a custom analyzer is created we should close it
+		if (!analysisRequest.getAnalyzerOverride().isEmpty()) {
+			analyzer.close();
+		}
+	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardReader.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardReader.java
@@ -11,6 +11,7 @@ import io.zulia.message.ZuliaIndex.AnalyzerSettings;
 import io.zulia.message.ZuliaIndex.FieldConfig.FieldType;
 import io.zulia.message.ZuliaQuery;
 import io.zulia.message.ZuliaServiceOuterClass;
+import io.zulia.server.analysis.ZuliaFieldAnalyzer;
 import io.zulia.server.analysis.ZuliaPerFieldAnalyzer;
 import io.zulia.server.analysis.highlight.ZuliaHighlighter;
 import io.zulia.server.analysis.similarity.ConstantSimilarity;
@@ -328,6 +329,7 @@ public class ShardReader implements AutoCloseable {
 				if (segmentAnalysisResult != null) {
 					shardQueryReponseBuilder.addAnalysisResult(segmentAnalysisResult);
 				}
+				analysisHandler.close();
 			}
 		}
 		return shardQueryReponseBuilder.build();
@@ -415,7 +417,7 @@ public class ShardReader implements AutoCloseable {
 
 				ZuliaIndex.AnalyzerSettings analyzerSettings = indexConfig.getAnalyzerSettingsByName(analyzerOverride);
 				if (analyzerSettings != null) {
-					analyzer = ZuliaPerFieldAnalyzer.getAnalyzerForField(analyzerSettings);
+					analyzer = new ZuliaFieldAnalyzer(analyzerSettings);
 				}
 				else {
 					throw new RuntimeException("Invalid analyzer name " + analyzerOverride);

--- a/zulia-server/src/test/java/io/zulia/server/test/node/AnalyzerTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/AnalyzerTest.java
@@ -42,7 +42,7 @@ public class AnalyzerTest {
 		indexConfig.addAnalyzerSetting(
 				AnalyzerSettings.newBuilder().setName("myAnalyzer").setTokenizer(AnalyzerSettings.Tokenizer.STANDARD).addFilter(Filter.LOWERCASE)
 						.addFilter(Filter.ASCII_FOLDING).addFilter(Filter.GERMAN_NORMALIZATION).addFilter(Filter.ENGLISH_POSSESSIVE)
-						.addFilter(Filter.ENGLISH_MIN_STEM).addFilter(Filter.BRITISH_US).build());
+						.addFilter(Filter.ENGLISH_MIN_STEM).addFilter(Filter.BRITISH_US).setStripHTML(true).build());
 
 		indexConfig.addDefaultSearchField("title");
 		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
@@ -62,7 +62,7 @@ public class AnalyzerTest {
 
 		for (int i = 0; i < repeatCount; i++) {
 			// random wikipedia titles and first bit of text from german and hungarian wikipedia to test folding
-			indexRecord(i * uniqueDocs, "Jürgen",
+			indexRecord(i * uniqueDocs, "<i>Jürgen</i>",
 					"Jürgen ist eine deutsche Nebenform des männlichen Vornamens Georg – Widmungen an den Heiligen Georg finden sich daher auch unter St. Jürgen.");
 			indexRecord(i * uniqueDocs + 1, "Straße ",
 					"Eine Straße ist im Landverkehr ein Verkehrsbauwerk, das Fußgängern und Fahrzeugen als Transport- und Verkehrsweg überwiegend dem Personentransport, dem Gütertransport und dem Tiertransport zur Ortsveränderung dient.");


### PR DESCRIPTION
Add HTML stripping as an option for analyzer settings
Add default standard analyzer with html stripping built in
Refactor ZuliaPerFieldAnalyzer to split out the tokenization chain into ZuliaFieldAnalyzer Make sure in analysis requests that a custom analyzer used would be closed