### PR TITLE
sparse_models

### DIFF
--- a/zulia-ai/src/main/java/io/zulia/ai/embedding/HuggingFaceModelDownloader.java
+++ b/zulia-ai/src/main/java/io/zulia/ai/embedding/HuggingFaceModelDownloader.java
@@ -10,7 +10,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 
-class HuggingFaceModelDownloader {
+public class HuggingFaceModelDownloader {
 
 	private static final String HF_BASE = "https://huggingface.co/";
 	private static final String[] ONNX_PATHS = { "onnx/model.onnx", "model.onnx" };

--- a/zulia-ai/src/main/java/io/zulia/ai/embedding/KnownEmbeddingModel.java
+++ b/zulia-ai/src/main/java/io/zulia/ai/embedding/KnownEmbeddingModel.java
@@ -59,7 +59,11 @@ public enum KnownEmbeddingModel {
 	// Snowflake Arctic Embed - retrieval-optimized, CLS pooling
 	SNOWFLAKE_ARCTIC_EMBED_M_V2(EmbeddingModelConfig.builder("https://huggingface.co/Snowflake/snowflake-arctic-embed-m-v2.0", 768)
 			.prefixes("Represent this sentence for searching relevant passages: ", "")
-			.poolingMode("cls").build());
+			.poolingMode("cls").build()),
+
+	// Bioclinical ModernBERT - biomedical/clinical domain, mean pooling, 8192 token context
+	BIOCLINICAL_MODERNBERT(EmbeddingModelConfig.builder("https://huggingface.co/zuliaio/bioclinical-modernbert-base-embeddings-onnx", 768)
+			.build());
 
 	private final EmbeddingModelConfig config;
 

--- a/zulia-ai/src/main/java/io/zulia/ai/sparse/KnownSparseModel.java
+++ b/zulia-ai/src/main/java/io/zulia/ai/sparse/KnownSparseModel.java
@@ -1,0 +1,25 @@
+package io.zulia.ai.sparse;
+
+public enum KnownSparseModel {
+
+	// OpenSearch Neural Sparse v1 - symmetric, BERT-base (110M params), 0.524 BEIR NDCG@10
+	OPENSEARCH_NEURAL_SPARSE_V1(SparseModelConfig.builder("https://huggingface.co/zuliaio/opensearch-sparse-v1-onnx").build()),
+
+	// OpenSearch Neural Sparse v2 Distill - symmetric, DistilBERT (67M params), 0.528 BEIR NDCG@10
+	OPENSEARCH_NEURAL_SPARSE_V2_DISTILL(SparseModelConfig.builder("https://huggingface.co/zuliaio/opensearch-sparse-v2-distill-onnx")
+			.includeTokenTypes(false).build()),
+
+	// IBM Granite Sparse - symmetric, RoBERTa (30M params), 0.508 BEIR NDCG@10, BPE tokenizer (50K vocab)
+	GRANITE_30M_SPARSE(SparseModelConfig.builder("https://huggingface.co/zuliaio/granite-30m-sparse-onnx")
+			.includeTokenTypes(false).build());
+
+	private final SparseModelConfig config;
+
+	KnownSparseModel(SparseModelConfig config) {
+		this.config = config;
+	}
+
+	public SparseModelConfig getConfig() {
+		return config;
+	}
+}

--- a/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseEncoderModel.java
+++ b/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseEncoderModel.java
@@ -1,0 +1,122 @@
+package io.zulia.ai.sparse;
+
+import ai.djl.MalformedModelException;
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+import ai.djl.inference.Predictor;
+import ai.djl.repository.zoo.Criteria;
+import ai.djl.repository.zoo.ModelNotFoundException;
+import ai.djl.repository.zoo.ZooModel;
+import ai.djl.translate.TranslateException;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.zulia.ai.embedding.HuggingFaceModelDownloader;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SparseEncoderModel implements AutoCloseable {
+
+	private final ZooModel<String, Map<String, Float>> model;
+	private final SparseModelConfig config;
+
+	private SparseEncoderModel(ZooModel<String, Map<String, Float>> model, SparseModelConfig config) {
+		this.model = model;
+		this.config = config;
+	}
+
+	public static SparseEncoderModel load(KnownSparseModel knownModel) throws ModelNotFoundException, MalformedModelException, IOException {
+		return load(knownModel.getConfig());
+	}
+
+	public static SparseEncoderModel load(SparseModelConfig config) throws ModelNotFoundException, MalformedModelException, IOException {
+		Path modelDir = HuggingFaceModelDownloader.downloadModel(config.modelUrl());
+		return loadFromDirectory(modelDir, config);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static SparseEncoderModel loadFromDirectory(Path modelDir, SparseModelConfig config)
+			throws ModelNotFoundException, MalformedModelException, IOException {
+		HuggingFaceTokenizer tokenizer = HuggingFaceTokenizer.newInstance(modelDir);
+		String[] vocabulary = loadVocabulary(modelDir);
+
+		boolean includeTokenTypes = config.includeTokenTypes() != null ? config.includeTokenTypes()
+				: detectIncludeTokenTypes(modelDir);
+
+		var translator = new SparseTranslator(tokenizer, vocabulary, config.weightThreshold(), config.maxTerms(),
+				includeTokenTypes);
+
+		Criteria<String, Map<String, Float>> criteria = Criteria.builder()
+				.setTypes(String.class, (Class<Map<String, Float>>) (Class<?>) Map.class)
+				.optModelPath(modelDir)
+				.optEngine("OnnxRuntime")
+				.optTranslator(translator)
+				.build();
+
+		ZooModel<String, Map<String, Float>> model = criteria.loadModel();
+		return new SparseEncoderModel(model, config);
+	}
+
+	public Map<String, Float> encode(String text) throws TranslateException {
+		try (Predictor<String, Map<String, Float>> predictor = model.newPredictor()) {
+			return predictor.predict(text);
+		}
+	}
+
+	public List<Map<String, Float>> batchEncode(List<String> texts) throws TranslateException {
+		var results = new ArrayList<Map<String, Float>>(texts.size());
+		try (Predictor<String, Map<String, Float>> predictor = model.newPredictor()) {
+			for (String text : texts) {
+				results.add(predictor.predict(text));
+			}
+		}
+		return results;
+	}
+
+	public SparseModelConfig getConfig() {
+		return config;
+	}
+
+	@Override
+	public void close() {
+		model.close();
+	}
+
+	private static boolean detectIncludeTokenTypes(Path modelDir) throws IOException {
+		Path configPath = modelDir.resolve("config.json");
+		if (!Files.exists(configPath)) {
+			return true;
+		}
+		try (Reader reader = Files.newBufferedReader(configPath)) {
+			JsonObject config = JsonParser.parseReader(reader).getAsJsonObject();
+			if (config.has("model_type")) {
+				String modelType = config.get("model_type").getAsString();
+				return !Set.of("distilbert", "roberta", "xlnet").contains(modelType);
+			}
+		}
+		return true;
+	}
+
+	private static String[] loadVocabulary(Path modelDir) throws IOException {
+		Path tokenizerPath = modelDir.resolve("tokenizer.json");
+		try (Reader reader = Files.newBufferedReader(tokenizerPath)) {
+			JsonObject root = JsonParser.parseReader(reader).getAsJsonObject();
+			JsonObject vocab = root.getAsJsonObject("model").getAsJsonObject("vocab");
+
+			String[] vocabulary = new String[vocab.size()];
+			for (Map.Entry<String, JsonElement> entry : vocab.entrySet()) {
+				int id = entry.getValue().getAsInt();
+				if (id >= 0 && id < vocabulary.length) {
+					vocabulary[id] = entry.getKey();
+				}
+			}
+			return vocabulary;
+		}
+	}
+}

--- a/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseModelConfig.java
+++ b/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseModelConfig.java
@@ -1,0 +1,39 @@
+package io.zulia.ai.sparse;
+
+public record SparseModelConfig(String modelUrl, float weightThreshold, int maxTerms, Boolean includeTokenTypes) {
+
+	public static Builder builder(String modelUrl) {
+		return new Builder(modelUrl);
+	}
+
+	public static class Builder {
+
+		private final String modelUrl;
+		private float weightThreshold = 0f;
+		private int maxTerms = 256;
+		private Boolean includeTokenTypes;
+
+		private Builder(String modelUrl) {
+			this.modelUrl = modelUrl;
+		}
+
+		public Builder weightThreshold(float weightThreshold) {
+			this.weightThreshold = weightThreshold;
+			return this;
+		}
+
+		public Builder maxTerms(int maxTerms) {
+			this.maxTerms = maxTerms;
+			return this;
+		}
+
+		public Builder includeTokenTypes(boolean includeTokenTypes) {
+			this.includeTokenTypes = includeTokenTypes;
+			return this;
+		}
+
+		public SparseModelConfig build() {
+			return new SparseModelConfig(modelUrl, weightThreshold, maxTerms, includeTokenTypes);
+		}
+	}
+}

--- a/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseTranslator.java
+++ b/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseTranslator.java
@@ -106,7 +106,7 @@ public class SparseTranslator implements Translator<String, Map<String, Float>> 
 		}
 		return result;
 	}
-	
+
 	private static boolean isSpecialToken(String token) {
 		return SPECIAL_TOKENS.contains(token);
 	}

--- a/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseTranslator.java
+++ b/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseTranslator.java
@@ -26,6 +26,13 @@ public class SparseTranslator implements Translator<String, Map<String, Float>> 
 	private final int maxTerms;
 	private final boolean includeTokenTypes;
 
+	static final Set<String> SPECIAL_TOKENS = Set.of(
+			// BERT
+			"[CLS]", "[SEP]", "[PAD]", "[UNK]", "[MASK]",
+			// RoBERTa
+			"<s>", "</s>", "<pad>", "<unk>", "<mask>"
+	);
+
 	SparseTranslator(HuggingFaceTokenizer tokenizer, String[] vocabulary, float weightThreshold, int maxTerms,
 			boolean includeTokenTypes) {
 		this.tokenizer = tokenizer;
@@ -99,14 +106,7 @@ public class SparseTranslator implements Translator<String, Map<String, Float>> 
 		}
 		return result;
 	}
