### PR TITLE
Cleanups in Zulia Client

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/command/Fetch.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/Fetch.java
@@ -46,7 +46,7 @@ public class Fetch extends SimpleCommand<FetchRequest, FetchResult> implements S
 		return this;
 	}
 
-	public String getFileFame() {
+	public String getFileName() {
 		return fileName;
 	}
 

--- a/zulia-client/src/main/java/io/zulia/client/command/builder/Search.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/builder/Search.java
@@ -70,8 +70,9 @@ public class Search extends SimpleCommand<QueryRequest, SearchResult> implements
 		return this;
 	}
 
-	public void clearQueries() {
+	public Search clearQueries() {
 		queryRequest.clearQuery();
+		return this;
 	}
 
 	public int getAmount() {
@@ -110,7 +111,7 @@ public class Search extends SimpleCommand<QueryRequest, SearchResult> implements
 		return this;
 	}
 
-	public int setStart() {
+	public int getStart() {
 		return queryRequest.getStart();
 	}
 
@@ -178,8 +179,9 @@ public class Search extends SimpleCommand<QueryRequest, SearchResult> implements
 		return this;
 	}
 
-	public void clearLastResult() {
+	public Search clearLastResult() {
 		queryRequest.clearLastResult();
+		return this;
 	}
 
 	public Search addFieldSimilarity(String field, Similarity similarity) {

--- a/zulia-client/src/main/java/io/zulia/client/config/ZuliaPoolConfig.java
+++ b/zulia-client/src/main/java/io/zulia/client/config/ZuliaPoolConfig.java
@@ -57,7 +57,7 @@ public class ZuliaPoolConfig {
 		return this;
 	}
 
-	public ZuliaPoolConfig clearMembers() {
+	public ZuliaPoolConfig clearNodes() {
 		nodes.clear();
 		return this;
 	}

--- a/zulia-client/src/main/java/io/zulia/client/pool/ConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ConnectionListener.java
@@ -21,4 +21,6 @@ public interface ConnectionListener {
 	<R extends Result> void exceptionWithRetry(ZuliaBase.Node selectedNode, BaseCommand<R> command, Exception e, int tries);
 
 	<R extends Result> void exception(ZuliaBase.Node selectedNode, BaseCommand<R> command, Exception exception);
+
+	void nodeUpdateException(Exception exception);
 }

--- a/zulia-client/src/main/java/io/zulia/client/pool/JULLoggingConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/JULLoggingConnectionListener.java
@@ -59,4 +59,9 @@ public class JULLoggingConnectionListener implements ConnectionListener {
 						+ " with exception: " + exception.getMessage());
 	}
 
+	@Override
+	public void nodeUpdateException(Exception exception) {
+		LOG.log(Level.WARNING, "Failed to update nodes and routing", exception);
+	}
+
 }

--- a/zulia-client/src/main/java/io/zulia/client/pool/NoOpConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/NoOpConnectionListener.java
@@ -45,4 +45,9 @@ public class NoOpConnectionListener implements ConnectionListener {
 
 	}
 
+	@Override
+	public void nodeUpdateException(Exception exception) {
+
+	}
+
 }

--- a/zulia-client/src/main/java/io/zulia/client/pool/Slf4jLoggingConnectionListener.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/Slf4jLoggingConnectionListener.java
@@ -56,4 +56,9 @@ public class Slf4jLoggingConnectionListener implements ConnectionListener {
 				selectedNode.getServicePort(), exception.getMessage());
 	}
 
+	@Override
+	public void nodeUpdateException(Exception exception) {
+		LOG.warn("Failed to update nodes and routing", exception);
+	}
+
 }

