### PR TITLE
Add BatchDeleteGroup with federated routing, mirroring BatchFetch pattern

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/command/BatchDelete.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/BatchDelete.java
@@ -1,26 +1,31 @@
 package io.zulia.client.command;
 
 import io.zulia.client.command.base.SimpleCommand;
+import io.zulia.client.command.builder.BatchDeleteGroupBuilder;
 import io.zulia.client.pool.ZuliaConnection;
 import io.zulia.client.result.BatchDeleteResult;
 import io.zulia.client.result.CompleteResult;
 import io.zulia.client.result.SearchResult;
-import io.zulia.message.ZuliaServiceOuterClass;
 import io.zulia.message.ZuliaServiceOuterClass.DeleteResponse;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import static io.zulia.message.ZuliaServiceGrpc.ZuliaServiceBlockingStub;
 import static io.zulia.message.ZuliaServiceOuterClass.BatchDeleteRequest;
 
-public class BatchDelete extends SimpleCommand<ZuliaServiceOuterClass.BatchDeleteRequest, BatchDeleteResult> {
+public class BatchDelete extends SimpleCommand<BatchDeleteRequest, BatchDeleteResult> {
 
-	private List<Delete> deletes;
+	private final List<Delete> deletes;
+	private final List<BatchDeleteGroupBuilder> groupList;
 
 	public BatchDelete() {
 		deletes = new ArrayList<>();
+		groupList = new ArrayList<>();
 	}
 
 	public BatchDelete addDelete(Delete delete) {
@@ -28,11 +33,24 @@ public class BatchDelete extends SimpleCommand<ZuliaServiceOuterClass.BatchDelet
 		return this;
 	}
 
+	public BatchDelete addDeleteGroup(BatchDeleteGroupBuilder group) {
+		groupList.add(group);
+		return this;
+	}
+
+	public BatchDelete addDeleteDocumentsFromUniqueIds(Collection<String> uniqueIds, String indexName) {
+		groupList.add(new BatchDeleteGroupBuilder(indexName, uniqueIds));
+		return this;
+	}
+
 	public BatchDelete deleteDocumentFromQueryResult(SearchResult queryResult) {
 
+		Map<String, List<String>> indexToUniqueIds = new LinkedHashMap<>();
 		for (CompleteResult completeResult : queryResult.getCompleteResults()) {
-			Delete delete = new DeleteDocument(completeResult.getUniqueId(), completeResult.getIndexName());
-			deletes.add(delete);
+			indexToUniqueIds.computeIfAbsent(completeResult.getIndexName(), k -> new ArrayList<>()).add(completeResult.getUniqueId());
+		}
+		for (Map.Entry<String, List<String>> entry : indexToUniqueIds.entrySet()) {
+			groupList.add(new BatchDeleteGroupBuilder(entry.getKey(), entry.getValue()));
 		}
 
 		return this;
@@ -44,6 +62,9 @@ public class BatchDelete extends SimpleCommand<ZuliaServiceOuterClass.BatchDelet
 
 		for (Delete delete : deletes) {
 			batchDeleteRequest.addRequest(delete.getRequest());
+		}
+		for (BatchDeleteGroupBuilder group : groupList) {
+			batchDeleteRequest.addBatchDeleteGroup(group.build());
 		}
 
 		return batchDeleteRequest.build();

--- a/zulia-client/src/main/java/io/zulia/client/command/builder/BatchDeleteGroupBuilder.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/builder/BatchDeleteGroupBuilder.java
@@ -1,0 +1,46 @@
+package io.zulia.client.command.builder;
+
+import io.zulia.message.ZuliaServiceOuterClass.BatchDeleteGroup;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class BatchDeleteGroupBuilder {
+
+	private final String indexName;
+	private final Set<String> uniqueIds;
+	private boolean deleteDocument = true;
+	private boolean deleteAllAssociated = false;
+	private String filename = "";
+
+	public BatchDeleteGroupBuilder(String indexName, Collection<String> uniqueIds) {
+		this.indexName = indexName;
+		this.uniqueIds = new LinkedHashSet<>(uniqueIds);
+	}
+
+	public BatchDeleteGroupBuilder setDeleteDocument(boolean deleteDocument) {
+		this.deleteDocument = deleteDocument;
+		return this;
+	}
+
+	public BatchDeleteGroupBuilder setDeleteAllAssociated(boolean deleteAllAssociated) {
+		this.deleteAllAssociated = deleteAllAssociated;
+		return this;
+	}
+
+	public BatchDeleteGroupBuilder setFilename(String filename) {
+		this.filename = filename;
+		return this;
+	}
+
+	public BatchDeleteGroup build() {
+		BatchDeleteGroup.Builder builder = BatchDeleteGroup.newBuilder();
+		builder.setIndexName(indexName);
+		builder.addAllUniqueId(uniqueIds);
+		builder.setDeleteDocument(deleteDocument);
+		builder.setDeleteAllAssociated(deleteAllAssociated);
+		builder.setFilename(filename);
+		return builder.build();
+	}
+}

--- a/zulia-common/src/main/proto/zulia_service.proto
+++ b/zulia-common/src/main/proto/zulia_service.proto
@@ -15,6 +15,7 @@ service ZuliaService {
     rpc Delete (DeleteRequest) returns (DeleteResponse);
     rpc InternalDelete (DeleteRequest) returns (DeleteResponse);
     rpc BatchDelete (BatchDeleteRequest) returns (stream DeleteResponse);
+    rpc InternalBatchDelete (InternalBatchDeleteRequest) returns (BatchDeleteResponse);
     rpc Fetch (FetchRequest) returns (FetchResponse);
     rpc InternalFetch (FetchRequest) returns (FetchResponse);
     rpc BatchFetch (BatchFetchRequest) returns (stream FetchResponse);
@@ -122,11 +123,34 @@ message DeleteRequest {
 message DeleteResponse {
 }
 
+message BatchDeleteGroup {
+    string indexName = 1;
+    repeated string uniqueId = 2;
+    bool deleteDocument = 3;
+    bool deleteAllAssociated = 4;
+    string filename = 5;
+}
+
 message BatchDeleteRequest {
     repeated DeleteRequest request = 1;
+    repeated BatchDeleteGroup batchDeleteGroup = 2;
 }
 
 message BatchDeleteResponse {
+    repeated DeleteResponse deleteResponse = 1;
+}
+
+message InternalShardBatchDeleteRequest {
+    string indexName = 1;
+    uint32 shardNumber = 2;
+    repeated string uniqueId = 3;
+    bool deleteDocument = 4;
+    bool deleteAllAssociated = 5;
+    string filename = 6;
+}
+
+message InternalBatchDeleteRequest {
+    repeated InternalShardBatchDeleteRequest shardBatchDeleteRequest = 1;
 }
 
 message FetchRequest {

--- a/zulia-server/src/main/java/io/zulia/server/connection/client/InternalClient.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/client/InternalClient.java
@@ -2,6 +2,7 @@ package io.zulia.server.connection.client;
 
 import io.zulia.message.ZuliaBase.Node;
 import io.zulia.message.ZuliaServiceOuterClass.*;
+import io.zulia.server.connection.client.handler.InternalBatchDeleteHandler;
 import io.zulia.server.connection.client.handler.InternalBatchFetchHandler;
 import io.zulia.server.connection.client.handler.InternalClearHandler;
 import io.zulia.server.connection.client.handler.InternalCreateIndexAliasHandler;
@@ -35,6 +36,7 @@ public class InternalClient {
 	private final InternalDeleteHandler internalDeleteHandler;
 	private final InternalFetchHandler internalFetchHandler;
 	private final InternalBatchFetchHandler internalBatchFetchHandler;
+	private final InternalBatchDeleteHandler internalBatchDeleteHandler;
 	private final InternalGetNumberOfDocsHandler internalGetNumberOfDocsHandler;
 	private final InternalOptimizeHandler internalOptimizeHandler;
 	private final InternalGetFieldNamesHandler internalGetFieldNamesHandler;
@@ -56,6 +58,7 @@ public class InternalClient {
 		internalDeleteHandler = new InternalDeleteHandler(this);
 		internalFetchHandler = new InternalFetchHandler(this);
 		internalBatchFetchHandler = new InternalBatchFetchHandler(this);
+		internalBatchDeleteHandler = new InternalBatchDeleteHandler(this);
 		internalGetNumberOfDocsHandler = new InternalGetNumberOfDocsHandler(this);
 		internalOptimizeHandler = new InternalOptimizeHandler(this);
 		internalGetFieldNamesHandler = new InternalGetFieldNamesHandler(this);
@@ -144,6 +147,10 @@ public class InternalClient {
 
 	public BatchFetchResponse executeBatchFetch(Node node, InternalBatchFetchRequest request) throws Exception {
 		return internalBatchFetchHandler.handleRequest(node, request);
+	}
+
+	public BatchDeleteResponse executeBatchDelete(Node node, InternalBatchDeleteRequest request) throws Exception {
+		return internalBatchDeleteHandler.handleRequest(node, request);
 	}
 
 	public GetNumberOfDocsResponse getNumberOfDocs(Node node, InternalGetNumberOfDocsRequest request) throws Exception {

--- a/zulia-server/src/main/java/io/zulia/server/connection/client/handler/InternalBatchDeleteHandler.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/client/handler/InternalBatchDeleteHandler.java
@@ -1,0 +1,17 @@
+package io.zulia.server.connection.client.handler;
+
+import io.zulia.message.ZuliaServiceOuterClass.BatchDeleteResponse;
+import io.zulia.message.ZuliaServiceOuterClass.InternalBatchDeleteRequest;
+import io.zulia.server.connection.client.InternalClient;
+import io.zulia.server.connection.client.InternalRpcConnection;
+
+public class InternalBatchDeleteHandler extends InternalRequestHandler<BatchDeleteResponse, InternalBatchDeleteRequest> {
+	public InternalBatchDeleteHandler(InternalClient internalClient) {
+		super(internalClient);
+	}
+
+	@Override
+	protected BatchDeleteResponse getResponse(InternalBatchDeleteRequest request, InternalRpcConnection rpcConnection) {
+		return rpcConnection.getService().internalBatchDelete(request);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/ZuliaServiceHandler.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/ZuliaServiceHandler.java
@@ -15,6 +15,7 @@ public class ZuliaServiceHandler extends ZuliaServiceImplBase {
 	private final DeleteServerRequest deleteServerRequest;
 	private final InternalDeleteServerRequest internalDeleteServerRequest;
 	private final BatchDeleteServerRequest batchDeleteServerRequest;
+	private final InternalBatchDeleteServerRequest internalBatchDeleteServerRequest;
 	private final FetchServerRequest fetchServerServerRequest;
 	private final InternalFetchServerRequest internalFetchServerServerRequest;
 	private final BatchFetchServerRequest batchFetchServerRequest;
@@ -53,6 +54,7 @@ public class ZuliaServiceHandler extends ZuliaServiceImplBase {
 		deleteServerRequest = new DeleteServerRequest(indexManager);
 		internalDeleteServerRequest = new InternalDeleteServerRequest(indexManager);
 		batchDeleteServerRequest = new BatchDeleteServerRequest(indexManager);
+		internalBatchDeleteServerRequest = new InternalBatchDeleteServerRequest(indexManager);
 		fetchServerServerRequest = new FetchServerRequest(indexManager);
 		internalFetchServerServerRequest = new InternalFetchServerRequest(indexManager);
 		batchFetchServerRequest = new BatchFetchServerRequest(indexManager);
@@ -116,6 +118,11 @@ public class ZuliaServiceHandler extends ZuliaServiceImplBase {
 	@Override
 	public void batchDelete(BatchDeleteRequest request, StreamObserver<DeleteResponse> responseObserver) {
 		batchDeleteServerRequest.handleRequest(request, responseObserver);
+	}
+
+	@Override
+	public void internalBatchDelete(InternalBatchDeleteRequest request, StreamObserver<BatchDeleteResponse> responseObserver) {
+		internalBatchDeleteServerRequest.handleRequest(request, responseObserver);
 	}
 
 	@Override

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/handler/BatchDeleteServerRequest.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/handler/BatchDeleteServerRequest.java
@@ -2,7 +2,6 @@ package io.zulia.server.connection.server.handler;
 
 import io.grpc.stub.StreamObserver;
 import io.zulia.message.ZuliaServiceOuterClass.BatchDeleteRequest;
-import io.zulia.message.ZuliaServiceOuterClass.DeleteRequest;
 import io.zulia.message.ZuliaServiceOuterClass.DeleteResponse;
 import io.zulia.server.index.ZuliaIndexManager;
 import org.slf4j.Logger;
@@ -19,11 +18,7 @@ public class BatchDeleteServerRequest {
 
 	public void handleRequest(BatchDeleteRequest request, StreamObserver<DeleteResponse> responseObserver) {
 		try {
-			for (DeleteRequest deleteRequest : request.getRequestList()) {
-				DeleteResponse deleteResponse = indexManager.delete(deleteRequest);
-				responseObserver.onNext(deleteResponse);
-			}
-
+			indexManager.batchDelete(request, responseObserver);
 			responseObserver.onCompleted();
 		}
 		catch (Exception e) {

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/handler/InternalBatchDeleteServerRequest.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/handler/InternalBatchDeleteServerRequest.java
@@ -1,0 +1,30 @@
+package io.zulia.server.connection.server.handler;
+
+import io.zulia.message.ZuliaServiceOuterClass.BatchDeleteResponse;
+import io.zulia.message.ZuliaServiceOuterClass.DeleteResponse;
+import io.zulia.message.ZuliaServiceOuterClass.InternalBatchDeleteRequest;
+import io.zulia.server.index.ZuliaIndexManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class InternalBatchDeleteServerRequest extends ServerRequestHandler<BatchDeleteResponse, InternalBatchDeleteRequest> {
+
+	private final static Logger LOG = LoggerFactory.getLogger(InternalBatchDeleteServerRequest.class);
+
+	public InternalBatchDeleteServerRequest(ZuliaIndexManager indexManager) {
+		super(indexManager);
+	}
+
+	@Override
+	protected BatchDeleteResponse handleCall(ZuliaIndexManager indexManager, InternalBatchDeleteRequest request) throws Exception {
+		List<DeleteResponse> responses = indexManager.internalBatchDelete(request);
+		return BatchDeleteResponse.newBuilder().addAllDeleteResponse(responses).build();
+	}
+
+	@Override
+	protected void onError(Throwable e) {
+		LOG.error("Failed to handle internal batch delete", e);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
@@ -353,8 +353,38 @@ public class ZuliaIndex {
 			documentStorage.deleteAssociatedDocument(uniqueId, fileName);
 		}
 
-		return DeleteResponse.newBuilder().build();
+		return DeleteResponse.getDefaultInstance();
 
+	}
+
+	public List<DeleteResponse> internalShardBatchDelete(InternalShardBatchDeleteRequest shardRequest) throws Exception {
+		int shardNumber = shardRequest.getShardNumber();
+		ZuliaShard shard = primaryShardMap.get(shardNumber);
+		if (shard == null) {
+			throw new ShardDoesNotExistException(indexName, shardNumber);
+		}
+
+		List<String> uniqueIds = shardRequest.getUniqueIdList();
+		boolean deleteDocument = shardRequest.getDeleteDocument();
+		boolean deleteAllAssociated = shardRequest.getDeleteAllAssociated();
+		String filename = shardRequest.getFilename();
+
+		List<DeleteResponse> responses = new ArrayList<>(uniqueIds.size());
+		for (String uniqueId : uniqueIds) {
+			if (deleteDocument) {
+				shard.deleteDocument(uniqueId);
+			}
+
+			if (deleteAllAssociated) {
+				documentStorage.deleteAssociatedDocuments(uniqueId);
+			}
+			else if (!filename.isEmpty()) {
+				documentStorage.deleteAssociatedDocument(uniqueId, filename);
+			}
+
+			responses.add(DeleteResponse.getDefaultInstance());
+		}
+		return responses;
 	}
 
 	public Query handleTermQuery(ZuliaQuery.Query query) {

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
@@ -36,6 +36,7 @@ import io.zulia.server.filestorage.DocumentStorage;
 import io.zulia.server.filestorage.FileDocumentStorage;
 import io.zulia.server.filestorage.MongoDocumentStorage;
 import io.zulia.server.filestorage.S3DocumentStorage;
+import io.zulia.server.index.federator.BatchDeleteRequestFederator;
 import io.zulia.server.index.federator.BatchFetchRequestFederator;
 import io.zulia.server.index.federator.ClearRequestFederator;
 import io.zulia.server.index.federator.CreateIndexAliasRequestFederator;
@@ -395,6 +396,53 @@ public class ZuliaIndexManager {
 	public DeleteResponse internalDelete(DeleteRequest request) throws Exception {
 		ZuliaIndex i = getIndexFromName(request.getIndexName());
 		return DeleteRequestRouter.internalDelete(i, request);
+	}
+
+	public void batchDelete(BatchDeleteRequest request, StreamObserver<DeleteResponse> responseObserver) throws Exception {
+		if (request.getRequestList().isEmpty() && request.getBatchDeleteGroupList().isEmpty()) {
+			return;
+		}
+
+		Set<String> indexNames = new HashSet<>();
+		for (DeleteRequest deleteRequest : request.getRequestList()) {
+			indexNames.add(deleteRequest.getIndexName());
+		}
+		for (BatchDeleteGroup group : request.getBatchDeleteGroupList()) {
+			indexNames.add(group.getIndexName());
+		}
+
+		Map<String, ZuliaIndex> indexCache = new HashMap<>();
+		for (String indexName : indexNames) {
+			indexCache.put(indexName, getIndexFromName(indexName));
+		}
+
+		BatchDeleteRequestFederator federator = new BatchDeleteRequestFederator(thisNode, currentOtherNodesActive, pool, internalClient, indexCache);
+		List<DeleteResponse> responses = federator.send(request);
+		for (DeleteResponse response : responses) {
+			responseObserver.onNext(response);
+		}
+	}
+
+	public List<DeleteResponse> internalBatchDelete(InternalBatchDeleteRequest request) throws Exception {
+		List<InternalShardBatchDeleteRequest> shardRequests = request.getShardBatchDeleteRequestList();
+		if (shardRequests.size() == 1) {
+			ZuliaIndex index = getIndexFromName(shardRequests.getFirst().getIndexName());
+			return index.internalShardBatchDelete(shardRequests.getFirst());
+		}
+
+		List<Future<List<DeleteResponse>>> futures = new ArrayList<>(shardRequests.size());
+		for (InternalShardBatchDeleteRequest shardRequest : shardRequests) {
+			futures.add(pool.submit(() -> {
+				ZuliaIndex index = getIndexFromName(shardRequest.getIndexName());
+				return index.internalShardBatchDelete(shardRequest);
+			}));
+		}
+
+		List<DeleteResponse> allResponses = new ArrayList<>();
+		for (Future<List<DeleteResponse>> future : futures) {
+			allResponses.addAll(future.get());
+		}
+		return allResponses;
 	}
 
 	public CreateIndexResponse createIndex(CreateIndexRequest request) throws Exception {

--- a/zulia-server/src/main/java/io/zulia/server/index/federator/BatchDeleteRequestFederator.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/federator/BatchDeleteRequestFederator.java
@@ -1,0 +1,156 @@
+package io.zulia.server.index.federator;
+
+import io.zulia.message.ZuliaBase.MasterSlaveSettings;
+import io.zulia.message.ZuliaBase.Node;
+import io.zulia.message.ZuliaServiceOuterClass.BatchDeleteGroup;
+import io.zulia.message.ZuliaServiceOuterClass.BatchDeleteRequest;
+import io.zulia.message.ZuliaServiceOuterClass.DeleteRequest;
+import io.zulia.message.ZuliaServiceOuterClass.DeleteResponse;
+import io.zulia.message.ZuliaServiceOuterClass.InternalBatchDeleteRequest;
+import io.zulia.message.ZuliaServiceOuterClass.InternalShardBatchDeleteRequest;
+import io.zulia.server.connection.client.InternalClient;
+import io.zulia.server.index.MasterSlaveSelector;
+import io.zulia.server.index.NodeRequestBase;
+import io.zulia.server.index.ZuliaIndex;
+import io.zulia.util.ShardUtil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+public class BatchDeleteRequestFederator extends NodeRequestBase<InternalBatchDeleteRequest, List<DeleteResponse>> {
+
+	private final ExecutorService pool;
+	private final InternalClient internalClient;
+	private final Map<String, ZuliaIndex> indexCache;
+
+	public BatchDeleteRequestFederator(Node thisNode, Collection<Node> otherNodesActive, ExecutorService pool, InternalClient internalClient,
+			Map<String, ZuliaIndex> indexCache) {
+		super(thisNode, otherNodesActive);
+		this.pool = pool;
+		this.internalClient = internalClient;
+		this.indexCache = indexCache;
+	}
+
+	@Override
+	protected List<DeleteResponse> processInternal(Node node, InternalBatchDeleteRequest request) throws Exception {
+		List<InternalShardBatchDeleteRequest> shardRequests = request.getShardBatchDeleteRequestList();
+		if (shardRequests.size() == 1) {
+			ZuliaIndex index = indexCache.get(shardRequests.getFirst().getIndexName());
+			return index.internalShardBatchDelete(shardRequests.getFirst());
+		}
+
+		List<Future<List<DeleteResponse>>> futures = new ArrayList<>(shardRequests.size());
+		for (InternalShardBatchDeleteRequest shardRequest : shardRequests) {
+			futures.add(pool.submit(() -> {
+				ZuliaIndex index = indexCache.get(shardRequest.getIndexName());
+				return index.internalShardBatchDelete(shardRequest);
+			}));
+		}
+
+		List<DeleteResponse> allResponses = new ArrayList<>();
+		for (Future<List<DeleteResponse>> future : futures) {
+			allResponses.addAll(future.get());
+		}
+		return allResponses;
+	}
+
+	@Override
+	protected List<DeleteResponse> processExternal(Node node, InternalBatchDeleteRequest request) throws Exception {
+		return internalClient.executeBatchDelete(node, request).getDeleteResponseList();
+	}
+
+	public List<DeleteResponse> send(BatchDeleteRequest request) throws Exception {
+
+		List<DeleteRequest> deleteRequests = request.getRequestList();
+		List<BatchDeleteGroup> batchDeleteGroups = request.getBatchDeleteGroupList();
+		if (deleteRequests.isEmpty() && batchDeleteGroups.isEmpty()) {
+			return List.of();
+		}
+
+		List<Node> nodesAvailable = new ArrayList<>();
+		nodesAvailable.add(thisNode);
+		nodesAvailable.addAll(otherNodesActive);
+
+		// Group into shard-level batches keyed by (node, indexName, shardNumber, deleteProfile)
+		record ShardKey(Node node, String indexName, int shardNumber, boolean deleteDocument, boolean deleteAllAssociated, String filename) {
+		}
+		Map<ShardKey, List<String>> shardGroups = new LinkedHashMap<>();
+
+		Map<String, MasterSlaveSelector> selectorCache = new HashMap<>();
+
+		for (DeleteRequest deleteRequest : deleteRequests) {
+			String indexName = deleteRequest.getIndexName();
+			MasterSlaveSelector selector = selectorCache.computeIfAbsent(indexName, name -> {
+				ZuliaIndex index = indexCache.get(name);
+				return new MasterSlaveSelector(MasterSlaveSettings.MASTER_ONLY, nodesAvailable, index.getIndexShardMapping());
+			});
+			Node targetNode = selector.getNodeForUniqueId(deleteRequest.getUniqueId());
+			int shardNumber = ShardUtil.findShardForUniqueId(deleteRequest.getUniqueId(), indexCache.get(indexName).getNumberOfShards());
+			ShardKey key = new ShardKey(targetNode, indexName, shardNumber, deleteRequest.getDeleteDocument(), deleteRequest.getDeleteAllAssociated(),
+					deleteRequest.getFilename());
+			shardGroups.computeIfAbsent(key, k -> new ArrayList<>()).add(deleteRequest.getUniqueId());
+		}
+
+		for (BatchDeleteGroup group : batchDeleteGroups) {
+			String indexName = group.getIndexName();
+			MasterSlaveSelector selector = selectorCache.computeIfAbsent(indexName, name -> {
+				ZuliaIndex index = indexCache.get(name);
+				return new MasterSlaveSelector(MasterSlaveSettings.MASTER_ONLY, nodesAvailable, index.getIndexShardMapping());
+			});
+			for (String uniqueId : group.getUniqueIdList()) {
+				Node targetNode = selector.getNodeForUniqueId(uniqueId);
+				int shardNumber = ShardUtil.findShardForUniqueId(uniqueId, indexCache.get(indexName).getNumberOfShards());
+				ShardKey key = new ShardKey(targetNode, indexName, shardNumber, group.getDeleteDocument(), group.getDeleteAllAssociated(),
+						group.getFilename());
+				shardGroups.computeIfAbsent(key, k -> new ArrayList<>()).add(uniqueId);
+			}
+		}
+
+		// Group shard batches by node into InternalBatchDeleteRequests
+		Map<Node, InternalBatchDeleteRequest.Builder> nodeRequests = new LinkedHashMap<>();
+		for (Map.Entry<ShardKey, List<String>> entry : shardGroups.entrySet()) {
+			ShardKey key = entry.getKey();
+			InternalShardBatchDeleteRequest shardRequest = InternalShardBatchDeleteRequest.newBuilder().setIndexName(key.indexName())
+					.setShardNumber(key.shardNumber()).addAllUniqueId(entry.getValue()).setDeleteDocument(key.deleteDocument())
+					.setDeleteAllAssociated(key.deleteAllAssociated()).setFilename(key.filename()).build();
+			nodeRequests.computeIfAbsent(key.node(), k -> InternalBatchDeleteRequest.newBuilder()).addShardBatchDeleteRequest(shardRequest);
+		}
+
+		// Submit work per node in parallel
+		List<Future<List<DeleteResponse>>> futures = new ArrayList<>(nodeRequests.size());
+
+		for (Map.Entry<Node, InternalBatchDeleteRequest.Builder> entry : nodeRequests.entrySet()) {
+			Node node = entry.getKey();
+			InternalBatchDeleteRequest nodeRequest = entry.getValue().build();
+
+			if (nodeIsLocal(node)) {
+				futures.add(pool.submit(() -> processInternal(node, nodeRequest)));
+			}
+			else {
+				futures.add(pool.submit(() -> processExternal(node, nodeRequest)));
+			}
+		}
+
+		List<DeleteResponse> allResponses = new ArrayList<>();
+		for (Future<List<DeleteResponse>> future : futures) {
+			try {
+				allResponses.addAll(future.get());
+			}
+			catch (ExecutionException e) {
+				Throwable cause = e.getCause();
+				if (cause instanceof Exception ex) {
+					throw ex;
+				}
+				throw new Exception(cause);
+			}
+		}
+		return allResponses;
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/federator/BatchFetchRequestFederator.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/federator/BatchFetchRequestFederator.java
@@ -17,6 +17,7 @@ import io.zulia.util.ShardUtil;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,12 +88,16 @@ public class BatchFetchRequestFederator extends NodeRequestBase<InternalBatchFet
 		}
 		Map<ShardKey, List<String>> shardGroups = new LinkedHashMap<>();
 
+		Map<String, MasterSlaveSelector> selectorCache = new HashMap<>();
+
 		for (FetchRequest fetchRequest : fetchRequests) {
 			String indexName = fetchRequest.getIndexName();
-			ZuliaIndex index = indexCache.get(indexName);
-			MasterSlaveSelector selector = new MasterSlaveSelector(masterSlaveSettings, nodesAvailable, index.getIndexShardMapping());
+			MasterSlaveSelector selector = selectorCache.computeIfAbsent(indexName, name -> {
+				ZuliaIndex index = indexCache.get(name);
+				return new MasterSlaveSelector(masterSlaveSettings, nodesAvailable, index.getIndexShardMapping());
+			});
 			Node targetNode = selector.getNodeForUniqueId(fetchRequest.getUniqueId());
-			int shardNumber = ShardUtil.findShardForUniqueId(fetchRequest.getUniqueId(), index.getNumberOfShards());
+			int shardNumber = ShardUtil.findShardForUniqueId(fetchRequest.getUniqueId(), indexCache.get(indexName).getNumberOfShards());
 			ShardKey key = new ShardKey(targetNode, indexName, shardNumber, fetchRequest.getResultFetchType(), fetchRequest.getDocumentFieldsList(),
 					fetchRequest.getDocumentMaskedFieldsList(), fetchRequest.getRealtime(), fetchRequest.getAssociatedFetchType(),
 					fetchRequest.getFilename());
@@ -101,11 +106,13 @@ public class BatchFetchRequestFederator extends NodeRequestBase<InternalBatchFet
 
 		for (BatchFetchGroup group : batchFetchGroups) {
 			String indexName = group.getIndexName();
-			ZuliaIndex index = indexCache.get(indexName);
-			MasterSlaveSelector selector = new MasterSlaveSelector(masterSlaveSettings, nodesAvailable, index.getIndexShardMapping());
+			MasterSlaveSelector selector = selectorCache.computeIfAbsent(indexName, name -> {
+				ZuliaIndex index = indexCache.get(name);
+				return new MasterSlaveSelector(masterSlaveSettings, nodesAvailable, index.getIndexShardMapping());
+			});
 			for (String uniqueId : group.getUniqueIdList()) {
 				Node targetNode = selector.getNodeForUniqueId(uniqueId);
-				int shardNumber = ShardUtil.findShardForUniqueId(uniqueId, index.getNumberOfShards());
+				int shardNumber = ShardUtil.findShardForUniqueId(uniqueId, indexCache.get(indexName).getNumberOfShards());
 				ShardKey key = new ShardKey(targetNode, indexName, shardNumber, group.getResultFetchType(), group.getDocumentFieldsList(),
 						group.getDocumentMaskedFieldsList(), group.getRealtime(), group.getAssociatedFetchType(), group.getFilename());
 				shardGroups.computeIfAbsent(key, k -> new ArrayList<>()).add(uniqueId);

--- a/zulia-server/src/test/java/io/zulia/server/test/node/GeneralFeaturesTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/GeneralFeaturesTest.java
@@ -3,10 +3,12 @@ package io.zulia.server.test.node;
 import io.zulia.DefaultAnalyzers;
 import io.zulia.client.command.BatchDelete;
 import io.zulia.client.command.BatchFetch;
+import io.zulia.client.command.DeleteFull;
 import io.zulia.client.command.FetchAllAssociated;
 import io.zulia.client.command.DeleteFromIndex;
 import io.zulia.client.command.Fetch;
 import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.BatchDeleteGroupBuilder;
 import io.zulia.client.command.builder.BatchFetchGroupBuilder;
 import io.zulia.client.command.builder.CountFacet;
 import io.zulia.client.command.builder.FilterQuery;
@@ -15,6 +17,7 @@ import io.zulia.client.command.builder.Search;
 import io.zulia.client.config.ClientIndexConfig;
 import io.zulia.client.pool.ZuliaWorkPool;
 import io.zulia.client.result.AssociatedResult;
+import io.zulia.client.result.BatchDeleteResult;
 import io.zulia.client.result.BatchFetchResult;
 import io.zulia.client.result.FetchResult;
 import io.zulia.client.result.SearchResult;
@@ -326,7 +329,7 @@ public class GeneralFeaturesTest {
 	public void batchDeleteTest() throws Exception {
 		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
 
-		// Index extra documents to delete
+		// --- Individual addDelete (existing coverage) ---
 		indexRecord(100, "To Be Deleted 1", "temp", "article", 1.0);
 		indexRecord(101, "To Be Deleted 2", "temp", "article", 1.0);
 		indexRecord(102, "To Be Deleted 3", "temp", "article", 1.0);
@@ -335,26 +338,147 @@ public class GeneralFeaturesTest {
 		SearchResult searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(UNIQUE_DOCS + 3, searchResult.getTotalHits());
 
-		// Batch delete specific IDs
 		BatchDelete batchDelete = new BatchDelete();
 		batchDelete.addDelete(new DeleteFromIndex("100", INDEX_NAME));
 		batchDelete.addDelete(new DeleteFromIndex("101", INDEX_NAME));
 		batchDelete.addDelete(new DeleteFromIndex("102", INDEX_NAME));
-		zuliaWorkPool.batchDelete(batchDelete);
+		BatchDeleteResult result = zuliaWorkPool.batchDelete(batchDelete);
+		Assertions.assertEquals(3, result.getDeleteCount());
 
-		// Batch delete from search results
-		indexRecord(200, "Delete via search 1", "temp2", "article", 1.0);
-		indexRecord(201, "Delete via search 2", "temp2", "article", 1.0);
+		search = new Search(INDEX_NAME).setRealtime(true);
+		searchResult = zuliaWorkPool.search(search);
+		Assertions.assertEquals(UNIQUE_DOCS, searchResult.getTotalHits());
+
+		// --- BatchDeleteGroupBuilder: basic delete by group ---
+		indexRecord(200, "Group Delete 1", "grp", "article", 1.0);
+		indexRecord(201, "Group Delete 2", "grp", "article", 1.0);
+		indexRecord(202, "Group Delete 3", "grp", "article", 1.0);
+
+		BatchDeleteGroupBuilder groupBuilder = new BatchDeleteGroupBuilder(INDEX_NAME, List.of("200", "201", "202"));
+		BatchDelete groupDelete = new BatchDelete().addDeleteGroup(groupBuilder);
+		result = zuliaWorkPool.batchDelete(groupDelete);
+		Assertions.assertEquals(3, result.getDeleteCount());
+
+		search = new Search(INDEX_NAME).setRealtime(true);
+		searchResult = zuliaWorkPool.search(search);
+		Assertions.assertEquals(UNIQUE_DOCS, searchResult.getTotalHits());
+
+		// --- addDeleteDocumentsFromUniqueIds convenience method ---
+		indexRecord(300, "Convenience 1", "conv", "article", 1.0);
+		indexRecord(301, "Convenience 2", "conv", "article", 1.0);
+
+		result = zuliaWorkPool.batchDelete(new BatchDelete().addDeleteDocumentsFromUniqueIds(List.of("300", "301"), INDEX_NAME));
+		Assertions.assertEquals(2, result.getDeleteCount());
+
+		search = new Search(INDEX_NAME).setRealtime(true);
+		searchResult = zuliaWorkPool.search(search);
+		Assertions.assertEquals(UNIQUE_DOCS, searchResult.getTotalHits());
+
+		// --- Mix: individual addDelete + addDeleteGroup in same batch ---
+		indexRecord(400, "Mix Individual", "mix", "article", 1.0);
+		indexRecord(401, "Mix Group 1", "mix", "article", 1.0);
+		indexRecord(402, "Mix Group 2", "mix", "article", 1.0);
+
+		BatchDelete mixDelete = new BatchDelete();
+		mixDelete.addDelete(new DeleteFromIndex("400", INDEX_NAME));
+		mixDelete.addDeleteGroup(new BatchDeleteGroupBuilder(INDEX_NAME, List.of("401", "402")));
+		result = zuliaWorkPool.batchDelete(mixDelete);
+		Assertions.assertEquals(3, result.getDeleteCount());
+
+		search = new Search(INDEX_NAME).setRealtime(true);
+		searchResult = zuliaWorkPool.search(search);
+		Assertions.assertEquals(UNIQUE_DOCS, searchResult.getTotalHits());
+
+		// --- deleteDocumentFromQueryResult groups by index ---
+		indexRecord(500, "Search Delete 1", "srch", "article", 1.0);
+		indexRecord(501, "Search Delete 2", "srch", "article", 1.0);
 
 		search = new Search(INDEX_NAME).setAmount(10).setRealtime(true);
-		search.addQuery(new FilterQuery("category:temp2"));
+		search.addQuery(new FilterQuery("category:srch"));
 		searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(2, searchResult.getTotalHits());
 
 		BatchDelete deleteFromResults = new BatchDelete().deleteDocumentFromQueryResult(searchResult);
-		zuliaWorkPool.batchDelete(deleteFromResults);
+		result = zuliaWorkPool.batchDelete(deleteFromResults);
+		Assertions.assertEquals(2, result.getDeleteCount());
 
-		// Verify the original documents remain after all batch deletes
+		search = new Search(INDEX_NAME).setRealtime(true);
+		searchResult = zuliaWorkPool.search(search);
+		Assertions.assertEquals(UNIQUE_DOCS, searchResult.getTotalHits());
+
+		// --- BatchDeleteGroupBuilder: delete associated documents by filename ---
+		// Doc 2 has notes.txt and summary.txt associated
+		FetchResult fetchResult = zuliaWorkPool.fetch(new FetchAllAssociated("2", INDEX_NAME));
+		Assertions.assertEquals(2, fetchResult.getAssociatedDocumentCount());
+
+		BatchDeleteGroupBuilder deleteAssocFile = new BatchDeleteGroupBuilder(INDEX_NAME, List.of("2")).setDeleteDocument(false)
+				.setFilename("summary.txt");
+		zuliaWorkPool.batchDelete(new BatchDelete().addDeleteGroup(deleteAssocFile));
+
+		fetchResult = zuliaWorkPool.fetch(new FetchAllAssociated("2", INDEX_NAME));
+		Assertions.assertEquals(1, fetchResult.getAssociatedDocumentCount());
+		Assertions.assertEquals("notes.txt", fetchResult.getFirstAssociatedDocument().getFilename());
+
+		// Doc 2 should still exist as a document
+		Fetch fetchDoc2 = new Fetch("2", INDEX_NAME);
+		fetchDoc2.setRealtime(true);
+		fetchResult = zuliaWorkPool.fetch(fetchDoc2);
+		Assertions.assertTrue(fetchResult.hasResultDocument());
+
+		// --- BatchDeleteGroupBuilder: deleteAllAssociated ---
+		// Doc 1 has notes.txt associated
+		fetchResult = zuliaWorkPool.fetch(new FetchAllAssociated("1", INDEX_NAME));
+		Assertions.assertEquals(1, fetchResult.getAssociatedDocumentCount());
+
+		BatchDeleteGroupBuilder deleteAllAssoc = new BatchDeleteGroupBuilder(INDEX_NAME, List.of("1")).setDeleteDocument(false)
+				.setDeleteAllAssociated(true);
+		zuliaWorkPool.batchDelete(new BatchDelete().addDeleteGroup(deleteAllAssoc));
+
+		fetchResult = zuliaWorkPool.fetch(new FetchAllAssociated("1", INDEX_NAME));
+		Assertions.assertEquals(0, fetchResult.getAssociatedDocumentCount());
+
+		// Doc 1 should still exist as a document
+		Fetch fetchDoc1 = new Fetch("1", INDEX_NAME);
+		fetchDoc1.setRealtime(true);
+		fetchResult = zuliaWorkPool.fetch(fetchDoc1);
+		Assertions.assertTrue(fetchResult.hasResultDocument());
+
+		// --- BatchDeleteGroupBuilder with DeleteFull via individual addDelete: delete doc + all associated ---
+		// Re-add associated for doc 2
+		Store store2 = new Store("2", INDEX_NAME);
+		store2.addAssociatedDocument(AssociatedBuilder.newBuilder().setFilename("notes.txt").setDocument("restored notes"));
+		zuliaWorkPool.store(store2);
+
+		fetchResult = zuliaWorkPool.fetch(new FetchAllAssociated("2", INDEX_NAME));
+		Assertions.assertEquals(1, fetchResult.getAssociatedDocumentCount());
+
+		// Use addDelete with DeleteFull alongside a group
+		indexRecord(600, "Full Delete Target", "full", "article", 1.0);
+
+		BatchDelete fullMix = new BatchDelete();
+		fullMix.addDelete(new DeleteFull("2", INDEX_NAME));
+		fullMix.addDeleteGroup(new BatchDeleteGroupBuilder(INDEX_NAME, List.of("600")));
+		result = zuliaWorkPool.batchDelete(fullMix);
+		Assertions.assertEquals(2, result.getDeleteCount());
+
+		// Doc 2 should be gone
+		Fetch fetchDoc2Again = new Fetch("2", INDEX_NAME);
+		fetchDoc2Again.setRealtime(true);
+		fetchResult = zuliaWorkPool.fetch(fetchDoc2Again);
+		Assertions.assertFalse(fetchResult.hasResultDocument());
+
+		// Associated docs for doc 2 should be gone
+		fetchResult = zuliaWorkPool.fetch(new FetchAllAssociated("2", INDEX_NAME));
+		Assertions.assertEquals(0, fetchResult.getAssociatedDocumentCount());
+
+		// Doc 600 should be gone
+		search = new Search(INDEX_NAME).setRealtime(true);
+		searchResult = zuliaWorkPool.search(search);
+		Assertions.assertEquals(UNIQUE_DOCS - 1, searchResult.getTotalHits());
+
+		// Restore doc 2 for downstream tests
+		indexRecord(2, "Python Basics", "tech", "book", 3.8);
+
 		search = new Search(INDEX_NAME).setRealtime(true);
 		searchResult = zuliaWorkPool.search(search);
 		Assertions.assertEquals(UNIQUE_DOCS, searchResult.getTotalHits());


### PR DESCRIPTION
* Add BatchDeleteGroup with federated routing, mirroring BatchFetch pattern
*  Cache MasterSlaveSelector per index in both BatchDeleteRequestFederator and BatchFetchRequestFederator
* Add test cases for batch delete features