### PR TITLE
Support wildcard index patterns in query requests

### DIFF
--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
@@ -390,12 +390,58 @@ public class ZuliaIndexManager {
 
 		for (String indexName : queryRequest.getIndexList()) {
 
-			ZuliaIndex index = getIndexFromName(indexName);
-			indexes.add(index);
+			if (isWildcardPattern(indexName)) {
+				List<String> matches = expandWildcard(indexName);
+				if (matches.isEmpty()) {
+					throw new IndexDoesNotExistException(indexName);
+				}
+				for (String matched : matches) {
+					ZuliaIndex index = indexMap.get(matched);
+					indexes.add(index);
 
-			Query query = index.getQuery(queryRequest);
-			queryMap.put(handleAlias(indexName), query);
+					Query query = index.getQuery(queryRequest);
+					queryMap.put(matched, query);
+				}
+			}
+			else {
+				ZuliaIndex index = getIndexFromName(indexName);
+				indexes.add(index);
+
+				Query query = index.getQuery(queryRequest);
+				queryMap.put(handleAlias(indexName), query);
+			}
 		}
+	}
+
+	private static boolean isWildcardPattern(String indexName) {
+		return indexName.indexOf('*') >= 0 || indexName.indexOf('?') >= 0;
+	}
+
+	private List<String> expandWildcard(String pattern) {
+		java.util.regex.Pattern regex = globToRegex(pattern);
+		List<String> matches = new ArrayList<>();
+		for (String existingName : indexMap.keySet()) {
+			if (regex.matcher(existingName).matches()) {
+				matches.add(existingName);
+			}
+		}
+		return matches;
+	}
+
+	private static java.util.regex.Pattern globToRegex(String glob) {
+		StringBuilder sb = new StringBuilder(glob.length() + 4);
+		sb.append('^');
+		for (int i = 0; i < glob.length(); i++) {
+			char c = glob.charAt(i);
+			switch (c) {
+				case '*' -> sb.append(".*");
+				case '?' -> sb.append('.');
+				case '.', '\\', '+', '(', ')', '[', ']', '{', '}', '^', '$', '|' -> sb.append('\\').append(c);
+				default -> sb.append(c);
+			}
+		}
+		sb.append('$');
+		return java.util.regex.Pattern.compile(sb.toString());
 	}
 
 	public StoreResponse store(StoreRequest request) throws Exception {

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
@@ -83,6 +83,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -418,7 +419,7 @@ public class ZuliaIndexManager {
 	}
 
 	private List<String> expandWildcard(String pattern) {
-		java.util.regex.Pattern regex = globToRegex(pattern);
+		Pattern regex = globToRegex(pattern);
 		List<String> matches = new ArrayList<>();
 		for (String existingName : indexMap.keySet()) {
 			if (regex.matcher(existingName).matches()) {
@@ -428,7 +429,7 @@ public class ZuliaIndexManager {
 		return matches;
 	}
 
-	private static java.util.regex.Pattern globToRegex(String glob) {
+	private static Pattern globToRegex(String glob) {
 		StringBuilder sb = new StringBuilder(glob.length() + 4);
 		sb.append('^');
 		for (int i = 0; i < glob.length(); i++) {
@@ -441,7 +442,7 @@ public class ZuliaIndexManager {
 			}
 		}
 		sb.append('$');
-		return java.util.regex.Pattern.compile(sb.toString());
+		return Pattern.compile(sb.toString());
 	}
 
 	public StoreResponse store(StoreRequest request) throws Exception {

--- a/zulia-server/src/test/java/io/zulia/server/test/node/WildcardIndexTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/WildcardIndexTest.java
@@ -1,0 +1,140 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.SearchResult;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.server.test.node.shared.NodeExtension;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class WildcardIndexTest {
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(3);
+
+	private static final List<String> LOG_INDEXES = List.of("logs-2026-04-19", "logs-2026-04-20", "logs-2026-04-21");
+	private static final String METRICS_INDEX = "metrics-2026-04-21";
+
+	private static final int DOCS_PER_LOG_INDEX = 10;
+	private static final int DOCS_IN_METRICS = 4;
+
+	@Test
+	@Order(1)
+	public void createIndexes() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		for (String name : LOG_INDEXES) {
+			createIndex(zuliaWorkPool, name);
+		}
+		createIndex(zuliaWorkPool, METRICS_INDEX);
+	}
+
+	@Test
+	@Order(2)
+	public void indexDocs() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		for (String name : LOG_INDEXES) {
+			for (int i = 0; i < DOCS_PER_LOG_INDEX; i++) {
+				indexRecord(zuliaWorkPool, name, name + "-" + i, "log entry " + i);
+			}
+		}
+		for (int i = 0; i < DOCS_IN_METRICS; i++) {
+			indexRecord(zuliaWorkPool, METRICS_INDEX, METRICS_INDEX + "-" + i, "metric " + i);
+		}
+	}
+
+	@Test
+	@Order(3)
+	public void wildcardMatchesAllLogs() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		SearchResult result = zuliaWorkPool.search(new Search("logs-*").setRealtime(true));
+		Assertions.assertEquals(LOG_INDEXES.size() * DOCS_PER_LOG_INDEX, result.getTotalHits());
+	}
+
+	@Test
+	@Order(4)
+	public void questionMarkMatchesSingleChar() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		// logs-2026-04-2? matches logs-2026-04-20 and logs-2026-04-21, not logs-2026-04-19
+		SearchResult result = zuliaWorkPool.search(new Search("logs-2026-04-2?").setRealtime(true));
+		Assertions.assertEquals(2 * DOCS_PER_LOG_INDEX, result.getTotalHits());
+	}
+
+	@Test
+	@Order(5)
+	public void metricsWildcardMatchesOneIndex() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		SearchResult result = zuliaWorkPool.search(new Search("metrics-*").setRealtime(true));
+		Assertions.assertEquals(DOCS_IN_METRICS, result.getTotalHits());
+	}
+
+	@Test
+	@Order(6)
+	public void literalAndWildcardMix() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		SearchResult result = zuliaWorkPool.search(new Search("logs-2026-04-19", "metrics-*").setRealtime(true));
+		Assertions.assertEquals(DOCS_PER_LOG_INDEX + DOCS_IN_METRICS, result.getTotalHits());
+	}
+
+	@Test
+	@Order(7)
+	public void literalNameStillWorks() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		SearchResult result = zuliaWorkPool.search(new Search("logs-2026-04-20").setRealtime(true));
+		Assertions.assertEquals(DOCS_PER_LOG_INDEX, result.getTotalHits());
+	}
+
+	@Test
+	@Order(8)
+	public void wildcardWithNoMatchesErrors() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(new Search("nonexistent-*").setRealtime(true)),
+				"wildcard matching no indexes should fail");
+	}
+
+	@Test
+	@Order(9)
+	public void wildcardDoesNotMatchAliases() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		zuliaWorkPool.createIndexAlias("everyLog", "logs-2026-04-21");
+		// "every*" would match the alias "everyLog" if aliases were considered.
+		// Expect no matches -> exception.
+		Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(new Search("every*").setRealtime(true)),
+				"wildcard should only match real indexes, not aliases");
+		// Sanity: the alias itself still resolves literally.
+		SearchResult result = zuliaWorkPool.search(new Search("everyLog").setRealtime(true));
+		Assertions.assertEquals(DOCS_PER_LOG_INDEX, result.getTotalHits());
+	}
+
+	private void createIndex(ZuliaWorkPool zuliaWorkPool, String indexName) throws Exception {
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("message");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("message").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.setIndexName(indexName);
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setShardCommitInterval(20);
+		zuliaWorkPool.createIndex(indexConfig);
+	}
+
+	private void indexRecord(ZuliaWorkPool zuliaWorkPool, String index, String uniqueId, String message) throws Exception {
+		Document mongoDocument = new Document();
+		mongoDocument.put("id", uniqueId);
+		mongoDocument.put("message", message);
+		Store s = new Store(uniqueId, index);
+		s.setResultDocument(ResultDocBuilder.newBuilder().setDocument(mongoDocument));
+		zuliaWorkPool.store(s);
+	}
+}


### PR DESCRIPTION
Expand `*` and `?` in `QueryRequest` index names against real indexes at
query dispatch time.  A pattern
with zero matches raises `IndexDoesNotExistException` to catch typos.
Literal names and aliases continue to be resolved as before.