--- a/zulia-client/src/main/java/io/zulia/client/pool/ZuliaPool.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ZuliaPool.java
@@ -23,40 +23,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static io.zulia.message.ZuliaBase.Node;
 import static io.zulia.message.ZuliaIndex.IndexShardMapping;
 
 public class ZuliaPool {
 
-	protected class ZuliaNodeUpdateThread extends Thread {
-
-		ZuliaNodeUpdateThread() {
-			setDaemon(true);
-			setName("ZuliaNodeUpdateThread" + hashCode());
-		}
-
-		@Override
-		public void run() {
-			while (!isClosed) {
-				try {
-					try {
-						Thread.sleep(nodeUpdateInterval);
-					}
-					catch (InterruptedException ignored) {
-
-					}
-					if (!isClosed) {
-						updateNodesAndRouting();
-					}
-
-				}
-				catch (Throwable ignored) {
-
-				}
-			}
-		}
-	}
+	private static final Logger LOG = Logger.getLogger(ZuliaPool.class.getName());
 
 	private final int retries;
 	private final boolean routingEnabled;
@@ -66,9 +41,9 @@ public class ZuliaPool {
 	private final ConcurrentHashMap<String, ZuliaRESTClient> zuliaRestPoolMap;
 	private final ConcurrentHashMap<String, Node> nodeKeyToNode;
 	private final ConnectionListener connectionListener;
-	private boolean isClosed;
-	private List<Node> nodes;
-	private IndexRouting indexRouting;
+	private volatile boolean isClosed;
+	private volatile List<Node> nodes;
+	private volatile IndexRouting indexRouting;
 
 	public ZuliaPool(final ZuliaPoolConfig zuliaPoolConfig) {
 		nodes = zuliaPoolConfig.getNodes();
@@ -88,8 +63,26 @@ public class ZuliaPool {
 		}
 
 		if (zuliaPoolConfig.isNodeUpdateEnabled()) {
-			ZuliaNodeUpdateThread mut = new ZuliaNodeUpdateThread();
-			mut.start();
+			Thread.ofVirtual().name("ZuliaNodeUpdateThread-" + hashCode()).start(this::nodeUpdateLoop);
+		}
+	}
+
+	private void nodeUpdateLoop() {
+		while (!isClosed) {
+			try {
+				//noinspection BusyWait
+				Thread.sleep(nodeUpdateInterval);
+				if (!isClosed) {
+					updateNodesAndRouting();
+				}
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			}
+			catch (Exception e) {
+				LOG.log(Level.WARNING, "Failed to update nodes and routing", e);
+			}
 		}
 	}
 
@@ -140,22 +133,19 @@ public class ZuliaPool {
 			Node selectedNode = null;
 			try {
 				if (routingEnabled && (indexRouting != null)) {
-					if (command instanceof ShardRoutableCommand) {
-						ShardRoutableCommand rc = (ShardRoutableCommand) command;
+					if (command instanceof ShardRoutableCommand rc) {
 						selectedNode = indexRouting.getNode(rc.getIndexName(), rc.getUniqueId());
 					}
-					else if (command instanceof SingleIndexRoutableCommand) {
-						SingleIndexRoutableCommand sirc = (SingleIndexRoutableCommand) command;
+					else if (command instanceof SingleIndexRoutableCommand sirc) {
 						selectedNode = indexRouting.getRandomNode(sirc.getIndexName());
 					}
-					else if (command instanceof MultiIndexRoutableCommand) {
-						MultiIndexRoutableCommand mirc = (MultiIndexRoutableCommand) command;
+					else if (command instanceof MultiIndexRoutableCommand mirc) {
 						selectedNode = indexRouting.getRandomNode(mirc.getIndexNames());
 					}
 				}
 
 				if (selectedNode == null) {
-					List<Node> tempList = nodes; //stop array index out bounds on updates without locking
+					List<Node> tempList = nodes;
 
 					if (tempList.isEmpty()) {
 						throw new IOException("There are no active nodes");
@@ -206,12 +196,12 @@ public class ZuliaPool {
 
 						Metadata trailers = e.getTrailers();
 						if (trailers != null && trailers.containsKey(MetaKeys.ERROR_KEY)) {
-							String errorMessage = trailers.get(MetaKeys.ERROR_KEY);
-							if (!Status.INVALID_ARGUMENT.equals(e.getStatus())) {
-								throw new Exception(grpcCommand.getClass().getSimpleName() + ": " + errorMessage);
+							String errorMessage = grpcCommand.getClass().getSimpleName() + ": " + trailers.get(MetaKeys.ERROR_KEY);
+							if (Status.INVALID_ARGUMENT.equals(e.getStatus())) {
+								throw new IllegalArgumentException(errorMessage);
 							}
 							else {
-								throw new IllegalArgumentException(grpcCommand.getClass().getSimpleName() + ": " + errorMessage);
+								throw new Exception(errorMessage);
 							}
 						}
 						else {
@@ -223,11 +213,15 @@ public class ZuliaPool {
 			}
 			catch (Exception e) {
 				if (tries >= retries) {
-					connectionListener.exception(selectedNode, command, e);
+					if (connectionListener != null) {
+						connectionListener.exception(selectedNode, command, e);
+					}
 					throw e;
 				}
 				tries++;
-				connectionListener.exceptionWithRetry(selectedNode, command, e, tries);
+				if (connectionListener != null) {
+					connectionListener.exceptionWithRetry(selectedNode, command, e, tries);
+				}
 			}
 		}
 

--- a/zulia-client/src/main/java/io/zulia/client/pool/ZuliaPool.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ZuliaPool.java
@@ -23,15 +23,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import static io.zulia.message.ZuliaBase.Node;
 import static io.zulia.message.ZuliaIndex.IndexShardMapping;
 
 public class ZuliaPool {
-
-	private static final Logger LOG = Logger.getLogger(ZuliaPool.class.getName());
 
 	private final int retries;
 	private final boolean routingEnabled;
@@ -81,7 +77,9 @@ public class ZuliaPool {
 				return;
 			}
 			catch (Exception e) {
-				LOG.log(Level.WARNING, "Failed to update nodes and routing", e);
+				if (connectionListener != null) {
+					connectionListener.nodeUpdateException(e);
+				}
 			}
 		}
 	}

--- a/zulia-client/src/test/java/io/zulia/client/pool/IndexRoutingTest.java
+++ b/zulia-client/src/test/java/io/zulia/client/pool/IndexRoutingTest.java
@@ -1,0 +1,141 @@
+package io.zulia.client.pool;
+
+import io.zulia.message.ZuliaBase.Node;
+import io.zulia.message.ZuliaIndex.IndexAlias;
+import io.zulia.message.ZuliaIndex.IndexShardMapping;
+import io.zulia.message.ZuliaIndex.ShardMapping;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IndexRoutingTest {
+
+	private Node nodeA;
+	private Node nodeB;
+	private IndexRouting routing;
+
+	@BeforeEach
+	void setUp() {
+		nodeA = Node.newBuilder().setServerAddress("hostA").setServicePort(32191).setRestPort(32192).build();
+		nodeB = Node.newBuilder().setServerAddress("hostB").setServicePort(32191).setRestPort(32192).build();
+
+		var shardMapping = IndexShardMapping.newBuilder()
+				.setIndexName("testIndex")
+				.setNumberOfShards(2)
+				.addShardMapping(ShardMapping.newBuilder().setShardNumber(0).setPrimaryNode(nodeA))
+				.addShardMapping(ShardMapping.newBuilder().setShardNumber(1).setPrimaryNode(nodeB))
+				.build();
+
+		var alias = IndexAlias.newBuilder().setAliasName("testAlias").setIndexName("testIndex").build();
+
+		routing = new IndexRouting(List.of(shardMapping), List.of(alias));
+	}
+
+	@Test
+	void getNodeRoutesConsistently() {
+		var node1 = routing.getNode("testIndex", "doc1");
+		var node2 = routing.getNode("testIndex", "doc1");
+		assertNotNull(node1);
+		assertSame(node1, node2, "Same uniqueId should always route to the same node");
+	}
+
+	@Test
+	void getNodeDistributesAcrossShards() {
+		Set<String> nodesHit = new HashSet<>();
+		for (int i = 0; i < 100; i++) {
+			var node = routing.getNode("testIndex", "doc-" + i);
+			assertNotNull(node);
+			nodesHit.add(node.getServerAddress());
+		}
+		assertEquals(2, nodesHit.size(), "Documents should be distributed across both nodes");
+	}
+
+	@Test
+	void getNodeReturnsNullForUnknownIndex() {
+		assertNull(routing.getNode("unknownIndex", "doc1"));
+	}
+
+	@Test
+	void aliasResolvesToIndex() {
+		var viaIndex = routing.getNode("testIndex", "doc1");
+		var viaAlias = routing.getNode("testAlias", "doc1");
+		assertNotNull(viaIndex);
+		assertEquals(viaIndex, viaAlias, "Alias should resolve to the same node as the real index");
+	}
+
+	@Test
+	void getRandomNodeReturnsNodeForKnownIndex() {
+		var node = routing.getRandomNode("testIndex");
+		assertNotNull(node);
+		assertTrue(node.equals(nodeA) || node.equals(nodeB));
+	}
+
+	@Test
+	void getRandomNodeReturnsNullForUnknownIndex() {
+		assertNull(routing.getRandomNode("unknownIndex"));
+	}
+
+	@Test
+	void getRandomNodeForMultipleIndexes() {
+		var shardMapping2 = IndexShardMapping.newBuilder()
+				.setIndexName("otherIndex")
+				.setNumberOfShards(1)
+				.addShardMapping(ShardMapping.newBuilder().setShardNumber(0).setPrimaryNode(nodeB))
+				.build();
+
+		var multiRouting = new IndexRouting(
+				List.of(
+						IndexShardMapping.newBuilder()
+								.setIndexName("testIndex")
+								.setNumberOfShards(1)
+								.addShardMapping(ShardMapping.newBuilder().setShardNumber(0).setPrimaryNode(nodeA))
+								.build(),
+						shardMapping2
+				),
+				List.of()
+		);
+
+		Set<String> nodesHit = new HashSet<>();
+		for (int i = 0; i < 100; i++) {
+			var node = multiRouting.getRandomNode(List.of("testIndex", "otherIndex"));
+			assertNotNull(node);
+			nodesHit.add(node.getServerAddress());
+		}
+		assertEquals(2, nodesHit.size(), "Should pick from nodes hosting either index");
+	}
+
+	@Test
+	void getRandomNodeForMultipleIndexesReturnsNullWhenOneUnknown() {
+		// When any index in the collection is unknown, routing gives up entirely
+		// and returns null, which causes ZuliaPool to fall back to random node selection.
+		// The server still handles multi-index resolution correctly.
+		assertNull(routing.getRandomNode(List.of("testIndex", "unknownIndex")));
+	}
+
+	@Test
+	void aliasWorksWithGetRandomNode() {
+		var node = routing.getRandomNode("testAlias");
+		assertNotNull(node);
+		assertTrue(node.equals(nodeA) || node.equals(nodeB));
+	}
+
+	@Test
+	void singleShardAlwaysRoutesToSameNode() {
+		var singleShard = IndexShardMapping.newBuilder()
+				.setIndexName("singleIndex")
+				.setNumberOfShards(1)
+				.addShardMapping(ShardMapping.newBuilder().setShardNumber(0).setPrimaryNode(nodeA))
+				.build();
+
+		var singleRouting = new IndexRouting(List.of(singleShard), List.of());
+
+		for (int i = 0; i < 50; i++) {
+			assertEquals(nodeA, singleRouting.getNode("singleIndex", "doc-" + i));
+		}
+	}
+}

--- a/zulia-client/src/test/java/io/zulia/client/pool/ZuliaPoolTest.java
+++ b/zulia-client/src/test/java/io/zulia/client/pool/ZuliaPoolTest.java
@@ -1,0 +1,363 @@
+package io.zulia.client.pool;
+
+import io.zulia.client.command.base.BaseCommand;
+import io.zulia.client.command.base.GrpcCommand;
+import io.zulia.client.config.ZuliaPoolConfig;
+import io.zulia.client.pool.stub.StubGrpcCommand;
+import io.zulia.client.pool.stub.StubMultiIndexCommand;
+import io.zulia.client.pool.stub.StubResult;
+import io.zulia.client.pool.stub.StubShardCommand;
+import io.zulia.client.pool.stub.StubSingleIndexCommand;
+import io.zulia.client.result.Result;
+import io.zulia.message.ZuliaBase.Node;
+import io.zulia.message.ZuliaIndex.IndexShardMapping;
+import io.zulia.message.ZuliaIndex.ShardMapping;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ZuliaPoolTest {
+
+	private ZuliaPool pool;
+
+	@AfterEach
+	void tearDown() {
+		if (pool != null) {
+			pool.close();
+		}
+	}
+
+	private Node makeNode(String host, int port) {
+		return Node.newBuilder().setServerAddress(host).setServicePort(port).setRestPort(port + 1).build();
+	}
+
+	private ZuliaPoolConfig configWithNodes(Node... nodes) {
+		var config = new ZuliaPoolConfig();
+		config.setNodeUpdateEnabled(false);
+		config.setRoutingEnabled(false);
+		config.setConnectionListener(null);
+		for (var node : nodes) {
+			config.addNode(node);
+		}
+		return config;
+	}
+
+	// Random node fallback 
+
+	@Test
+	void executePicksRandomNodeWhenRoutingDisabled() throws Exception {
+		var node = makeNode("localhost", 32191);
+		var config = configWithNodes(node);
+		pool = new ZuliaPool(config);
+
+		var result = pool.execute(new StubGrpcCommand());
+		assertEquals("localhost", result.getNodeAddress());
+	}
+
+	@Test
+	void executeThrowsWhenNoNodes() {
+		var config = configWithNodes();
+		pool = new ZuliaPool(config);
+
+		assertThrows(IOException.class, () -> pool.execute(new StubGrpcCommand()));
+	}
+
+	// Routing dispatch 
+
+	@Test
+	void shardRoutableCommandRoutesToCorrectNode() throws Exception {
+		var nodeA = makeNode("hostA", 32191);
+		var nodeB = makeNode("hostB", 32191);
+
+		var config = new ZuliaPoolConfig();
+		config.setNodeUpdateEnabled(false);
+		config.setRoutingEnabled(true);
+		config.setConnectionListener(null);
+		config.addNode(nodeA);
+		config.addNode(nodeB);
+		pool = new ZuliaPool(config);
+
+		var shardMapping = IndexShardMapping.newBuilder()
+				.setIndexName("myIndex")
+				.setNumberOfShards(2)
+				.addShardMapping(ShardMapping.newBuilder().setShardNumber(0).setPrimaryNode(nodeA))
+				.addShardMapping(ShardMapping.newBuilder().setShardNumber(1).setPrimaryNode(nodeB))
+				.build();
+		pool.updateIndexMappings(List.of(shardMapping), List.of());
+
+		// Same uniqueId should always route to the same node
+		var cmd = new StubShardCommand("myIndex", "doc-42");
+		var result1 = pool.execute(cmd);
+		var result2 = pool.execute(cmd);
+		assertEquals(result1.getNodeAddress(), result2.getNodeAddress());
+	}
+
+	@Test
+	void singleIndexRoutableCommandRoutesToIndexNode() throws Exception {
+		var nodeA = makeNode("hostA", 32191);
+
+		var config = new ZuliaPoolConfig();
+		config.setNodeUpdateEnabled(false);
+		config.setRoutingEnabled(true);
+		config.setConnectionListener(null);
+		config.addNode(nodeA);
+		pool = new ZuliaPool(config);
+
+		var shardMapping = IndexShardMapping.newBuilder()
+				.setIndexName("myIndex")
+				.setNumberOfShards(1)
+				.addShardMapping(ShardMapping.newBuilder().setShardNumber(0).setPrimaryNode(nodeA))
+				.build();
+		pool.updateIndexMappings(List.of(shardMapping), List.of());
+
+		var result = pool.execute(new StubSingleIndexCommand("myIndex"));
+		assertEquals("hostA", result.getNodeAddress());
+	}
+
+	@Test
+	void multiIndexRoutableCommandRoutesAcrossIndexNodes() throws Exception {
+		var nodeA = makeNode("hostA", 32191);
+		var nodeB = makeNode("hostB", 32191);
+		var nodeC = makeNode("hostC", 32191);
+
+		var config = new ZuliaPoolConfig();
+		config.setNodeUpdateEnabled(false);
+		config.setRoutingEnabled(true);
+		config.setConnectionListener(null);
+		config.addNode(nodeA);
+		config.addNode(nodeB);
+		config.addNode(nodeC);
+		pool = new ZuliaPool(config);
+
+		// idx1 is on nodeA, idx2 is on nodeB, nodeC hosts neither
+		var mapping1 = IndexShardMapping.newBuilder()
+				.setIndexName("idx1")
+				.setNumberOfShards(1)
+				.addShardMapping(ShardMapping.newBuilder().setShardNumber(0).setPrimaryNode(nodeA))
+				.build();
+		var mapping2 = IndexShardMapping.newBuilder()
+				.setIndexName("idx2")
+				.setNumberOfShards(1)
+				.addShardMapping(ShardMapping.newBuilder().setShardNumber(0).setPrimaryNode(nodeB))
+				.build();
+		pool.updateIndexMappings(List.of(mapping1, mapping2), List.of());
+
+		// Querying both indexes should only route to nodes hosting those indexes (never nodeC)
+		var hosts = new HashSet<String>();
+		for (int i = 0; i < 100; i++) {
+			var result = pool.execute(new StubMultiIndexCommand(List.of("idx1", "idx2")));
+			hosts.add(result.getNodeAddress());
+		}
+		assertEquals(Set.of("hostA", "hostB"), hosts);
+	}
+
+	@Test
+	void routingFallsBackToRandomWhenIndexUnknown() throws Exception {
+		var nodeA = makeNode("hostA", 32191);
+
+		var config = new ZuliaPoolConfig();
+		config.setNodeUpdateEnabled(false);
+		config.setRoutingEnabled(true);
+		config.setConnectionListener(null);
+		config.addNode(nodeA);
+		pool = new ZuliaPool(config);
+
+		// Routing enabled, but no index mappings loaded should fall back to random
+		var result = pool.execute(new StubSingleIndexCommand("unknownIndex"));
+		assertEquals("hostA", result.getNodeAddress());
+	}
+
+	// Retry logic
+
+	@Test
+	void failingCommandWithZeroRetriesThrowsAfterOneAttempt() {
+		var node = makeNode("localhost", 32191);
+		var config = configWithNodes(node);
+		config.setDefaultRetries(0);
+		pool = new ZuliaPool(config);
+
+		var counter = new AtomicInteger(0);
+		var cmd = new GrpcCommand<StubResult>() {
+			@Override
+			public StubResult execute(ZuliaConnection zuliaConnection) {
+				counter.incrementAndGet();
+				throw new RuntimeException("fail");
+			}
+		};
+
+		assertThrows(RuntimeException.class, () -> pool.execute(cmd));
+		assertEquals(1, counter.get(), "With 0 retries, should try exactly once");
+	}
+
+	@Test
+	void retriesExhaustedThenThrows() {
+		var node = makeNode("localhost", 32191);
+		var config = configWithNodes(node);
+		config.setDefaultRetries(2);
+		pool = new ZuliaPool(config);
+
+		var counter = new AtomicInteger(0);
+		var cmd = new GrpcCommand<StubResult>() {
+			@Override
+			public StubResult execute(ZuliaConnection zuliaConnection) {
+				counter.incrementAndGet();
+				throw new RuntimeException("fail");
+			}
+		};
+
+		assertThrows(RuntimeException.class, () -> pool.execute(cmd));
+		// Initial try + 2 retries = 3 total attempts
+		assertEquals(3, counter.get());
+	}
+
+	@Test
+	void retrySucceedsOnSecondAttempt() throws Exception {
+		var node = makeNode("localhost", 32191);
+		var config = configWithNodes(node);
+		config.setDefaultRetries(1);
+		pool = new ZuliaPool(config);
+
+		var counter = new AtomicInteger(0);
+		var cmd = new GrpcCommand<StubResult>() {
+			@Override
+			public StubResult execute(ZuliaConnection zuliaConnection) {
+				if (counter.incrementAndGet() == 1) {
+					throw new RuntimeException("transient failure");
+				}
+				return new StubResult("localhost");
+			}
+		};
+
+		var result = pool.execute(cmd);
+		assertEquals("localhost", result.getNodeAddress());
+		assertEquals(2, counter.get());
+	}
+
+	// Null connectionListener safety 
+
+	@Test
+	void nullConnectionListenerDoesNotNPEOnError() {
+		var node = makeNode("localhost", 32191);
+		var config = configWithNodes(node);
+		config.setConnectionListener(null);
+		config.setDefaultRetries(0);
+		pool = new ZuliaPool(config);
+
+		assertThrows(RuntimeException.class, () -> pool.execute(new StubGrpcCommand(new RuntimeException("fail"))));
+	}
+
+	@Test
+	void nullConnectionListenerDoesNotNPEOnRetry() {
+		var node = makeNode("localhost", 32191);
+		var config = configWithNodes(node);
+		config.setConnectionListener(null);
+		config.setDefaultRetries(1);
+		pool = new ZuliaPool(config);
+
+		assertThrows(RuntimeException.class, () -> pool.execute(new StubGrpcCommand(new RuntimeException("fail"))));
+	}
+
+	// Connection listener callbacks
+
+	@Test
+	void listenerReceivesExceptionOnFinalFailure() {
+		var node = makeNode("localhost", 32191);
+
+		var capturedCommand = new AtomicReference<BaseCommand<?>>();
+		var capturedEx = new AtomicReference<Exception>();
+		var listener = new NoOpConnectionListener() {
+			@Override
+			public <R extends Result> void exception(Node selectedNode, BaseCommand<R> command, Exception exception) {
+				capturedCommand.set(command);
+				capturedEx.set(exception);
+			}
+		};
+
+		var config = configWithNodes(node);
+		config.setConnectionListener(listener);
+		config.setDefaultRetries(0);
+		pool = new ZuliaPool(config);
+
+		var cmd = new StubGrpcCommand(new RuntimeException("test error"));
+		assertThrows(RuntimeException.class, () -> pool.execute(cmd));
+
+		assertSame(cmd, capturedCommand.get());
+		assertEquals("test error", capturedEx.get().getMessage());
+	}
+
+	@Test
+	void listenerReceivesRetryCallbacks() {
+		var node = makeNode("localhost", 32191);
+		var retryCount = new AtomicInteger(0);
+		var listener = new NoOpConnectionListener() {
+			@Override
+			public <R extends Result> void exceptionWithRetry(Node selectedNode, BaseCommand<R> command, Exception e, int tries) {
+				retryCount.set(tries);
+			}
+		};
+
+		var config = configWithNodes(node);
+		config.setConnectionListener(listener);
+		config.setDefaultRetries(2);
+		pool = new ZuliaPool(config);
+
+		assertThrows(RuntimeException.class, () -> pool.execute(new StubGrpcCommand(new RuntimeException("fail"))));
+		assertEquals(2, retryCount.get());
+	}
+
+	// Node updates 
+
+	@Test
+	void updateNodesRemovesStaleFallbackNodes() throws Exception {
+		var nodeA = makeNode("hostA", 32191);
+		var nodeB = makeNode("hostB", 32191);
+
+		var config = configWithNodes(nodeA, nodeB);
+		pool = new ZuliaPool(config);
+
+		// Remove nodeA, keep only nodeB
+		pool.updateNodes(List.of(nodeB));
+
+		// All executions should now go to nodeB
+		for (int i = 0; i < 20; i++) {
+			var result = pool.execute(new StubGrpcCommand());
+			assertEquals("hostB", result.getNodeAddress());
+		}
+	}
+
+	@Test
+	void updateNodesAddsNewNodes() throws Exception {
+		var nodeA = makeNode("hostA", 32191);
+		var config = configWithNodes(nodeA);
+		pool = new ZuliaPool(config);
+
+		// Add nodeB
+		var nodeB = makeNode("hostB", 32191);
+		pool.updateNodes(List.of(nodeA, nodeB));
+
+		var hosts = new HashSet<String>();
+		for (int i = 0; i < 100; i++) {
+			var result = pool.execute(new StubGrpcCommand());
+			hosts.add(result.getNodeAddress());
+		}
+		assertEquals(2, hosts.size());
+	}
+
+	// Close 
+
+	@Test
+	void closeIsIdempotent() {
+		var node = makeNode("localhost", 32191);
+		pool = new ZuliaPool(configWithNodes(node));
+		pool.close();
+		pool.close(); // should not throw
+	}
+}

--- a/zulia-client/src/test/java/io/zulia/client/pool/stub/StubGrpcCommand.java
+++ b/zulia-client/src/test/java/io/zulia/client/pool/stub/StubGrpcCommand.java
@@ -1,0 +1,24 @@
+package io.zulia.client.pool.stub;
+
+import io.zulia.client.command.base.GrpcCommand;
+import io.zulia.client.pool.ZuliaConnection;
+
+public class StubGrpcCommand extends GrpcCommand<StubResult> {
+	private final RuntimeException errorToThrow;
+
+	public StubGrpcCommand() {
+		this.errorToThrow = null;
+	}
+
+	public StubGrpcCommand(RuntimeException errorToThrow) {
+		this.errorToThrow = errorToThrow;
+	}
+
+	@Override
+	public StubResult execute(ZuliaConnection zuliaConnection) {
+		if (errorToThrow != null) {
+			throw errorToThrow;
+		}
+		return new StubResult(zuliaConnection.getNode().getServerAddress());
+	}
+}

--- a/zulia-client/src/test/java/io/zulia/client/pool/stub/StubMultiIndexCommand.java
+++ b/zulia-client/src/test/java/io/zulia/client/pool/stub/StubMultiIndexCommand.java
@@ -1,0 +1,19 @@
+package io.zulia.client.pool.stub;
+
+import io.zulia.client.command.base.MultiIndexRoutableCommand;
+
+import java.util.Collection;
+import java.util.List;
+
+public class StubMultiIndexCommand extends StubGrpcCommand implements MultiIndexRoutableCommand {
+	private final List<String> indexNames;
+
+	public StubMultiIndexCommand(List<String> indexNames) {
+		this.indexNames = indexNames;
+	}
+
+	@Override
+	public Collection<String> getIndexNames() {
+		return indexNames;
+	}
+}

--- a/zulia-client/src/test/java/io/zulia/client/pool/stub/StubResult.java
+++ b/zulia-client/src/test/java/io/zulia/client/pool/stub/StubResult.java
@@ -1,0 +1,15 @@
+package io.zulia.client.pool.stub;
+
+import io.zulia.client.result.Result;
+
+public class StubResult extends Result {
+	private final String nodeAddress;
+
+	public StubResult(String nodeAddress) {
+		this.nodeAddress = nodeAddress;
+	}
+
+	public String getNodeAddress() {
+		return nodeAddress;
+	}
+}

--- a/zulia-client/src/test/java/io/zulia/client/pool/stub/StubShardCommand.java
+++ b/zulia-client/src/test/java/io/zulia/client/pool/stub/StubShardCommand.java
@@ -1,0 +1,23 @@
+package io.zulia.client.pool.stub;
+
+import io.zulia.client.command.base.ShardRoutableCommand;
+
+public class StubShardCommand extends StubGrpcCommand implements ShardRoutableCommand {
+	private final String indexName;
+	private final String uniqueId;
+
+	public StubShardCommand(String indexName, String uniqueId) {
+		this.indexName = indexName;
+		this.uniqueId = uniqueId;
+	}
+
+	@Override
+	public String getUniqueId() {
+		return uniqueId;
+	}
+
+	@Override
+	public String getIndexName() {
+		return indexName;
+	}
+}

--- a/zulia-client/src/test/java/io/zulia/client/pool/stub/StubSingleIndexCommand.java
+++ b/zulia-client/src/test/java/io/zulia/client/pool/stub/StubSingleIndexCommand.java
@@ -1,0 +1,16 @@
+package io.zulia.client.pool.stub;
+
+import io.zulia.client.command.base.SingleIndexRoutableCommand;
+
+public class StubSingleIndexCommand extends StubGrpcCommand implements SingleIndexRoutableCommand {
+	private final String indexName;
+
+	public StubSingleIndexCommand(String indexName) {
+		this.indexName = indexName;
+	}
+
+	@Override
+	public String getIndexName() {
+		return indexName;
+	}
+}

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/zuliaadmin/DisplayIndexCmd.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/zuliaadmin/DisplayIndexCmd.java
@@ -30,7 +30,7 @@ public class DisplayIndexCmd implements Callable<Integer> {
 	@CommandLine.Mixin
 	private MultipleIndexArgs multipleIndexArgs;
 
-	@CommandLine.Option(names = "--view", description = "Valid values: ${COMPLETION-CANDIDATES}")
+	@CommandLine.Option(names = "--view", required = true, description = "Valid values: ${COMPLETION-CANDIDATES}")
 	public IndexSettings view;
 
 	@Override


### PR DESCRIPTION

* Fix `Fetch.getFileFame()` typo, renamed to `getFileName()`
* Fix `Search.setStart()` renamed to `getStart()` (was a getter with setter naming)
* Make `Search.clearQueries()` and `clearLastResult()` return `Search` for fluent API consistency
* Rename `ZuliaPoolConfig.clearMembers()` to `clearNodes()` for consistent naming
* Fix potential NPE on `connectionListener` in `ZuliaPool.execute()` retry/error path
* Add `volatile` to `isClosed`, `nodes`, and `indexRouting` fields for cross-thread visibility
* Replace `ZuliaNodeUpdateThread` inner class with a virtual thread
* Log node update failures instead of silently swallowing all `Throwable`
* Restore interrupt flag on `InterruptedException` in node update loop
* Use pattern matching `instanceof` in `ZuliaPool.execute()` routing dispatch
* Add `ConnectionListener.nodeUpdateException()` so logging of node update failures can be configured per listener
* Implement `nodeUpdateException` in `NoOpConnectionListener` (no-op), `Slf4jLoggingConnectionListener` (warn), and `JULLoggingConnectionListener` (WARNING)
* `ZuliaPool` delegates node update failures to the connection listener instead of a direct JUL logger

* Add `IndexRoutingTest` covering consistent shard routing, distribution, alias resolution, random node selection, and multi-index routing
* Add `ZuliaPoolTest` covering random node fallback, routing dispatch for all command types, retry logic, null-listener safety, listener callbacks, node updates, and close idempotency
