### PR TITLE
Make minimum should match queries have default OR handling in the minimum should match context 

### DIFF
--- a/zulia-query-parser/build.gradle.kts
+++ b/zulia-query-parser/build.gradle.kts
@@ -3,6 +3,9 @@ description = "Zulia Query Parser"
 dependencies {
     api(projects.zuliaAnalyzer)
     api(libs.lucene.queryparser)
+
+    testRuntimeClasspath(libs.logback.classic)
+    testRuntimeClasspath(libs.jansi)
 }
 
 

--- a/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/processors/ZuliaMinMatchOrHandlingProcessor.java
+++ b/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/processors/ZuliaMinMatchOrHandlingProcessor.java
@@ -1,0 +1,98 @@
+package io.zulia.server.search.queryparser.processors;
+
+import org.apache.lucene.queryparser.flexible.core.nodes.AndQueryNode;
+import org.apache.lucene.queryparser.flexible.core.nodes.BooleanQueryNode;
+import org.apache.lucene.queryparser.flexible.core.nodes.GroupQueryNode;
+import org.apache.lucene.queryparser.flexible.core.nodes.ModifierQueryNode;
+import org.apache.lucene.queryparser.flexible.core.nodes.OrQueryNode;
+import org.apache.lucene.queryparser.flexible.core.nodes.QueryNode;
+import org.apache.lucene.queryparser.flexible.core.processors.QueryNodeProcessorImpl;
+import org.apache.lucene.queryparser.flexible.standard.nodes.MinShouldMatchNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Inside every MinShouldMatchNode group, rewrite "default" BooleanQueryNode that
+ * isn't AndQueryNode or OrQueryNode into OrQueryNode.
+ * This forces local default-OR behavior regardless of the global default operator
+ * while preserving explicit AND subtrees and explicit modifiers (+, -, NOT, ...).
+ * Needs to be immediately before BooleanQuery2ModifierNodeProcessor in the pipeline
+ */
+public class ZuliaMinMatchOrHandlingProcessor extends QueryNodeProcessorImpl {
+
+	@Override
+	protected QueryNode postProcessNode(QueryNode node) {
+		if (!(node instanceof MinShouldMatchNode mm)) {
+			return node;
+		}
+
+		GroupQueryNode group = mm.groupQueryNode;
+		if (group == null || group.getChild() == null) {
+			return node;
+		}
+
+		QueryNode rewritten = rewrite(group.getChild(), false);
+		group.setChild(rewritten);
+		return node;
+	}
+
+	private QueryNode rewrite(QueryNode node, boolean underExplicitAnd) {
+		if (node == null)
+			return null;
+
+		// Keep explicit modifiers (+ , - , NOT , ...)
+		if (node instanceof ModifierQueryNode) {
+			return node;
+		}
+
+		// Preserve explicit AND subtrees but still recurse into them
+		if (node instanceof AndQueryNode) {
+			List<QueryNode> kids = node.getChildren();
+			if (kids != null && !kids.isEmpty()) {
+				List<QueryNode> newKids = new ArrayList<>(kids.size());
+				for (QueryNode c : kids) {
+					newKids.add(rewrite(c, true));
+				}
+				node.set(newKids);
+			}
+			return node;
+		}
+
+		// Recurse first
+		List<QueryNode> kids = node.getChildren();
+		if (kids != null && !kids.isEmpty()) {
+			List<QueryNode> newKids = new ArrayList<>(kids.size());
+			for (QueryNode c : kids) {
+				newKids.add(rewrite(c, underExplicitAnd));
+			}
+			node.set(newKids);
+		}
+
+		// If inside an explicit AND subtree, do not coerce default boolean into OR
+		if (underExplicitAnd) {
+			return node;
+		}
+
+		// Coerce "default" boolean (implicit whitespace) into explicit OR
+		// Default boolean shows up as BooleanQueryNode, but NOT AndQueryNode/OrQueryNode.
+		if (node instanceof BooleanQueryNode && !(node instanceof OrQueryNode)) {
+			List<QueryNode> children = node.getChildren();
+			if (children != null && children.size() > 1) {
+				return new OrQueryNode(children);
+			}
+		}
+
+		return node;
+	}
+
+	@Override
+	protected QueryNode preProcessNode(QueryNode node) {
+		return node;
+	}
+
+	@Override
+	protected List<QueryNode> setChildrenOrder(List<QueryNode> children) {
+		return children;
+	}
+}

--- a/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/processors/ZuliaQueryNodeProcessorPipeline.java
+++ b/zulia-query-parser/src/main/java/io/zulia/server/search/queryparser/processors/ZuliaQueryNodeProcessorPipeline.java
@@ -58,6 +58,10 @@ public class ZuliaQueryNodeProcessorPipeline extends QueryNodeProcessorPipeline 
 		add(new AllowLeadingWildcardProcessor());
 		add(new AnalyzerQueryNodeProcessor());
 		add(new PhraseSlopQueryNodeProcessor());