-
-	private static final Set<String> SPECIAL_TOKENS = Set.of(
-			// BERT
-			"[CLS]", "[SEP]", "[PAD]", "[UNK]", "[MASK]",
-			// RoBERTa
-			"<s>", "</s>", "<pad>", "<unk>", "<mask>"
-	);
-
+	
 	private static boolean isSpecialToken(String token) {
 		return SPECIAL_TOKENS.contains(token);
 	}

--- a/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseTranslator.java
+++ b/zulia-ai/src/main/java/io/zulia/ai/sparse/SparseTranslator.java
@@ -1,0 +1,113 @@
+package io.zulia.ai.sparse;
+
+import ai.djl.huggingface.tokenizers.Encoding;
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer;
+import ai.djl.ndarray.NDArray;
+import ai.djl.ndarray.NDList;
+import ai.djl.ndarray.NDManager;
+import ai.djl.ndarray.types.DataType;
+import ai.djl.translate.Batchifier;
+import ai.djl.translate.Translator;
+import ai.djl.translate.TranslatorContext;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class SparseTranslator implements Translator<String, Map<String, Float>> {
+
+	private static final String ATTENTION_MASK_KEY = "attention_mask";
+
+	private final HuggingFaceTokenizer tokenizer;
+	private final String[] vocabulary;
+	private final float weightThreshold;
+	private final int maxTerms;
+	private final boolean includeTokenTypes;
+
+	SparseTranslator(HuggingFaceTokenizer tokenizer, String[] vocabulary, float weightThreshold, int maxTerms,
+			boolean includeTokenTypes) {
+		this.tokenizer = tokenizer;
+		this.vocabulary = vocabulary;
+		this.weightThreshold = weightThreshold;
+		this.maxTerms = maxTerms;
+		this.includeTokenTypes = includeTokenTypes;
+	}
+
+	@Override
+	public Batchifier getBatchifier() {
+		return Batchifier.STACK;
+	}
+
+	@Override
+	public NDList processInput(TranslatorContext ctx, String input) {
+		Encoding encoding = tokenizer.encode(input);
+		long[] inputIds = encoding.getIds();
+		long[] attentionMask = encoding.getAttentionMask();
+
+		NDManager manager = ctx.getNDManager();
+		NDArray ids = manager.create(inputIds);          // [seq_len]
+		NDArray mask = manager.create(attentionMask);    // [seq_len]
+
+		ctx.setAttachment(ATTENTION_MASK_KEY, mask);
+
+		if (includeTokenTypes) {
+			NDArray types = manager.zeros(ids.getShape(), DataType.INT64);
+			return new NDList(ids, mask, types);
+		}
+		return new NDList(ids, mask);
+	}
+
+	@Override
+	public Map<String, Float> processOutput(TranslatorContext ctx, NDList list) {
+		NDArray logits = list.getFirst(); // [seq_len, vocab_size]
+		NDArray mask = (NDArray) ctx.getAttachment(ATTENTION_MASK_KEY); // [seq_len]
+
+		// Sparse activation: log(1 + ReLU(logits)) * attention_mask, max-pooled over sequence
+		try (NDManager scope = ctx.getNDManager().newSubManager()) {
+			NDArray relu = logits.clip(0, Float.MAX_VALUE);
+			NDArray activated = relu.add(1).log();
+			NDArray expandedMask = mask.expandDims(1).toType(DataType.FLOAT32, false); // [seq_len, 1]
+			NDArray masked = activated.mul(expandedMask);
+			NDArray sparse = masked.max(new int[] { 0 }); // [vocab_size]
+
+			float[] weights = sparse.toFloatArray();
+			return buildSparseMap(weights);
+		}
+	}
+
+	private Map<String, Float> buildSparseMap(float[] weights) {
+		record TokenWeight(String token, float weight) {
+		}
+
+		List<TokenWeight> candidates = new ArrayList<>();
+		int limit = Math.min(weights.length, vocabulary.length);
+
+		for (int i = 0; i < limit; i++) {
+			if (weights[i] > weightThreshold && vocabulary[i] != null && !isSpecialToken(vocabulary[i])) {
+				candidates.add(new TokenWeight(vocabulary[i], weights[i]));
+			}
+		}
+
+		candidates.sort((a, b) -> Float.compare(b.weight(), a.weight()));
+
+		var result = new LinkedHashMap<String, Float>();
+		int count = Math.min(candidates.size(), maxTerms);
+		for (int i = 0; i < count; i++) {
+			result.put(candidates.get(i).token(), candidates.get(i).weight());
+		}
+		return result;
+	}
+
+	private static final Set<String> SPECIAL_TOKENS = Set.of(
+			// BERT
+			"[CLS]", "[SEP]", "[PAD]", "[UNK]", "[MASK]",
+			// RoBERTa
+			"<s>", "</s>", "<pad>", "<unk>", "<mask>"
+	);
+
+	private static boolean isSpecialToken(String token) {
+		return SPECIAL_TOKENS.contains(token);
+	}
+}

