### PR TITLE
Data Source Fixes

### DIFF
--- a/zulia-data/src/main/java/io/zulia/data/source/DataSourceRecord.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/DataSourceRecord.java
@@ -37,7 +37,7 @@ public interface DataSourceRecord {
 
 	Integer getInt(String field);
 
-	default int getDouble(String field, int defaultValue) {
+	default int getInt(String field, int defaultValue) {
 		Integer val = getInt(field);
 		return val != null ? val : defaultValue;
 	}

--- a/zulia-data/src/main/java/io/zulia/data/source/json/JsonArraySource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/json/JsonArraySource.java
@@ -78,8 +78,7 @@ public class JsonArraySource implements DataSource<JsonSourceRecord>, AutoClosea
 					}
 				}
 				catch (IOException e) {
-					System.out.println(e.getMessage());
-					//throw new RuntimeException(e);
+					throw new RuntimeException(e);
 				}
 				return jsonSourceRecord;
 			}

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSourceConfig.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSourceConfig.java
@@ -34,7 +34,7 @@ public class ExcelSourceConfig {
 	}
 
 	public ExcelSourceConfig withStrictHeaders() {
-		return withHeaders(new HeaderConfig().allowBlanks(true).allowDuplicates(true));
+		return withHeaders(new HeaderConfig().allowBlanks(false).allowDuplicates(false));
 	}
 
 	public ExcelSourceConfig withHeaders(HeaderConfig headerConfig) {


### PR DESCRIPTION
* Rename misnamed `getDouble(String, int)` to `getInt(String, int)` in DataSourceRecord
* Fix `ExcelSourceConfig.withStrictHeaders()` to reject blanks and duplicates, matching DelimitedSourceConfig behavior
* Stop silently swallowing IOException in JsonArraySource iterator and propagate as RuntimeException