+
+		//zulia add for special mm handling that makes inside mm context default operator OR
+		add(new ZuliaMinMatchOrHandlingProcessor());
+
 		add(new BooleanQuery2ModifierNodeProcessor());
 		add(new NoChildOptimizationQueryNodeProcessor());
 		add(new RemoveDeletedQueryNodesProcessor());

--- a/zulia-query-parser/src/test/java/io/zulia/queryparser/test/QueryParserTest.java
+++ b/zulia-query-parser/src/test/java/io/zulia/queryparser/test/QueryParserTest.java
@@ -1,0 +1,63 @@
+package io.zulia.queryparser.test;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.message.ZuliaIndex;
+import io.zulia.message.ZuliaQuery;
+import io.zulia.server.analysis.ZuliaPerFieldAnalyzer;
+import io.zulia.server.config.ServerIndexConfig;
+import io.zulia.server.search.queryparser.ZuliaFlexibleQueryParser;
+import org.apache.lucene.search.Query;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+public class QueryParserTest {
+
+	@Test
+	public void minimumShouldMatchTest() throws Exception {
+
+		ZuliaIndex.IndexSettings.Builder builder = ZuliaIndex.IndexSettings.newBuilder();
+		builder.addFieldConfig(ZuliaIndex.FieldConfig.newBuilder()
+				.addIndexAs(ZuliaIndex.IndexAs.newBuilder().setAnalyzerName(DefaultAnalyzers.STANDARD).setIndexFieldName("title").build())
+				.setFieldType(ZuliaIndex.FieldConfig.FieldType.STRING).setStoredFieldName("title").build());
+		builder.addFieldConfig(ZuliaIndex.FieldConfig.newBuilder()
+				.addIndexAs(ZuliaIndex.IndexAs.newBuilder().setAnalyzerName(DefaultAnalyzers.STANDARD).setIndexFieldName("abstract").build())
+				.setFieldType(ZuliaIndex.FieldConfig.FieldType.STRING).setStoredFieldName("abstract").build());
+
+		ServerIndexConfig serverIndexConfig = new ServerIndexConfig(builder.build());
+		ZuliaPerFieldAnalyzer zuliaPerFieldAnalyzer = new ZuliaPerFieldAnalyzer(serverIndexConfig);
+		ZuliaFlexibleQueryParser zuliaFlexibleQueryParser = new ZuliaFlexibleQueryParser(zuliaPerFieldAnalyzer, serverIndexConfig);
+
+
+		Query parse;
+
+		String mmQuery = "abstract:diabetes title:(cancer AND lung -fly rat bear insect +fruit)@2";
+
+		zuliaFlexibleQueryParser.setDefaultOperator(ZuliaQuery.Query.Operator.OR);
+		parse = zuliaFlexibleQueryParser.parse(mmQuery);
+		Assertions.assertEquals("abstract:diabetes ((+title:cancer +title:lung -title:fly title:rat title:bear title:insect +title:fruit)~2)",
+				parse.toString());
+
+		zuliaFlexibleQueryParser.setDefaultOperator(ZuliaQuery.Query.Operator.AND);
+		parse = zuliaFlexibleQueryParser.parse(mmQuery);
+		Assertions.assertEquals("+abstract:diabetes +((+title:cancer +title:lung -title:fly title:rat title:bear title:insect +title:fruit)~2)",
+				parse.toString());
+
+		zuliaFlexibleQueryParser.setMinimumNumberShouldMatch(2);
+		zuliaFlexibleQueryParser.setDefaultFields(List.of("title"));
+		String mmQuery2 = "cancer AND lung -fly rat bear insect +fruit dragon";
+
+		zuliaFlexibleQueryParser.setDefaultOperator(ZuliaQuery.Query.Operator.OR);
+		parse = zuliaFlexibleQueryParser.parse(mmQuery2);
+		Assertions.assertEquals("(+title:cancer +title:lung -title:fly title:rat title:bear title:insect +title:fruit title:dragon)~2",
+				parse.toString());
+
+		zuliaFlexibleQueryParser.setDefaultOperator(ZuliaQuery.Query.Operator.AND);
+		parse = zuliaFlexibleQueryParser.parse(mmQuery2);
+		Assertions.assertEquals("(+title:cancer +title:lung -title:fly title:rat title:bear title:insect +title:fruit title:dragon)~2",
+				parse.toString());
+
+	}
+
+}

--- a/zulia-query-parser/src/test/resources/logback.xml
+++ b/zulia-query-parser/src/test/resources/logback.xml
@@ -1,0 +1,16 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <withJansi>true</withJansi>
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%cyan(%date{ISO8601}) %gray([%thread]) %highlight(%-5level) %magenta(%logger{36}) - %msg%n
+            </pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>


### PR DESCRIPTION
Make minimum should match queries have default OR handling in the minimum should match context of parens
 + / - / NoT inside the mm should match block are kept. 

At a global level setting minimumNumberShouldMatch on a query effecetively sets defaultOperator to OR regardless of what a user set

Setup query parser test cases and first test case for  minimum should match