--- a/zulia-ai/src/test/java/io/zulia/ai/sparse/SparseEncoderModelTest.java
+++ b/zulia-ai/src/test/java/io/zulia/ai/sparse/SparseEncoderModelTest.java
@@ -1,14 +1,10 @@
 package io.zulia.ai.sparse;
 
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -17,14 +13,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class SparseEncoderModelTest {
 
-	private static final String MODEL_DIR_ENV = "SPARSE_MODEL_DIR";
-
-	@Test
-	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
-	void testEncode() throws Exception {
-		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
-		var config = SparseModelConfig.builder("unused").build();
-		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+	@ParameterizedTest
+	@EnumSource(KnownSparseModel.class)
+	void testEncode(KnownSparseModel knownModel) throws Exception {
+		try (var model = SparseEncoderModel.load(knownModel)) {
 			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
 			assertNotNull(sparse);
 			assertFalse(sparse.isEmpty(), "sparse representation should not be empty");
@@ -32,34 +24,34 @@ class SparseEncoderModelTest {
 		}
 	}
 
-	@Test
-	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
-	void testTermExpansion() throws Exception {
-		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
-		var config = SparseModelConfig.builder("unused").build();
-		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+	@ParameterizedTest
+	@EnumSource(KnownSparseModel.class)
+	void testTermExpansion(KnownSparseModel knownModel) throws Exception {
+		try (var model = SparseEncoderModel.load(knownModel)) {
 			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
 			assertTrue(sparse.size() > 3, "sparse representation should contain expanded terms beyond the input tokens");
 		}
 	}
 
-	@Test
-	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
-	void testMaxTermsCapped() throws Exception {
-		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
-		var config = SparseModelConfig.builder("unused").maxTerms(50).build();
-		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+	@ParameterizedTest
+	@EnumSource(KnownSparseModel.class)
+	void testMaxTermsCapped(KnownSparseModel knownModel) throws Exception {
+		var knownConfig = knownModel.getConfig();
+		var builder = SparseModelConfig.builder(knownConfig.modelUrl()).maxTerms(50);
+		if (knownConfig.includeTokenTypes() != null) {
+			builder.includeTokenTypes(knownConfig.includeTokenTypes());
+		}
+		var config = builder.build();
+		try (var model = SparseEncoderModel.load(config)) {
 			Map<String, Float> sparse = model.encode("lung cancer immunotherapy treatment options and clinical trial results");
 			assertTrue(sparse.size() <= 50, "sparse representation should not exceed maxTerms (50), got %d".formatted(sparse.size()));
 		}
 	}
 
-	@Test
-	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
-	void testWeightsDescending() throws Exception {
-		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
-		var config = SparseModelConfig.builder("unused").build();
-		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+	@ParameterizedTest
+	@EnumSource(KnownSparseModel.class)
+	void testWeightsDescending(KnownSparseModel knownModel) throws Exception {
+		try (var model = SparseEncoderModel.load(knownModel)) {
 			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
 			float previous = Float.MAX_VALUE;
 			for (float weight : sparse.values()) {
@@ -69,12 +61,10 @@ class SparseEncoderModelTest {
 		}
 	}
 
-	@Test
-	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
-	void testBatchEncode() throws Exception {
-		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
-		var config = SparseModelConfig.builder("unused").build();
-		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+	@ParameterizedTest
+	@EnumSource(KnownSparseModel.class)
+	void testBatchEncode(KnownSparseModel knownModel) throws Exception {
+		try (var model = SparseEncoderModel.load(knownModel)) {
 			List<String> texts = List.of("lung cancer", "breast cancer", "heart disease");
 			List<Map<String, Float>> results = model.batchEncode(texts);
 			assertEquals(3, results.size());
@@ -84,32 +74,15 @@ class SparseEncoderModelTest {
 		}
 	}
 
-	private static final Set<String> SPECIAL_TOKENS = Set.of(
-			"[CLS]", "[SEP]", "[PAD]", "[UNK]", "[MASK]",
-			"<s>", "</s>", "<pad>", "<unk>", "<mask>"
-	);
-
-	@Test
-	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
-	void testNoSpecialTokens() throws Exception {
-		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
-		var config = SparseModelConfig.builder("unused").build();
-		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
-			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
-			for (String token : sparse.keySet()) {
-				assertFalse(SPECIAL_TOKENS.contains(token),
-						"special token should not appear in output: " + token);
-			}
-		}
-	}
-
 	@ParameterizedTest
 	@EnumSource(KnownSparseModel.class)
-	void testKnownModelEncode(KnownSparseModel knownModel) throws Exception {
+	void testNoSpecialTokens(KnownSparseModel knownModel) throws Exception {
 		try (var model = SparseEncoderModel.load(knownModel)) {
 			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
-			assertNotNull(sparse);
-			assertFalse(sparse.isEmpty());
+			for (String token : sparse.keySet()) {
+				assertFalse(SparseTranslator.SPECIAL_TOKENS.contains(token),
+						"special token should not appear in output: " + token);
+			}
 		}
 	}
 }

--- a/zulia-ai/src/test/java/io/zulia/ai/sparse/SparseEncoderModelTest.java
+++ b/zulia-ai/src/test/java/io/zulia/ai/sparse/SparseEncoderModelTest.java
@@ -1,0 +1,115 @@
+package io.zulia.ai.sparse;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SparseEncoderModelTest {
+
+	private static final String MODEL_DIR_ENV = "SPARSE_MODEL_DIR";
+
+	@Test
+	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
+	void testEncode() throws Exception {
+		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
+		var config = SparseModelConfig.builder("unused").build();
+		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
+			assertNotNull(sparse);
+			assertFalse(sparse.isEmpty(), "sparse representation should not be empty");
+			sparse.values().forEach(weight -> assertTrue(weight > 0, "all weights should be positive"));
+		}
+	}
+
+	@Test
+	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
+	void testTermExpansion() throws Exception {
+		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
+		var config = SparseModelConfig.builder("unused").build();
+		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
+			assertTrue(sparse.size() > 3, "sparse representation should contain expanded terms beyond the input tokens");
+		}
+	}
+
+	@Test
+	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
+	void testMaxTermsCapped() throws Exception {
+		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
+		var config = SparseModelConfig.builder("unused").maxTerms(50).build();
+		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+			Map<String, Float> sparse = model.encode("lung cancer immunotherapy treatment options and clinical trial results");
+			assertTrue(sparse.size() <= 50, "sparse representation should not exceed maxTerms (50), got %d".formatted(sparse.size()));
+		}
+	}
+
+	@Test
+	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
+	void testWeightsDescending() throws Exception {
+		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
+		var config = SparseModelConfig.builder("unused").build();
+		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
+			float previous = Float.MAX_VALUE;
+			for (float weight : sparse.values()) {
+				assertTrue(weight <= previous, "weights should be in descending order");
+				previous = weight;
+			}
+		}
+	}
+
+	@Test
+	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
+	void testBatchEncode() throws Exception {
+		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
+		var config = SparseModelConfig.builder("unused").build();
+		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+			List<String> texts = List.of("lung cancer", "breast cancer", "heart disease");
+			List<Map<String, Float>> results = model.batchEncode(texts);
+			assertEquals(3, results.size());
+			for (Map<String, Float> sparse : results) {
+				assertFalse(sparse.isEmpty());
+			}
+		}
+	}
+
+	private static final Set<String> SPECIAL_TOKENS = Set.of(
+			"[CLS]", "[SEP]", "[PAD]", "[UNK]", "[MASK]",
+			"<s>", "</s>", "<pad>", "<unk>", "<mask>"
+	);
+
+	@Test
+	@EnabledIfEnvironmentVariable(named = MODEL_DIR_ENV, matches = ".+")
+	void testNoSpecialTokens() throws Exception {
+		Path modelDir = Path.of(System.getenv(MODEL_DIR_ENV));
+		var config = SparseModelConfig.builder("unused").build();
+		try (var model = SparseEncoderModel.loadFromDirectory(modelDir, config)) {
+			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
+			for (String token : sparse.keySet()) {
+				assertFalse(SPECIAL_TOKENS.contains(token),
+						"special token should not appear in output: " + token);
+			}
+		}
+	}
+
+	@ParameterizedTest
+	@EnumSource(KnownSparseModel.class)
+	void testKnownModelEncode(KnownSparseModel knownModel) throws Exception {
+		try (var model = SparseEncoderModel.load(knownModel)) {
+			Map<String, Float> sparse = model.encode("lung cancer immunotherapy");
+			assertNotNull(sparse);
+			assertFalse(sparse.isEmpty());
+		}
+	}
+}


### PR DESCRIPTION
### Add learned sparse encoder support

- Add sparse retrieval model support to zulia-ai, producing token-weight maps for Lucene FeatureField indexing
- Supports BERT, DistilBERT, and RoBERTa architectures with automatic model detection
- Models download from HuggingFace on first use and cache locally
- Three known models included (all Apache 2.0, hosted under zuliaio HuggingFace org):
    - OpenSearch Neural Sparse v1 and v2 Distill
    - IBM Granite 30M Sparse
- Parameterized tests covering all known sparse models