### PR TITLE
Support multi-index aliases with designated write index

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/command/CreateIndexAlias.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/CreateIndexAlias.java
@@ -7,6 +7,8 @@ import io.zulia.message.ZuliaIndex.IndexAlias;
 import io.zulia.message.ZuliaServiceOuterClass.CreateIndexAliasRequest;
 import io.zulia.message.ZuliaServiceOuterClass.CreateIndexAliasResponse;
 
+import java.util.List;
+
 import static io.zulia.message.ZuliaServiceGrpc.ZuliaServiceBlockingStub;
 
 /**
@@ -23,7 +25,19 @@ public class CreateIndexAlias extends SimpleCommand<CreateIndexAliasRequest, Cre
 	}
 
 	public CreateIndexAlias(String aliasName, String indexName) {
-		this.indexAlias = IndexAlias.newBuilder().setAliasName(aliasName).setIndexName(indexName).build();
+		this.indexAlias = IndexAlias.newBuilder().setAliasName(aliasName).addIndexNames(indexName).build();
+	}
+
+	public CreateIndexAlias(String aliasName, List<String> indexNames) {
+		this(aliasName, indexNames, null);
+	}
+
+	public CreateIndexAlias(String aliasName, List<String> indexNames, String writeIndex) {
+		IndexAlias.Builder builder = IndexAlias.newBuilder().setAliasName(aliasName).addAllIndexNames(indexNames);
+		if (writeIndex != null && !writeIndex.isEmpty()) {
+			builder.setWriteIndex(writeIndex);
+		}
+		this.indexAlias = builder.build();
 	}
 
 	@Override

--- a/zulia-client/src/main/java/io/zulia/client/pool/ZuliaWorkPool.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ZuliaWorkPool.java
@@ -61,6 +61,14 @@ public class ZuliaWorkPool extends ZuliaBaseWorkPool {
 		return execute(new CreateIndexAlias(aliasName, indexName));
 	}
 
+	public CreateIndexAliasResult createIndexAlias(String aliasName, List<String> indexNames) throws Exception {
+		return execute(new CreateIndexAlias(aliasName, indexNames));
+	}
+
+	public CreateIndexAliasResult createIndexAlias(String aliasName, List<String> indexNames, String writeIndex) throws Exception {
+		return execute(new CreateIndexAlias(aliasName, indexNames, writeIndex));
+	}
+
 	public ListenableFuture<CreateIndexResult> createIndexAsync(CreateIndex createIndex) {
 		return executeAsync(createIndex);
 	}

--- a/zulia-common/src/main/java/io/zulia/util/IndexAliasUtil.java
+++ b/zulia-common/src/main/java/io/zulia/util/IndexAliasUtil.java
@@ -1,0 +1,49 @@
+package io.zulia.util;
+
+import io.zulia.message.ZuliaIndex.IndexAlias;
+
+import java.util.List;
+
+public final class IndexAliasUtil {
+
+	private IndexAliasUtil() {
+	}
+
+	public static List<String> getIndexNames(IndexAlias alias) {
+		if (!alias.getIndexNamesList().isEmpty()) {
+			return alias.getIndexNamesList();
+		}
+		if (!alias.getIndexName().isEmpty()) {
+			return List.of(alias.getIndexName());
+		}
+		return List.of();
+	}
+
+	public static String requireSingleIndex(IndexAlias alias) {
+		List<String> names = getIndexNames(alias);
+		if (names.isEmpty()) {
+			throw new IllegalArgumentException("Alias <" + alias.getAliasName() + "> has no index names");
+		}
+		if (names.size() > 1) {
+			throw new IllegalArgumentException(
+					"Alias <" + alias.getAliasName() + "> maps to multiple indexes " + names + " and cannot be used for single-index operations");
+		}
+		return names.getFirst();
+	}
+
+	public static String requireWriteIndex(IndexAlias alias) {
+		String writeIndex = alias.getWriteIndex();
+		if (!writeIndex.isEmpty()) {
+			return writeIndex;
+		}
+		List<String> names = getIndexNames(alias);
+		if (names.isEmpty()) {
+			throw new IllegalArgumentException("Alias <" + alias.getAliasName() + "> has no index names");
+		}
+		if (names.size() > 1) {
+			throw new IllegalArgumentException("Alias <" + alias.getAliasName() + "> maps to multiple indexes " + names
+					+ " and has no designated write index; cannot be used for single-index write operations");
+		}
+		return names.getFirst();
+	}
+}

--- a/zulia-common/src/main/proto/zulia_index.proto
+++ b/zulia-common/src/main/proto/zulia_index.proto
@@ -12,7 +12,9 @@ message IndexShardMapping {
 
 message IndexAlias {
     string aliasName = 1;
-    string indexName = 2;
+    string indexName = 2; // kept for backward compat - first/only index
+    repeated string indexNames = 3; // full list of indexes when alias is multi-index
+    string writeIndex = 4; // designated write target; must be one of indexNames. empty means reject single-index writes for multi-index aliases
 }
 
 message ShardMapping {

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
@@ -54,6 +54,7 @@ import io.zulia.server.index.router.FetchRequestRouter;
 import io.zulia.server.index.router.StoreRequestRouter;
 import io.zulia.server.node.ZuliaNode;
 import io.zulia.server.util.MongoProvider;
+import io.zulia.util.IndexAliasUtil;
 import io.zulia.util.ZuliaUtil;
 import io.zulia.util.pool.TaskExecutor;
 import io.zulia.util.pool.WorkPool;
@@ -98,7 +99,7 @@ public class ZuliaIndexManager {
 	private final Node thisNode;
 	private Collection<Node> currentOtherNodesActive = Collections.emptyList();
 	private final ConcurrentHashMap<String, Lock> indexUpdateMap = new ConcurrentHashMap<>();
-	private final ConcurrentHashMap<String, String> indexAliasMap;
+	private final ConcurrentHashMap<String, IndexAlias> indexAliasMap;
 
 	private static final int MONGO_DB_NAME_MAX_LENGTH = 63;
 
@@ -122,7 +123,7 @@ public class ZuliaIndexManager {
 		this.indexAliasMap = new ConcurrentHashMap<>();
 
 		for (IndexAlias indexAlias : indexService.getIndexAliases()) {
-			indexAliasMap.put(indexAlias.getAliasName(), indexAlias.getIndexName());
+			indexAliasMap.put(indexAlias.getAliasName(), indexAlias);
 		}
 
 		this.pool = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name("manager-", 0).factory());
@@ -326,7 +327,7 @@ public class ZuliaIndexManager {
 	}
 
 	public OutputStream getAssociatedDocumentOutputStream(String indexName, String uniqueId, String fileName, Document metadata) throws Exception {
-		ZuliaIndex i = getIndexFromName(indexName);
+		ZuliaIndex i = getIndexForWrite(indexName);
 		long timestamp = System.currentTimeMillis();
 		return i.getAssociatedDocumentOutputStream(uniqueId, fileName, timestamp, metadata);
 	}
@@ -345,8 +346,7 @@ public class ZuliaIndexManager {
 
 		if ((request.getActiveOnly())) {
 			List<IndexShardMapping> indexShardMappingList = indexMap.values().stream().map(ZuliaIndex::getIndexShardMapping).toList();
-			List<IndexAlias> indexAliasesList = indexAliasMap.entrySet().stream()
-					.map(e -> IndexAlias.newBuilder().setAliasName(e.getKey()).setIndexName(e.getValue()).build()).toList();
+			List<IndexAlias> indexAliasesList = List.copyOf(indexAliasMap.values());
 			return GetNodesResponse.newBuilder().addAllNode(currentOtherNodesActive).addNode(thisNode).addAllIndexShardMapping(indexShardMappingList)
 					.addAllIndexAlias(indexAliasesList).build();
 		}
@@ -389,34 +389,35 @@ public class ZuliaIndexManager {
 	private void populateIndexesAndIndexMap(QueryRequest queryRequest, Map<String, Query> queryMap, Set<ZuliaIndex> indexes) throws Exception {
 
 		for (String indexName : queryRequest.getIndexList()) {
-
-			ZuliaIndex index = getIndexFromName(indexName);
-			indexes.add(index);
-
-			Query query = index.getQuery(queryRequest);
-			queryMap.put(handleAlias(indexName), query);
+			for (String resolvedName : resolveAlias(indexName)) {
+				ZuliaIndex index = lookupIndex(indexName, resolvedName);
+				if (indexes.add(index)) {
+					Query query = index.getQuery(queryRequest);
+					queryMap.put(resolvedName, query);
+				}
+			}
 		}
 	}
 
 	public StoreResponse store(StoreRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		StoreRequestRouter router = new StoreRequestRouter(thisNode, currentOtherNodesActive, i, request.getUniqueId(), internalClient);
 		return router.send(request);
 	}
 
 	public StoreResponse internalStore(StoreRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		return StoreRequestRouter.internalStore(i, request);
 	}
 
 	public DeleteResponse delete(DeleteRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		DeleteRequestRouter router = new DeleteRequestRouter(thisNode, currentOtherNodesActive, i, request.getUniqueId(), internalClient);
 		return router.send(request);
 	}
 
 	public DeleteResponse internalDelete(DeleteRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		return DeleteRequestRouter.internalDelete(i, request);
 	}
 
@@ -435,7 +436,7 @@ public class ZuliaIndexManager {
 
 		Map<String, ZuliaIndex> indexCache = new HashMap<>();
 		for (String indexName : indexNames) {
-			indexCache.put(indexName, getIndexFromName(indexName));
+			indexCache.put(indexName, getIndexForWrite(indexName));
 		}
 
 		BatchDeleteRequestFederator federator = new BatchDeleteRequestFederator(thisNode, currentOtherNodesActive, pool, internalClient, indexCache);
@@ -448,14 +449,14 @@ public class ZuliaIndexManager {
 	public List<DeleteResponse> internalBatchDelete(InternalBatchDeleteRequest request) throws Exception {
 		List<InternalShardBatchDeleteRequest> shardRequests = request.getShardBatchDeleteRequestList();
 		if (shardRequests.size() == 1) {
-			ZuliaIndex index = getIndexFromName(shardRequests.getFirst().getIndexName());
+			ZuliaIndex index = getIndexForWrite(shardRequests.getFirst().getIndexName());
 			return index.internalShardBatchDelete(shardRequests.getFirst());
 		}
 
 		List<Future<List<DeleteResponse>>> futures = new ArrayList<>(shardRequests.size());
 		for (InternalShardBatchDeleteRequest shardRequest : shardRequests) {
 			futures.add(pool.submit(() -> {
-				ZuliaIndex index = getIndexFromName(shardRequest.getIndexName());
+				ZuliaIndex index = getIndexForWrite(shardRequest.getIndexName());
 				return index.internalShardBatchDelete(shardRequest);
 			}));
 		}
@@ -575,7 +576,7 @@ public class ZuliaIndexManager {
 			throw new IllegalArgumentException("Index name must be given");
 		}
 
-		String indexName = handleAlias(orgIndexName);
+		String indexName = resolveWriteIndex(orgIndexName);
 
 		if (!indexName.equals(orgIndexName)) {
 			LOG.info("Update Index Following Alias {} to index {}", orgIndexName, indexName);
@@ -883,39 +884,39 @@ public class ZuliaIndexManager {
 	}
 
 	public ClearResponse clear(ClearRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		ClearRequestFederator federator = new ClearRequestFederator(thisNode, currentOtherNodesActive, MasterSlaveSettings.MASTER_ONLY, i, pool,
 				internalClient);
 		return federator.getResponse(request);
 	}
 
 	public ClearResponse internalClear(ClearRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		return ClearRequestFederator.internalClear(i, request);
 	}
 
 	public OptimizeResponse optimize(OptimizeRequest request) throws Exception {
 
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		OptimizeRequestFederator federator = new OptimizeRequestFederator(thisNode, currentOtherNodesActive, MasterSlaveSettings.MASTER_ONLY, i, pool,
 				internalClient);
 		return federator.getResponse(request);
 	}
 
 	public OptimizeResponse internalOptimize(OptimizeRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		return OptimizeRequestFederator.internalOptimize(i, request);
 	}
 
 	public ReindexResponse reindex(ReindexRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		ReindexRequestFederator federator = new ReindexRequestFederator(thisNode, currentOtherNodesActive, MasterSlaveSettings.MASTER_ONLY, i, pool,
 				internalClient);
 		return federator.getResponse(request);
 	}
 
 	public ReindexResponse internalReindex(ReindexRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		return ReindexRequestFederator.internalReindex(i, request);
 	}
 
@@ -949,36 +950,45 @@ public class ZuliaIndexManager {
 	}
 
 	public GetIndexSettingsResponse getIndexSettings(GetIndexSettingsRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
+		ZuliaIndex i = getIndexForWrite(request.getIndexName());
 		if (i != null) {
 			return GetIndexSettingsResponse.newBuilder().setIndexSettings(i.getIndexConfig().getIndexSettings()).build();
 		}
 		return null;
 	}
 
-	private ZuliaIndex getIndexFromName(String indexName) throws IndexDoesNotExistException {
+	private ZuliaIndex getIndexFromName(String indexName) throws Exception {
+		return lookupIndex(indexName, resolveSingleIndex(indexName));
+	}
 
-		String orgIndex = indexName;
-		indexName = handleAlias(indexName);
+	private ZuliaIndex getIndexForWrite(String indexName) throws Exception {
+		return lookupIndex(indexName, resolveWriteIndex(indexName));
+	}
 
-		ZuliaIndex i = indexMap.get(indexName);
+	private ZuliaIndex lookupIndex(String originalName, String resolvedName) throws IndexDoesNotExistException {
+		ZuliaIndex i = indexMap.get(resolvedName);
 		if (i == null) {
-
-			if (orgIndex.equals(indexName)) {
-				throw new IndexDoesNotExistException(indexName);
+			if (resolvedName.equals(originalName)) {
+				throw new IndexDoesNotExistException(originalName);
 			}
-			else {
-				throw new IndexDoesNotExistException(orgIndex + "->" + indexName);
-			}
+			throw new IndexDoesNotExistException(originalName + "->" + resolvedName);
 		}
 		return i;
 	}
 
-	private String handleAlias(String indexName) {
-		if (indexAliasMap.containsKey(indexName)) {
-			indexName = indexAliasMap.get(indexName);
-		}
-		return indexName;
+	private List<String> resolveAlias(String indexName) {
+		IndexAlias alias = indexAliasMap.get(indexName);
+		return alias != null ? IndexAliasUtil.getIndexNames(alias) : List.of(indexName);
+	}
+
+	private String resolveSingleIndex(String indexName) {
+		IndexAlias alias = indexAliasMap.get(indexName);
+		return alias != null ? IndexAliasUtil.requireSingleIndex(alias) : indexName;
+	}
+
+	private String resolveWriteIndex(String indexName) {
+		IndexAlias alias = indexAliasMap.get(indexName);
+		return alias != null ? IndexAliasUtil.requireWriteIndex(alias) : indexName;
 	}
 
 	public CreateIndexAliasResponse createIndexAlias(CreateIndexAliasRequest request) throws Exception {
@@ -990,8 +1000,18 @@ public class ZuliaIndexManager {
 			throw new IllegalArgumentException("Alias name cannot be null or empty");
 		}
 
-		if (indexAlias.getIndexName().isEmpty()) {
-			throw new IllegalArgumentException("Index name cannot be null or empty");
+		List<String> indexNames = IndexAliasUtil.getIndexNames(indexAlias);
+		if (indexNames.isEmpty()) {
+			throw new IllegalArgumentException("At least one index name must be provided");
+		}
+		for (String name : indexNames) {
+			if (name.isEmpty()) {
+				throw new IllegalArgumentException("Index name cannot be null or empty");
+			}
+		}
+
+		if (indexMap.containsKey(aliasName)) {
+			throw new IllegalArgumentException("Alias name <" + aliasName + "> collides with an existing index");
 		}
 
 		IndexAlias existingAlias = indexService.getIndexAlias(aliasName);
@@ -1039,7 +1059,7 @@ public class ZuliaIndexManager {
 
 	public CreateIndexAliasResponse internalCreateIndexAlias(String aliasName) throws Exception {
 		IndexAlias indexAlias = indexService.getIndexAlias(aliasName);
-		indexAliasMap.put(indexAlias.getAliasName(), indexAlias.getIndexName());
+		indexAliasMap.put(indexAlias.getAliasName(), indexAlias);
 		return CreateIndexAliasResponse.newBuilder().build();
 	}
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/MultiIndexAliasTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/MultiIndexAliasTest.java
@@ -1,0 +1,196 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.DeleteFull;
+import io.zulia.client.command.Fetch;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.FilterQuery;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.SearchResult;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.message.ZuliaIndex.IndexAlias;
+import io.zulia.server.test.node.shared.NodeExtension;
+import io.zulia.util.IndexAliasUtil;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class MultiIndexAliasTest {
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(3);
+
+	private static final String INDEX_A = "multiAliasA";
+	private static final String INDEX_B = "multiAliasB";
+	private static final String INDEX_C = "multiAliasC";
+	private static final String READ_ALIAS = "multiRead";
+	private static final String WRITE_ALIAS = "multiWrite";
+	private static final String ROLLOVER_ALIAS = "multiRollover";
+
+	@Test
+	@Order(1)
+	public void createIndexes() throws Exception {
+		ZuliaWorkPool pool = nodeExtension.getClient();
+		for (String name : List.of(INDEX_A, INDEX_B, INDEX_C)) {
+			ClientIndexConfig cfg = new ClientIndexConfig();
+			cfg.addDefaultSearchField("title");
+			cfg.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+			cfg.addFieldConfig(FieldConfigBuilder.createString("title").indexAs(DefaultAnalyzers.STANDARD).sort());
+			cfg.setIndexName(name);
+			cfg.setNumberOfShards(1);
+			cfg.setShardCommitInterval(1);
+			pool.createIndex(cfg);
+		}
+		indexDoc(INDEX_A, "a1", "apple");
+		indexDoc(INDEX_A, "a2", "apricot");
+		indexDoc(INDEX_B, "b1", "banana");
+		indexDoc(INDEX_B, "b2", "blueberry");
+		indexDoc(INDEX_B, "b3", "blackberry");
+		indexDoc(INDEX_C, "c1", "cherry");
+	}
+
+	@Test
+	@Order(2)
+	public void readOnlyMultiIndexAlias() throws Exception {
+		ZuliaWorkPool pool = nodeExtension.getClient();
+		pool.createIndexAlias(READ_ALIAS, List.of(INDEX_A, INDEX_B, INDEX_C));
+
+		SearchResult result = pool.search(new Search(READ_ALIAS).setRealtime(true));
+		Assertions.assertEquals(6, result.getTotalHits(), "multi-index alias should fan out across all indexes");
+
+		result = pool.search(new Search(INDEX_A, INDEX_B).setRealtime(true));
+		Assertions.assertEquals(5, result.getTotalHits(), "explicit multi-index search baseline");
+	}
+
+	@Test
+	@Order(3)
+	public void singleOpsRejectedForReadOnlyMultiAlias() {
+		ZuliaWorkPool pool = nodeExtension.getClient();
+
+		Assertions.assertThrows(Exception.class, () -> indexDoc(READ_ALIAS, "x1", "nope"),
+				"store should reject multi-index alias without writeIndex");
+		Assertions.assertThrows(Exception.class, () -> pool.delete(new DeleteFull("a1", READ_ALIAS)),
+				"delete should reject multi-index alias without writeIndex");
+		Assertions.assertThrows(Exception.class, () -> pool.fetch(new Fetch("a1", READ_ALIAS)),
+				"fetch should reject multi-index alias");
+		Assertions.assertThrows(Exception.class, () -> pool.getNumberOfDocs(READ_ALIAS),
+				"getNumberOfDocs should reject multi-index alias");
+	}
+
+	@Test
+	@Order(4)
+	public void writeIndexRoutesStoreAndDelete() throws Exception {
+		ZuliaWorkPool pool = nodeExtension.getClient();
+		pool.createIndexAlias(WRITE_ALIAS, List.of(INDEX_A, INDEX_B, INDEX_C), INDEX_B);
+
+		Store store = new Store("w1", WRITE_ALIAS);
+		store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(new Document("id", "w1").append("title", "written via alias")));
+		pool.store(store);
+
+		SearchResult onB = pool.search(new Search(INDEX_B).setRealtime(true).addQuery(new FilterQuery("id:w1")));
+		Assertions.assertEquals(1, onB.getTotalHits(), "document should land on designated writeIndex");
+
+		SearchResult onA = pool.search(new Search(INDEX_A).setRealtime(true).addQuery(new FilterQuery("id:w1")));
+		Assertions.assertEquals(0, onA.getTotalHits(), "document must not land on non-write members");
+
+		SearchResult viaAlias = pool.search(new Search(WRITE_ALIAS).setRealtime(true).addQuery(new FilterQuery("id:w1")));
+		Assertions.assertEquals(1, viaAlias.getTotalHits(), "fanned-out search through alias returns written doc");
+
+		pool.delete(new DeleteFull("w1", WRITE_ALIAS));
+		viaAlias = pool.search(new Search(WRITE_ALIAS).setRealtime(true).addQuery(new FilterQuery("id:w1")));
+		Assertions.assertEquals(0, viaAlias.getTotalHits(), "delete through alias removed from writeIndex");
+	}
+
+	@Test
+	@Order(5)
+	public void writeIndexCanTargetNonReadMember() throws Exception {
+		ZuliaWorkPool pool = nodeExtension.getClient();
+		pool.createIndexAlias("backfill", List.of(INDEX_A, INDEX_B), INDEX_C);
+
+		Store store = new Store("bf1", "backfill");
+		store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(new Document("id", "bf1").append("title", "backfilling")));
+		pool.store(store);
+
+		SearchResult onC = pool.search(new Search(INDEX_C).setRealtime(true).addQuery(new FilterQuery("id:bf1")));
+		Assertions.assertEquals(1, onC.getTotalHits(), "writes land on writeIndex even when outside read members");
+
+		SearchResult viaAlias = pool.search(new Search("backfill").setRealtime(true).addQuery(new FilterQuery("id:bf1")));
+		Assertions.assertEquals(0, viaAlias.getTotalHits(), "reads only fan out to indexNames, not to writeIndex-outside-membership");
+	}
+
+	@Test
+	@Order(6)
+	public void backwardCompatSingleIndexAlias() throws Exception {
+		ZuliaWorkPool pool = nodeExtension.getClient();
+		pool.createIndexAlias("legacyAlias", INDEX_A);
+		indexDoc("legacyAlias", "legacy1", "grape");
+		SearchResult result = pool.search(new Search("legacyAlias").setRealtime(true));
+		Assertions.assertTrue(result.getTotalHits() >= 3, "single-index alias still supports writes + reads");
+	}
+
+	@Test
+	@Order(7)
+	public void writeIndexFlipEnablesRollover() throws Exception {
+		ZuliaWorkPool pool = nodeExtension.getClient();
+		pool.createIndexAlias(ROLLOVER_ALIAS, List.of(INDEX_A, INDEX_B), INDEX_A);
+
+		Store first = new Store("r1", ROLLOVER_ALIAS);
+		first.setResultDocument(ResultDocBuilder.newBuilder().setDocument(new Document("id", "r1").append("title", "roll1")));
+		pool.store(first);
+
+		pool.createIndexAlias(ROLLOVER_ALIAS, List.of(INDEX_A, INDEX_B), INDEX_B);
+
+		Store second = new Store("r2", ROLLOVER_ALIAS);
+		second.setResultDocument(ResultDocBuilder.newBuilder().setDocument(new Document("id", "r2").append("title", "roll2")));
+		pool.store(second);
+
+		SearchResult onA = pool.search(new Search(INDEX_A).setRealtime(true).addQuery(new FilterQuery("id:r1 OR id:r2")));
+		Assertions.assertEquals(1, onA.getTotalHits(), "pre-flip doc stays on old write target");
+
+		SearchResult onB = pool.search(new Search(INDEX_B).setRealtime(true).addQuery(new FilterQuery("id:r1 OR id:r2")));
+		Assertions.assertEquals(1, onB.getTotalHits(), "post-flip doc lands on new write target");
+
+		SearchResult combined = pool.search(new Search(ROLLOVER_ALIAS).setRealtime(true).addQuery(new FilterQuery("id:r1 OR id:r2")));
+		Assertions.assertEquals(2, combined.getTotalHits(), "alias still reads across both");
+	}
+
+	@Test
+	@Order(8)
+	public void nodesResponseExposesFullAlias() throws Exception {
+		ZuliaWorkPool pool = nodeExtension.getClient();
+		List<IndexAlias> aliases = pool.getNodes().getIndexAliases();
+		IndexAlias write = aliases.stream().filter(a -> a.getAliasName().equals(WRITE_ALIAS)).findFirst().orElseThrow();
+		Assertions.assertEquals(List.of(INDEX_A, INDEX_B, INDEX_C), IndexAliasUtil.getIndexNames(write));
+		Assertions.assertEquals(INDEX_B, write.getWriteIndex());
+	}
+
+	@Test
+	@Order(9)
+	public void restartPreservesMultiIndexAlias() throws Exception {
+		nodeExtension.restartNodes();
+		ZuliaWorkPool pool = nodeExtension.getClient();
+		SearchResult result = pool.search(new Search(READ_ALIAS).setRealtime(true));
+		Assertions.assertTrue(result.getTotalHits() > 0, "alias membership survives restart");
+
+		IndexAlias write = pool.getNodes().getIndexAliases().stream()
+				.filter(a -> a.getAliasName().equals(WRITE_ALIAS)).findFirst().orElseThrow();
+		Assertions.assertEquals(INDEX_B, write.getWriteIndex(), "writeIndex persists across restart");
+	}
+
+	private void indexDoc(String index, String id, String title) throws Exception {
+		ZuliaWorkPool pool = nodeExtension.getClient();
+		Store s = new Store(id, index);
+		s.setResultDocument(ResultDocBuilder.newBuilder().setDocument(new Document("id", id).append("title", title)));
+		pool.store(s);
+	}
+}

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/zuliaadmin/CreateAliasCmd.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/zuliaadmin/CreateAliasCmd.java
@@ -4,6 +4,7 @@ import io.zulia.client.pool.ZuliaWorkPool;
 import io.zulia.tools.cmd.ZuliaAdmin;
 import picocli.CommandLine;
 
+import java.util.List;
 import java.util.concurrent.Callable;
 
 @CommandLine.Command(name = "createAlias", description = "Creates or updates an alias")
@@ -12,18 +13,25 @@ public class CreateAliasCmd implements Callable<Integer> {
 	@CommandLine.ParentCommand
 	private ZuliaAdmin zuliaAdmin;
 
-	//TODO: when an alias can point to multiple index we can use index info here
-	@CommandLine.Option(names = { "-i", "--index" }, description = "Index that the alias points to", required = true)
-	private String index;
+	@CommandLine.Option(names = { "-i", "--index" }, description = "Index(es) that the alias points to", required = true, split = ",", arity = "1..*")
+	private List<String> indexes;
 
 	@CommandLine.Option(names = { "-a", "--alias" }, description = "Alias name", required = true)
 	private String alias;
+
+	@CommandLine.Option(names = { "-w", "--writeIndex" }, description = "Designated write index (must be one of the listed indexes; only meaningful when multiple indexes are given)")
+	private String writeIndex;
 
 	@Override
 	public Integer call() throws Exception {
 
 		ZuliaWorkPool zuliaWorkPool = zuliaAdmin.getConnection();
-		zuliaWorkPool.createIndexAlias(alias, index);
+		if (indexes.size() == 1 && (writeIndex == null || writeIndex.isEmpty())) {
+			zuliaWorkPool.createIndexAlias(alias, indexes.getFirst());
+		}
+		else {
+			zuliaWorkPool.createIndexAlias(alias, indexes, writeIndex);
+		}
 		return CommandLine.ExitCode.OK;
 	}
 }

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/zuliaadmin/DisplayAliasesCmd.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/zuliaadmin/DisplayAliasesCmd.java
@@ -4,10 +4,12 @@ import io.zulia.client.pool.ZuliaWorkPool;
 import io.zulia.cmd.common.ZuliaCommonCmd;
 import io.zulia.message.ZuliaIndex;
 import io.zulia.tools.cmd.ZuliaAdmin;
+import io.zulia.util.IndexAliasUtil;
 import picocli.CommandLine;
 
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 @CommandLine.Command(name = "displayAliases", description = "Displays aliases")
 public class DisplayAliasesCmd implements Callable<Integer> {
@@ -21,10 +23,14 @@ public class DisplayAliasesCmd implements Callable<Integer> {
 		ZuliaWorkPool zuliaWorkPool = zuliaAdmin.getConnection();
 
 		List<ZuliaIndex.IndexAlias> indexAliases = zuliaWorkPool.getNodes().getIndexAliases();
-		ZuliaCommonCmd.printMagenta(String.format("%40s | %40s", "Alias", "Index"));
+		ZuliaCommonCmd.printMagenta(String.format("%40s | %40s | %20s", "Alias", "Indexes", "Write Index"));
 
 		for (ZuliaIndex.IndexAlias indexAlias : indexAliases) {
-			System.out.printf("%40s | %40s", indexAlias.getAliasName(), indexAlias.getIndexName());
+			String writeIndex = indexAlias.getWriteIndex();
+			String indexes = IndexAliasUtil.getIndexNames(indexAlias).stream()
+					.map(name -> name.equals(writeIndex) ? name + "*" : name)
+					.collect(Collectors.joining(", "));
+			System.out.printf("%40s | %40s | %20s", indexAlias.getAliasName(), indexes, writeIndex.isEmpty() ? "-" : writeIndex);
 			System.out.println();
 		}
 


### PR DESCRIPTION
# Support multi-index aliases with designated write index
 * Extend `IndexAlias` so a single alias can point at multiple indexes and fan out queries across all of them. 
 * An optional `writeIndex` designates which member receives any single-index mutation (store, delete, batchDelete, clear, optimize, reindex, associated-doc writes, updateIndex, getIndexSettings), enabling the rollover / zero-downtime reindex pattern without juggling two aliases.