### PR TITLE
Add basic replication support

### DIFF
--- a/zulia-common/src/main/java/io/zulia/ZuliaRESTConstants.java
+++ b/zulia-common/src/main/java/io/zulia/ZuliaRESTConstants.java
@@ -20,6 +20,7 @@ public interface ZuliaRESTConstants {
 	String INDEXES_URL = "/indexes";
 	String NODES_URL = "/nodes";
 	String STATS_URL = "/stats";
+	String REPLICATION_URL = "/replication";
 
 	String QUERY = "q";
 	String QUERY_FIELD = "qf";

--- a/zulia-common/src/main/proto/zulia_service.proto
+++ b/zulia-common/src/main/proto/zulia_service.proto
@@ -44,6 +44,8 @@ service ZuliaService {
     rpc GetIndexSettings (GetIndexSettingsRequest) returns (GetIndexSettingsResponse);
     rpc Reindex (ReindexRequest) returns (ReindexResponse);
     rpc InternalReindex (ReindexRequest) returns (ReindexResponse);
+    rpc InternalGetSegmentFileInfo (GetSegmentFileInfoRequest) returns (GetSegmentFileInfoResponse);
+    rpc InternalSendSegmentFiles (stream SegmentFileData) returns (SendSegmentFilesResponse);
 }
 
 message IndexRouting {
@@ -384,4 +386,38 @@ message ReindexResponse {
 message RestIndexSettingsResponse {
     IndexSettings indexSettings = 1;
     repeated QueryRequest warmingSearch = 2;
+}
+
+message GetSegmentFileInfoRequest {
+    string indexName = 1;
+    int32 shardNumber = 2;
+    bool taxonomy = 3;
+}
+
+message SegmentFileInfo {
+    string fileName = 1;
+    int64 length = 2;
+    string checksum = 3;
+}
+
+message GetSegmentFileInfoResponse {
+    int64 generation = 1;
+    string segmentsFileName = 2;
+    repeated SegmentFileInfo files = 3;
+    string luceneVersion = 4;
+}
+
+message SegmentFileData {
+    string indexName = 1;
+    int32 shardNumber = 2;
+    bool taxonomy = 3;
+    string fileName = 4;
+    bytes data = 5;
+    int64 generation = 6;
+    bool lastChunk = 7;
+}
+
+message SendSegmentFilesResponse {
+    bool success = 1;
+    int64 generation = 2;
 }

--- a/zulia-server/src/main/java/io/zulia/server/config/ZuliaConfig.java
+++ b/zulia-server/src/main/java/io/zulia/server/config/ZuliaConfig.java
@@ -42,6 +42,14 @@ public class ZuliaConfig {
 
 	private int hitsPerConcurrentRequest;
 
+	// Minutes; deadline on the bidi segment-file stream. Raise if force-merges or vector segments produce
+	// files large enough that a 10-minute ship can't finish.
+	private int replicaResponseTimeout = 10;
+
+	// Aggregate cap across all replication streams leaving this node, in bytes/sec. 0 = unlimited. Prevents
+	// bootstrap of a large index from saturating the network and impacting query traffic. Default 60 MiB/s.
+	private long replicationMaxBytesPerSec = 60L * 1024 * 1024;
+
 	public ZuliaConfig() {
 	}
 
@@ -189,12 +197,29 @@ public class ZuliaConfig {
 		this.health = health;
 	}
 
+	public int getReplicaResponseTimeout() {
+		return replicaResponseTimeout;
+	}
+
+	public void setReplicaResponseTimeout(int replicaResponseTimeout) {
+		this.replicaResponseTimeout = replicaResponseTimeout;
+	}
+
+	public long getReplicationMaxBytesPerSec() {
+		return replicationMaxBytesPerSec;
+	}
+
+	public void setReplicationMaxBytesPerSec(long replicationMaxBytesPerSec) {
+		this.replicationMaxBytesPerSec = replicationMaxBytesPerSec;
+	}
+
 	@Override
 	public String toString() {
 		return "ZuliaConfig{" + "dataPath='" + dataPath + '\'' + ", cluster=" + cluster + ", clusterName='" + clusterName + '\'' + ", clusterStorageEngine='"
 				+ clusterStorageEngine + '\'' + ", s3=" + s3 + ", mongoServers=" + mongoServers + ", mongoConnection=" + mongoConnection + ", mongoAuth="
 				+ mongoAuth + ", serverAddress='" + serverAddress + '\'' + ", servicePort=" + servicePort + ", restPort=" + restPort + ", health=" + health
 				+ ", responseCompression=" + responseCompression + ", rpcWorkers=" + rpcWorkers + ", defaultConcurrency=" + defaultConcurrency + ", debug="
-				+ debug + ", maxFacetsCachedPerDimension=" + maxFacetsCachedPerDimension + ", hitsPerConcurrentRequest=" + hitsPerConcurrentRequest + '}';
+				+ debug + ", maxFacetsCachedPerDimension=" + maxFacetsCachedPerDimension + ", hitsPerConcurrentRequest=" + hitsPerConcurrentRequest
+				+ ", replicaResponseTimeout=" + replicaResponseTimeout + ", replicationMaxBytesPerSec=" + replicationMaxBytesPerSec + '}';
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/connection/client/InternalRpcConnection.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/client/InternalRpcConnection.java
@@ -4,6 +4,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import io.zulia.message.ZuliaServiceGrpc;
 import io.zulia.message.ZuliaServiceGrpc.ZuliaServiceBlockingStub;
+import io.zulia.message.ZuliaServiceGrpc.ZuliaServiceStub;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +18,7 @@ public class InternalRpcConnection {
 
 	private ManagedChannel channel;
 	private ZuliaServiceBlockingStub blockingStub;
+	private ZuliaServiceStub asyncStub;
 
 	public InternalRpcConnection(String memberAddress, int servicePort) {
 		this.memberAddress = memberAddress;
@@ -27,12 +29,17 @@ public class InternalRpcConnection {
 		channel = managedChannelBuilder.build();
 
 		blockingStub = ZuliaServiceGrpc.newBlockingStub(channel);
+		asyncStub = ZuliaServiceGrpc.newStub(channel);
 
 		LOG.info("Connecting to {}:{}", memberAddress, servicePort);
 	}
 
 	public ZuliaServiceBlockingStub getService() {
 		return blockingStub;
+	}
+
+	public ZuliaServiceStub getAsyncService() {
+		return asyncStub;
 	}
 
 	public void close() {
@@ -55,6 +62,7 @@ public class InternalRpcConnection {
 
 		channel = null;
 		blockingStub = null;
+		asyncStub = null;
 
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/ZuliaServiceHandler.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/ZuliaServiceHandler.java
@@ -45,6 +45,8 @@ public class ZuliaServiceHandler extends ZuliaServiceImplBase {
 	private final CreateIndexAliasServerRequest createIndexAliasServerRequest;
 	private final InternalCreateIndexAliasServerRequest internalCreateIndexAliasServerRequest;
 	private final InternalDeleteIndexAliasServerRequest internalDeleteIndexAliasServerRequest;
+	private final GetSegmentFileInfoServerRequest getSegmentFileInfoServerRequest;
+	private final SendSegmentFilesServerRequest sendSegmentFilesServerRequest;
 
 	public ZuliaServiceHandler(ZuliaIndexManager indexManager) {
 		internalQueryServerRequest = new InternalQueryServerRequest(indexManager);
@@ -83,6 +85,8 @@ public class ZuliaServiceHandler extends ZuliaServiceImplBase {
 		createIndexAliasServerRequest = new CreateIndexAliasServerRequest(indexManager);
 		internalCreateIndexAliasServerRequest = new InternalCreateIndexAliasServerRequest(indexManager);
 		internalDeleteIndexAliasServerRequest = new InternalDeleteIndexAliasServerRequest(indexManager);
+		getSegmentFileInfoServerRequest = new GetSegmentFileInfoServerRequest(indexManager);
+		sendSegmentFilesServerRequest = new SendSegmentFilesServerRequest(indexManager);
 	}
 
 	@Override
@@ -263,5 +267,15 @@ public class ZuliaServiceHandler extends ZuliaServiceImplBase {
 	@Override
 	public void internalDeleteIndexAlias(DeleteIndexAliasRequest request, StreamObserver<DeleteIndexAliasResponse> responseObserver) {
 		internalDeleteIndexAliasServerRequest.handleRequest(request, responseObserver);
+	}
+
+	@Override
+	public void internalGetSegmentFileInfo(GetSegmentFileInfoRequest request, StreamObserver<GetSegmentFileInfoResponse> responseObserver) {
+		getSegmentFileInfoServerRequest.handleRequest(request, responseObserver);
+	}
+
+	@Override
+	public StreamObserver<SegmentFileData> internalSendSegmentFiles(StreamObserver<SendSegmentFilesResponse> responseObserver) {
+		return sendSegmentFilesServerRequest.handleRequest(responseObserver);
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/handler/GetSegmentFileInfoServerRequest.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/handler/GetSegmentFileInfoServerRequest.java
@@ -1,0 +1,38 @@
+package io.zulia.server.connection.server.handler;
+
+import io.zulia.message.ZuliaServiceOuterClass.GetSegmentFileInfoRequest;
+import io.zulia.message.ZuliaServiceOuterClass.GetSegmentFileInfoResponse;
+import io.zulia.message.ZuliaServiceOuterClass.SegmentFileInfo;
+import io.zulia.server.index.ZuliaIndex;
+import io.zulia.server.index.ZuliaIndexManager;
+import io.zulia.server.index.replication.ReplicaFileInfo;
+import org.apache.lucene.util.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class GetSegmentFileInfoServerRequest extends ServerRequestHandler<GetSegmentFileInfoResponse, GetSegmentFileInfoRequest> {
+
+	private final static Logger LOG = LoggerFactory.getLogger(GetSegmentFileInfoServerRequest.class);
+
+	public GetSegmentFileInfoServerRequest(ZuliaIndexManager indexManager) {
+		super(indexManager);
+	}
+
+	@Override
+	protected GetSegmentFileInfoResponse handleCall(ZuliaIndexManager indexManager, GetSegmentFileInfoRequest request) throws Exception {
+		ZuliaIndex zuliaIndex = indexManager.getIndexFromName(request.getIndexName());
+		List<ReplicaFileInfo> files = zuliaIndex.listReplicaFileInfo(request.getShardNumber(), request.getTaxonomy());
+		GetSegmentFileInfoResponse.Builder responseBuilder = GetSegmentFileInfoResponse.newBuilder().setLuceneVersion(Version.LATEST.toString());
+		for (ReplicaFileInfo info : files) {
+			responseBuilder.addFiles(SegmentFileInfo.newBuilder().setFileName(info.name()).setLength(info.length()).setChecksum(info.checksum()).build());
+		}
+		return responseBuilder.build();
+	}
+
+	@Override
+	protected void onError(Throwable e) {
+		LOG.error("Failed to handle get segment file info", e);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/handler/NoOpStreamObserver.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/handler/NoOpStreamObserver.java
@@ -1,0 +1,19 @@
+package io.zulia.server.connection.server.handler;
+
+import io.grpc.stub.StreamObserver;
+import io.zulia.message.ZuliaServiceOuterClass.SegmentFileData;
+
+public class NoOpStreamObserver implements StreamObserver<SegmentFileData> {
+
+	@Override
+	public void onNext(SegmentFileData value) {
+	}
+
+	@Override
+	public void onError(Throwable t) {
+	}
+
+	@Override
+	public void onCompleted() {
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/handler/ReplicaStreamObserver.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/handler/ReplicaStreamObserver.java
@@ -1,0 +1,126 @@
+package io.zulia.server.connection.server.handler;
+
+import com.google.protobuf.ByteString;
+import io.grpc.stub.StreamObserver;
+import io.zulia.message.ZuliaServiceOuterClass.SegmentFileData;
+import io.zulia.message.ZuliaServiceOuterClass.SendSegmentFilesResponse;
+import io.zulia.server.index.ZuliaIndexManager;
+import io.zulia.server.index.replication.ReplicaDirectoryApplier;
+import io.zulia.server.index.replication.ReplicationLimits;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Semaphore;
+
+public class ReplicaStreamObserver implements StreamObserver<SegmentFileData> {
+
+	private final static Logger LOG = LoggerFactory.getLogger(ReplicaStreamObserver.class);
+
+	private final ZuliaIndexManager indexManager;
+	private final StreamObserver<SendSegmentFilesResponse> responseObserver;
+	private final Semaphore inboundSemaphore;
+
+	private ReplicaDirectoryApplier applier;
+	private long generation;
+	private boolean terminated;
+	private boolean permitReleased;
+
+	public ReplicaStreamObserver(ZuliaIndexManager indexManager, StreamObserver<SendSegmentFilesResponse> responseObserver, Semaphore inboundSemaphore) {
+		this.indexManager = indexManager;
+		this.responseObserver = responseObserver;
+		this.inboundSemaphore = inboundSemaphore;
+	}
+
+	@Override
+	public void onNext(SegmentFileData data) {
+		if (terminated) {
+			return;
+		}
+		try {
+			if (applier == null) {
+				applier = indexManager.getIndexFromName(data.getIndexName()).newReplicaApplier(data.getShardNumber());
+			}
+
+			generation = data.getGeneration();
+
+			ByteString payload = data.getData();
+			if (payload.size() > ReplicationLimits.MAX_CHUNK_BYTES) {
+				throw new IllegalArgumentException("Chunk size " + payload.size() + " exceeds cap " + ReplicationLimits.MAX_CHUNK_BYTES);
+			}
+			byte[] buf = payload.toByteArray();
+			applier.writeBytes(data.getTaxonomy(), data.getFileName(), buf, 0, buf.length);
+
+			if (data.getLastChunk()) {
+				applier.finishFile();
+			}
+		}
+		catch (Exception e) {
+			terminate(e);
+		}
+	}
+
+	@Override
+	public void onError(Throwable t) {
+		// Client cancelled or dropped; the call is already terminated, do not call responseObserver.onError.
+		LOG.warn("Error in send segment files stream: {}", t.getMessage());
+		terminated = true;
+		if (applier != null) {
+			applier.abort();
+		}
+		releasePermit();
+	}
+
+	@Override
+	public void onCompleted() {
+		if (terminated) {
+			releasePermit();
+			return;
+		}
+		try {
+			if (applier != null) {
+				applier.commit();
+			}
+			responseObserver.onNext(SendSegmentFilesResponse.newBuilder().setSuccess(true).setGeneration(generation).build());
+			responseObserver.onCompleted();
+		}
+		catch (Exception e) {
+			// Do not ack: the primary advances the generation gate only on success and will retry next commit.
+			LOG.error("Commit on replica failed during onCompleted for generation {}", generation, e);
+			terminated = true;
+			if (applier != null) {
+				applier.abort();
+			}
+			try {
+				responseObserver.onError(e);
+			}
+			catch (IllegalStateException ignored) {
+			}
+		}
+		finally {
+			releasePermit();
+		}
+	}
+
+	private void terminate(Exception e) {
+		LOG.error("Error receiving segment file data", e);
+		if (!terminated) {
+			terminated = true;
+			if (applier != null) {
+				applier.abort();
+			}
+			try {
+				responseObserver.onError(e);
+			}
+			catch (IllegalStateException ignored) {
+			}
+			releasePermit();
+		}
+	}
+
+	private void releasePermit() {
+		if (!permitReleased) {
+			permitReleased = true;
+			inboundSemaphore.release();
+		}
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/handler/SendSegmentFilesServerRequest.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/handler/SendSegmentFilesServerRequest.java
@@ -1,0 +1,35 @@
+package io.zulia.server.connection.server.handler;
+
+import io.grpc.Status;
+import io.grpc.stub.StreamObserver;
+import io.zulia.message.ZuliaServiceOuterClass.SegmentFileData;
+import io.zulia.message.ZuliaServiceOuterClass.SendSegmentFilesResponse;
+import io.zulia.server.index.ZuliaIndexManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Semaphore;
+
+public class SendSegmentFilesServerRequest {
+
+	private final static Logger LOG = LoggerFactory.getLogger(SendSegmentFilesServerRequest.class);
+
+	// Excess streams fail with RESOURCE_EXHAUSTED so the primary retries next commit rather than queueing.
+	private static final int MAX_CONCURRENT_INBOUND = 16;
+
+	private final ZuliaIndexManager indexManager;
+	private final Semaphore inboundSemaphore = new Semaphore(MAX_CONCURRENT_INBOUND);
+
+	public SendSegmentFilesServerRequest(ZuliaIndexManager indexManager) {
+		this.indexManager = indexManager;
+	}
+
+	public StreamObserver<SegmentFileData> handleRequest(StreamObserver<SendSegmentFilesResponse> responseObserver) {
+		if (!inboundSemaphore.tryAcquire()) {
+			LOG.warn("Rejecting inbound replication: {} streams already in progress", MAX_CONCURRENT_INBOUND);
+			responseObserver.onError(Status.RESOURCE_EXHAUSTED.withDescription("Too many concurrent replications").asRuntimeException());
+			return new NoOpStreamObserver();
+		}
+		return new ReplicaStreamObserver(indexManager, responseObserver, inboundSemaphore);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardReadManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardReadManager.java
@@ -1,0 +1,170 @@
+package io.zulia.server.index;
+
+import io.zulia.server.analysis.ZuliaPerFieldAnalyzer;
+import io.zulia.server.config.ServerIndexConfig;
+import io.zulia.server.search.aggregation.AggregationSettings;
+import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
+import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.MMapDirectory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class ShardReadManager {
+
+	private final static Logger LOG = LoggerFactory.getLogger(ShardReadManager.class);
+
+	private final int shardNumber;
+	private final Path pathToIndex;
+	private final Path pathToTaxoIndex;
+	private final ServerIndexConfig indexConfig;
+	private final ZuliaPerFieldAnalyzer zuliaPerFieldAnalyzer;
+	private final AggregationSettings aggregationSettings;
+	private final ExecutorService segmentOpenExecutor;
+
+	private final Directory indexDirectory;
+	private final Directory taxoDirectory;
+
+	public ShardReadManager(int shardNumber, Path pathToIndex, Path pathToTaxoIndex, ServerIndexConfig indexConfig,
+			ZuliaPerFieldAnalyzer zuliaPerFieldAnalyzer, AggregationSettings aggregationSettings) throws IOException {
+		this.shardNumber = shardNumber;
+		this.pathToIndex = pathToIndex;
+		this.pathToTaxoIndex = pathToTaxoIndex;
+		this.indexConfig = indexConfig;
+		this.zuliaPerFieldAnalyzer = zuliaPerFieldAnalyzer;
+		this.aggregationSettings = aggregationSettings;
+
+		String indexName = indexConfig.getIndexName();
+		this.segmentOpenExecutor = Executors.newThreadPerTaskExecutor(
+				Thread.ofVirtual().name(indexName + ":s" + shardNumber + "-replica-segment-", 0).factory());
+
+		Files.createDirectories(pathToIndex);
+		Files.createDirectories(pathToTaxoIndex);
+
+		this.indexDirectory = MMapDirectory.open(pathToIndex);
+		this.taxoDirectory = MMapDirectory.open(pathToTaxoIndex);
+
+		ensureIndexExists(indexDirectory);
+		ensureTaxoIndexExists(taxoDirectory);
+	}
+
+	private void ensureIndexExists(Directory directory) throws IOException {
+		if (!DirectoryReader.indexExists(directory)) {
+			LOG.info("Creating empty index for replica shard {}", shardNumber);
+			try (IndexWriter writer = new IndexWriter(directory, new IndexWriterConfig())) {
+				writer.commit();
+			}
+		}
+	}
+
+	private void ensureTaxoIndexExists(Directory directory) throws IOException {
+		if (!DirectoryReader.indexExists(directory)) {
+			LOG.info("Creating empty taxonomy index for replica shard {}", shardNumber);
+			try (DirectoryTaxonomyWriter writer = new DirectoryTaxonomyWriter(directory)) {
+				writer.commit();
+			}
+		}
+	}
+
+	public int getShardNumber() {
+		return shardNumber;
+	}
+
+	public ServerIndexConfig getIndexConfig() {
+		return indexConfig;
+	}
+
+	public ZuliaPerFieldAnalyzer getZuliaPerFieldAnalyzer() {
+		return zuliaPerFieldAnalyzer;
+	}
+
+	public Directory getIndexDirectory() {
+		return indexDirectory;
+	}
+
+	public Directory getTaxoDirectory() {
+		return taxoDirectory;
+	}
+
+	public Path getPathToIndex() {
+		return pathToIndex;
+	}
+
+	public Path getPathToTaxoIndex() {
+		return pathToTaxoIndex;
+	}
+
+	// Safe after refreshReaders; mmapped files held by in-flight queries stay valid (mmap-after-unlink).
+	public void cleanupUnreferencedFiles() {
+		cleanupDirectory(indexDirectory, "index");
+		cleanupDirectory(taxoDirectory, "taxonomy");
+	}
+
+	private void cleanupDirectory(Directory directory, String label) {
+		Set<String> referenced;
+		try {
+			SegmentInfos segmentInfos = SegmentInfos.readLatestCommit(directory);
+			referenced = new HashSet<>(segmentInfos.files(true));
+		}
+		catch (IOException e) {
+			LOG.warn("Skipping {} cleanup for replica shard {}: could not read segment infos: {}", label, shardNumber, e.getMessage());
+			return;
+		}
+
+		String[] allFiles;
+		try {
+			allFiles = directory.listAll();
+		}
+		catch (IOException e) {
+			LOG.warn("Skipping {} cleanup for replica shard {}: could not list directory: {}", label, shardNumber, e.getMessage());
+			return;
+		}
+
+		int deleted = 0;
+		for (String fileName : allFiles) {
+			if (referenced.contains(fileName)) {
+				continue;
+			}
+			if (IndexWriter.WRITE_LOCK_NAME.equals(fileName)) {
+				continue;
+			}
+			try {
+				directory.deleteFile(fileName);
+				deleted++;
+				LOG.debug("Deleted unreferenced {} file {} from replica shard {}", label, fileName, shardNumber);
+			}
+			catch (IOException e) {
+				LOG.warn("Failed to delete unreferenced {} file {} from replica shard {}: {}", label, fileName, shardNumber, e.getMessage());
+			}
+		}
+		if (deleted > 0) {
+			LOG.info("Cleaned up {} unreferenced {} file(s) on replica shard {}", deleted, label, shardNumber);
+		}
+	}
+
+	public ShardReader createShardReader() throws IOException {
+		DirectoryReader indexReader = DirectoryReader.open(indexDirectory);
+		DirectoryTaxonomyReader taxoReader = new DirectoryTaxonomyReader(taxoDirectory);
+		taxoReader.setCacheSize(128000);
+		return new ShardReader(shardNumber, indexReader, taxoReader, indexConfig, zuliaPerFieldAnalyzer, segmentOpenExecutor, aggregationSettings);
+	}
+
+	public void close() throws IOException {
+		segmentOpenExecutor.close();
+		indexDirectory.close();
+		taxoDirectory.close();
+	}
+
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardWriteManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardWriteManager.java
@@ -7,11 +7,12 @@ import io.zulia.server.config.ServerIndexConfig;
 import io.zulia.server.index.cache.ZuliaTaxonomyWriterCache;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
-import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
 import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexCommit;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.index.KeepOnlyLastCommitDeletionPolicy;
+import org.apache.lucene.index.SnapshotDeletionPolicy;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.store.Directory;
@@ -43,10 +44,11 @@ public class ShardWriteManager {
 	private volatile int indexingThrottlePermits;
 
 	private final IndexWriter indexWriter;
-	private final DirectoryTaxonomyWriter taxoWriter;
+	private final SnapshotDirectoryTaxonomyWriter taxoWriter;
 	private final ExecutorService segmentOpenExecutor;
 	private final Path pathToIndex;
 	private final Path pathToTaxoIndex;
+	private final SnapshotDeletionPolicy snapshotDeletionPolicy;
 
 	private Long lastCommit;
 	private Long lastChange;
@@ -79,6 +81,7 @@ public class ShardWriteManager {
 		this.mergeScheduler = new ZuliaConcurrentMergeScheduler();
 		this.pathToIndex = pathToIndex;
 		this.pathToTaxoIndex = pathToTaxoIndex;
+		this.snapshotDeletionPolicy = new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
 		this.indexWriter = openIndexWriter(pathToIndex);
 		this.taxoWriter = openTaxoWriter(pathToTaxoIndex, aggregationSettings.maxFacetsCachedPerDimension());
 		this.segmentOpenExecutor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name(indexName + ":s" + shardNumber + "-segment-", 0).factory());
@@ -105,7 +108,7 @@ public class ShardWriteManager {
 		tieredMergePolicy.setMaxMergedSegmentMB(10_000);
 		tieredMergePolicy.setDeletesPctAllowed(0.15);
 		config.setMergePolicy(tieredMergePolicy);
-		config.setIndexDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
+		config.setIndexDeletionPolicy(snapshotDeletionPolicy);
 		config.setMaxBufferedDocs(Integer.MAX_VALUE);
 		config.setRAMBufferSizeMB(128); // should be overwritten by ZuliaShard.updateIndexSettings()
 		config.setUseCompoundFile(false);
@@ -118,11 +121,11 @@ public class ShardWriteManager {
 
 	}
 
-	private DirectoryTaxonomyWriter openTaxoWriter(Path pathToTaxo, int maxFacetsCachedPerDimension) throws IOException {
+	private SnapshotDirectoryTaxonomyWriter openTaxoWriter(Path pathToTaxo, int maxFacetsCachedPerDimension) throws IOException {
 		Directory d = MMapDirectory.open(pathToTaxo);
 		NRTCachingDirectory nrtCachingDirectory = new NRTCachingDirectory(d, 5, 15);
 
-		DirectoryTaxonomyWriter writer = new DirectoryTaxonomyWriter(nrtCachingDirectory, IndexWriterConfig.OpenMode.CREATE_OR_APPEND,
+		SnapshotDirectoryTaxonomyWriter writer = new SnapshotDirectoryTaxonomyWriter(nrtCachingDirectory, IndexWriterConfig.OpenMode.CREATE_OR_APPEND,
 				new ZuliaTaxonomyWriterCache(maxFacetsCachedPerDimension));
 		LOG.info("Opened taxonomy for {}:s{} with {} ordinals", indexName, shardNumber, writer.getSize());
 		return writer;
@@ -298,6 +301,36 @@ public class ShardWriteManager {
 			totalIndexedUnthrottled.incrementAndGet();
 		}
 
+	}
+
+	public Directory getIndexDirectory() {
+		return indexWriter.getDirectory();
+	}
+
+	public Directory getTaxoDirectory() {
+		return taxoWriter.getDirectory();
+	}
+
+	// Today the taxoWriter is always non-null. This is an extension point for a future facet backend where ordinals
+	// live outside Lucene and replication skips the taxo pass.
+	public boolean hasTaxonomy() {
+		return taxoWriter != null;
+	}
+
+	public IndexCommit snapshotIndex() throws IOException {
+		return snapshotDeletionPolicy.snapshot();
+	}
+
+	public void releaseSnapshot(IndexCommit commit) throws IOException {
+		snapshotDeletionPolicy.release(commit);
+	}
+
+	public IndexCommit snapshotTaxo() throws IOException {
+		return taxoWriter.getDeletionPolicy().snapshot();
+	}
+
+	public void releaseTaxoSnapshot(IndexCommit commit) throws IOException {
+		taxoWriter.getDeletionPolicy().release(commit);
 	}
 
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/SnapshotDirectoryTaxonomyWriter.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/SnapshotDirectoryTaxonomyWriter.java
@@ -1,0 +1,34 @@
+package io.zulia.server.index;
+
+import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
+import org.apache.lucene.facet.taxonomy.writercache.TaxonomyWriterCache;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexWriterConfig.OpenMode;
+import org.apache.lucene.index.SnapshotDeletionPolicy;
+import org.apache.lucene.store.Directory;
+
+import java.io.IOException;
+
+// Ported from Lucene 9's IndexAndTaxonomyRevision.SnapshotDirectoryTaxonomyWriter (removed in Lucene 10).
+// Installs a SnapshotDeletionPolicy on the taxonomy's internal IndexWriter so segment replication can grab
+// a consistent IndexCommit for the taxo directory.
+public class SnapshotDirectoryTaxonomyWriter extends DirectoryTaxonomyWriter {
+
+	private SnapshotDeletionPolicy snapshotDeletionPolicy;
+
+	public SnapshotDirectoryTaxonomyWriter(Directory directory, OpenMode openMode, TaxonomyWriterCache cache) throws IOException {
+		super(directory, openMode, cache);
+	}
+
+	@Override
+	protected IndexWriterConfig createIndexWriterConfig(OpenMode openMode) {
+		IndexWriterConfig config = super.createIndexWriterConfig(openMode);
+		snapshotDeletionPolicy = new SnapshotDeletionPolicy(config.getIndexDeletionPolicy());
+		config.setIndexDeletionPolicy(snapshotDeletionPolicy);
+		return config;
+	}
+
+	public SnapshotDeletionPolicy getDeletionPolicy() {
+		return snapshotDeletionPolicy;
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
@@ -31,8 +31,15 @@ import io.zulia.server.config.IndexService;
 import io.zulia.server.config.ServerIndexConfig;
 import io.zulia.server.config.SortFieldInfo;
 import io.zulia.server.config.ZuliaConfig;
+import io.zulia.server.connection.client.InternalClient;
 import io.zulia.server.exceptions.IndexDoesNotExistException;
 import io.zulia.server.exceptions.ShardDoesNotExistException;
+import io.zulia.server.index.replication.ReplicaDirectoryApplier;
+import io.zulia.server.index.replication.ReplicaFileInfo;
+import io.zulia.server.index.replication.ReplicationRateLimiter;
+import io.zulia.server.index.replication.ReplicationShardState;
+import io.zulia.server.index.replication.ReplicationUtil;
+import io.zulia.server.index.replication.SegmentReplicationManager;
 import io.zulia.server.field.FieldTypeUtil;
 import io.zulia.server.filestorage.DocumentStorage;
 import io.zulia.server.search.aggregation.AggregationSettings;
@@ -43,7 +50,6 @@ import io.zulia.server.search.queryparser.SetQueryHelper;
 import io.zulia.server.search.queryparser.ZuliaFlexibleQueryParser;
 import io.zulia.server.util.DeletingFileVisitor;
 import io.zulia.util.ShardUtil;
-import java.util.concurrent.ConcurrentLinkedDeque;
 import org.apache.lucene.expressions.Expression;
 import org.apache.lucene.expressions.SimpleBindings;
 import org.apache.lucene.expressions.js.JavascriptCompiler;
@@ -62,6 +68,7 @@ import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.bson.Document;
 import org.slf4j.Logger;
@@ -83,6 +90,7 @@ import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -106,13 +114,20 @@ public class ZuliaIndex {
 	private final TimerTask commitTask;
 	private final Timer warmTimer;
 	private final TimerTask warmTask;
+	private final Timer replicationWatchdogTimer;
+	private final TimerTask replicationWatchdogTask;
+
+	// Worst-case lag before a stale replica starts catching up; the per-shard generation gate makes each
+	// pass cheap when nothing has changed.
+	private static final long REPLICATION_WATCHDOG_INTERVAL_MS = 30_000;
 	private final ZuliaPerFieldAnalyzer zuliaPerFieldAnalyzer;
 	private final IndexService indexService;
 	private final IndexShardMapping indexShardMapping;
 	private final AggregationSettings aggregationSettings;
+	private final SegmentReplicationManager segmentReplicationManager;
 
 	public ZuliaIndex(ZuliaConfig zuliaConfig, ServerIndexConfig indexConfig, DocumentStorage documentStorage, IndexService indexService,
-			IndexShardMapping indexShardMapping) {
+			IndexShardMapping indexShardMapping, InternalClient internalClient, ReplicationRateLimiter replicationRateLimiter) {
 
 		this.zuliaConfig = zuliaConfig;
 		this.aggregationSettings = new AggregationSettings(zuliaConfig.getHitsPerConcurrentRequest(), zuliaConfig.getMaxFacetsCachedPerDimension());
@@ -121,6 +136,8 @@ public class ZuliaIndex {
 		this.numberOfShards = indexConfig.getNumberOfShards();
 		this.indexService = indexService;
 		this.indexShardMapping = indexShardMapping;
+		this.segmentReplicationManager = new SegmentReplicationManager(internalClient, indexShardMapping, indexName, zuliaConfig.getReplicaResponseTimeout(),
+				replicationRateLimiter);
 
 		this.documentStorage = documentStorage;
 
@@ -167,6 +184,20 @@ public class ZuliaIndex {
 
 		warmTimer.scheduleAtFixedRate(warmTask, 1000, 1000);
 
+		replicationWatchdogTimer = new Timer(indexName + "-ReplicationWatchdog", true);
+		replicationWatchdogTask = new TimerTask() {
+			@Override
+			public void run() {
+				try {
+					segmentReplicationManager.watchdogTick(primaryShardMap.values());
+				}
+				catch (Exception e) {
+					LOG.warn("Replication watchdog tick failed for {}", indexName, e);
+				}
+			}
+		};
+		replicationWatchdogTimer.scheduleAtFixedRate(replicationWatchdogTask, REPLICATION_WATCHDOG_INTERVAL_MS, REPLICATION_WATCHDOG_INTERVAL_MS);
+
 	}
 
 	public SortFieldInfo getSortFieldType(String fieldName) {
@@ -201,10 +232,16 @@ public class ZuliaIndex {
 		warmTask.cancel();
 		warmTimer.cancel();
 
+		replicationWatchdogTask.cancel();
+		replicationWatchdogTimer.cancel();
+
 		if (!terminate) {
 			LOG.info("Committing {}", indexName);
 			doCommit(true);
 		}
+
+		// After the final commit has fired its replication hook, await in-flight transfers before closing shards.
+		segmentReplicationManager.shutdown();
 
 		LOG.info("Shutting down shard pool for {}", indexName);
 		shardPool.shutdownNow();
@@ -238,21 +275,29 @@ public class ZuliaIndex {
 	}
 
 	private void loadShard(int shardNumber, boolean primary) throws Exception {
-
-		ShardWriteManager shardWriteManager = new ShardWriteManager(shardNumber, getPathForIndex(shardNumber), getPathForFacetsIndex(shardNumber), indexConfig,
-				zuliaPerFieldAnalyzer, aggregationSettings);
-
-		ZuliaShard s = new ZuliaShard(shardWriteManager, primary);
-
 		if (primary) {
-			LOG.info("Loaded primary shard {}:s{}", indexName, shardNumber);
-			primaryShardMap.put(shardNumber, s);
+			loadPrimaryShard(shardNumber);
 		}
 		else {
-			LOG.info("Loaded replica shard {}:s{}", indexName, shardNumber);
-			replicaShardMap.put(shardNumber, s);
+			loadReplicaShard(shardNumber);
 		}
+	}
 
+	private void loadPrimaryShard(int shardNumber) throws Exception {
+		ShardWriteManager shardWriteManager = new ShardWriteManager(shardNumber, getPathForIndex(shardNumber), getPathForFacetsIndex(shardNumber), indexConfig,
+				zuliaPerFieldAnalyzer, aggregationSettings);
+		ZuliaShard s = new ZuliaShard(shardWriteManager);
+		s.setPostCommitHook(() -> segmentReplicationManager.replicateAfterCommit(s));
+		LOG.info("Loaded primary shard {}:s{}", indexName, shardNumber);
+		primaryShardMap.put(shardNumber, s);
+	}
+
+	private void loadReplicaShard(int shardNumber) throws Exception {
+		ShardReadManager shardReadManager = new ShardReadManager(shardNumber, getPathForIndex(shardNumber), getPathForFacetsIndex(shardNumber), indexConfig,
+				zuliaPerFieldAnalyzer, aggregationSettings);
+		ZuliaShard s = new ZuliaShard(shardReadManager);
+		LOG.info("Loaded replica shard {}:s{}", indexName, shardNumber);
+		replicaShardMap.put(shardNumber, s);
 	}
 
 	private Path getPathForIndex(int shardNumber) {
@@ -1271,6 +1316,36 @@ public class ZuliaIndex {
 		return indexName;
 	}
 
+	public ReplicaDirectoryApplier newReplicaApplier(int shardNumber) throws ShardDoesNotExistException {
+		return new ReplicaDirectoryApplier(requireReplicaShard(shardNumber));
+	}
+
+	public List<ReplicaFileInfo> listReplicaFileInfo(int shardNumber, boolean taxonomy) throws IOException {
+		ZuliaShard shard = requireReplicaShard(shardNumber);
+		ShardReadManager readManager = shard.getShardReadManager();
+		Directory directory = taxonomy ? readManager.getTaxoDirectory() : readManager.getIndexDirectory();
+		List<ReplicaFileInfo> result = new ArrayList<>();
+		for (String fileName : directory.listAll()) {
+			ReplicaFileInfo info = ReplicationUtil.readFileInfo(directory, fileName);
+			if (info != null) {
+				result.add(info);
+			}
+		}
+		return result;
+	}
+
+	private ZuliaShard requireReplicaShard(int shardNumber) throws ShardDoesNotExistException {
+		ZuliaShard shard = replicaShardMap.get(shardNumber);
+		if (shard == null || shard.getShardReadManager() == null) {
+			throw new ShardDoesNotExistException(indexName, shardNumber);
+		}
+		return shard;
+	}
+
+	public List<ReplicationShardState> getReplicationState() {
+		return segmentReplicationManager.getReplicationState();
+	}
+
 	public void loadShards(Predicate<Node> thisNodeTest) throws Exception {
 		List<ShardMapping> shardMappingList = indexShardMapping.getShardMappingList();
 		for (ShardMapping shardMapping : shardMappingList) {
@@ -1286,6 +1361,12 @@ public class ZuliaIndex {
 				}
 
 			}
+		}
+
+		// Catch up replicas that missed commits while this primary was down. replicateAfterCommit
+		// short-circuits when there are no replicas or nothing has changed, so this is cheap.
+		for (ZuliaShard primary : primaryShardMap.values()) {
+			segmentReplicationManager.replicateAfterCommit(primary);
 		}
 	}
 

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
@@ -49,6 +49,8 @@ import io.zulia.server.index.federator.GetTermsRequestFederator;
 import io.zulia.server.index.federator.OptimizeRequestFederator;
 import io.zulia.server.index.federator.QueryRequestFederator;
 import io.zulia.server.index.federator.ReindexRequestFederator;
+import io.zulia.server.index.replication.ReplicationRateLimiter;
+import io.zulia.server.index.replication.ReplicationShardState;
 import io.zulia.server.index.router.DeleteRequestRouter;
 import io.zulia.server.index.router.FetchRequestRouter;
 import io.zulia.server.index.router.StoreRequestRouter;
@@ -101,12 +103,14 @@ public class ZuliaIndexManager {
 	private Collection<Node> currentOtherNodesActive = Collections.emptyList();
 	private final ConcurrentHashMap<String, Lock> indexUpdateMap = new ConcurrentHashMap<>();
 	private final ConcurrentHashMap<String, IndexAlias> indexAliasMap;
+	private final ReplicationRateLimiter replicationRateLimiter;
 
 	private static final int MONGO_DB_NAME_MAX_LENGTH = 63;
 
 	public ZuliaIndexManager(ZuliaConfig zuliaConfig, NodeService nodeService) throws Exception {
 
 		this.zuliaConfig = zuliaConfig;
+		this.replicationRateLimiter = new ReplicationRateLimiter(zuliaConfig.getReplicationMaxBytesPerSec());
 
 		this.thisNode = ZuliaNode.nodeFromConfig(zuliaConfig);
 		this.nodeService = nodeService;
@@ -200,7 +204,8 @@ public class ZuliaIndexManager {
 
 		DocumentStorage documentStorage = getDocumentStorage(serverIndexConfig);
 
-		ZuliaIndex zuliaIndex = new ZuliaIndex(zuliaConfig, serverIndexConfig, documentStorage, indexService, indexShardMapping);
+		ZuliaIndex zuliaIndex = new ZuliaIndex(zuliaConfig, serverIndexConfig, documentStorage, indexService, indexShardMapping, internalClient,
+				replicationRateLimiter);
 
 		indexMap.put(indexSettings.getIndexName(), zuliaIndex);
 
@@ -1004,7 +1009,11 @@ public class ZuliaIndexManager {
 		return null;
 	}
 
-	private ZuliaIndex getIndexFromName(String indexName) throws Exception {
+	public List<ReplicationShardState> getReplicationState(String indexName) throws Exception {
+		return getIndexFromName(indexName).getReplicationState();
+	}
+
+	public ZuliaIndex getIndexFromName(String indexName) throws Exception {
 		return lookupIndex(indexName, resolveSingleIndex(indexName));
 	}
 

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaShard.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaShard.java
@@ -41,14 +41,30 @@ public class ZuliaShard {
 	private HashSet<String> trackedIds;
 
 	private boolean unloaded;
+	private volatile boolean replicaNeedsWarming;
+	private volatile Runnable postCommitHook;
 
-	public ZuliaShard(ShardWriteManager shardWriteManager, boolean primary) throws Exception {
+	private final ShardReadManager shardReadManager;
 
-		this.primary = primary;
+	public ZuliaShard(ShardWriteManager shardWriteManager) throws Exception {
+
+		this.primary = true;
 		this.shardWriteManager = shardWriteManager;
+		this.shardReadManager = null;
 		this.shardNumber = shardWriteManager.getShardNumber();
 		this.indexName = shardWriteManager.getIndexConfig().getIndexName();
 		this.shardReaderManager = new ShardReaderManager(shardWriteManager.createShardReader());
+
+	}
+
+	public ZuliaShard(ShardReadManager shardReadManager) throws Exception {
+
+		this.primary = false;
+		this.shardWriteManager = null;
+		this.shardReadManager = shardReadManager;
+		this.shardNumber = shardReadManager.getShardNumber();
+		this.indexName = shardReadManager.getIndexConfig().getIndexName();
+		this.shardReaderManager = new ShardReaderManager(shardReadManager.createShardReader());
 
 	}
 
@@ -57,11 +73,13 @@ public class ZuliaShard {
 	}
 
 	public void updateIndexSettings() {
-		shardWriteManager.updateIndexSettings();
+		if (shardWriteManager != null) {
+			shardWriteManager.updateIndexSettings();
+		}
 	}
 
 	public int getShardNumber() {
-		return shardWriteManager.getShardNumber();
+		return shardNumber;
 	}
 
 	public ShardQueryResponse queryShard(ShardQuery shardQuery) throws Exception {
@@ -86,6 +104,15 @@ public class ZuliaShard {
 
 		shardWriteManager.commit();
 		shardReaderManager.maybeRefreshBlocking();
+
+		Runnable hook = postCommitHook;
+		if (hook != null) {
+			hook.run();
+		}
+	}
+
+	public void setPostCommitHook(Runnable postCommitHook) {
+		this.postCommitHook = postCommitHook;
 	}
 
 	public void tryIdleCommit() throws IOException {
@@ -98,6 +125,15 @@ public class ZuliaShard {
 
 	public void tryWarmSearches(ZuliaIndex zuliaIndex, boolean primary) {
 
+		if (shardWriteManager != null) {
+			tryWarmPrimary(zuliaIndex, primary);
+		}
+		else if (replicaNeedsWarming) {
+			tryWarmReplica(zuliaIndex);
+		}
+	}
+
+	private void tryWarmPrimary(ZuliaIndex zuliaIndex, boolean primary) {
 		long lastestShardTime = shardReaderManager.getLatestShardTime();
 		WarmInfo warmInfo = shardWriteManager.needsSearchWarming(lastestShardTime);
 		if (warmInfo.needsWarming()) {
@@ -112,7 +148,7 @@ public class ZuliaShard {
 
 			List<ZuliaServiceOuterClass.QueryRequest> warmingSearches = shardWriteManager.getIndexConfig().getWarmingSearches();
 			if (!warmingSearches.isEmpty()) {
-				warmSearches(zuliaIndex, primary, warmingSearches, warmInfo, lastestShardTime);
+				warmPrimarySearches(zuliaIndex, primary, warmingSearches, warmInfo, lastestShardTime);
 			}
 			else {
 				LOG.info("Refreshed index {}:s{} without warming searches", indexName, shardNumber);
@@ -121,7 +157,41 @@ public class ZuliaShard {
 		}
 	}
 
-	private void warmSearches(ZuliaIndex zuliaIndex, boolean primary, List<ZuliaServiceOuterClass.QueryRequest> warmingSearches, WarmInfo warmInfo,
+	private void tryWarmReplica(ZuliaIndex zuliaIndex) {
+		replicaNeedsWarming = false;
+
+		List<ZuliaServiceOuterClass.QueryRequest> warmingSearches = zuliaIndex.getIndexConfig().getWarmingSearches();
+		if (warmingSearches.isEmpty()) {
+			return;
+		}
+
+		LOG.info("Started warming replica searches for index {}:s{}", indexName, shardNumber);
+		EnumSet<PrimaryReplicaSettings> usesReplica = EnumSet.of(PrimaryReplicaSettings.REPLICA_ONLY, PrimaryReplicaSettings.PRIMARY_IF_AVAILABLE);
+
+		for (ZuliaServiceOuterClass.QueryRequest warmingSearch : warmingSearches) {
+			if (unloaded || replicaNeedsWarming) {
+				return;
+			}
+
+			PrimaryReplicaSettings primaryReplicaSettings = warmingSearch.getPrimaryReplicaSettings();
+			if (usesReplica.contains(primaryReplicaSettings)) {
+				try {
+					LOG.info("Warming replica search for index {}:s{} with label {}", indexName, shardNumber, warmingSearch.getSearchLabel());
+					Query query = zuliaIndex.getQuery(warmingSearch);
+					ShardQuery shardQuery = zuliaIndex.getShardQuery(query, warmingSearch, -1);
+					queryShard(shardQuery);
+				}
+				catch (Exception e) {
+					LOG.error("Warming replica search for index {}:s{} with label {}: {}", indexName, shardNumber, warmingSearch.getSearchLabel(),
+							e.getMessage());
+				}
+			}
+		}
+
+		LOG.info("Finished warming replica searches for index {}:s{}", indexName, shardNumber);
+	}
+
+	private void warmPrimarySearches(ZuliaIndex zuliaIndex, boolean primary, List<ZuliaServiceOuterClass.QueryRequest> warmingSearches, WarmInfo warmInfo,
 			long lastestShardTime) {
 
 		LOG.info("Started warming searching for index {}:s{}", indexName, shardNumber);
@@ -247,7 +317,12 @@ public class ZuliaShard {
 	public void close() throws IOException {
 		unloaded = true;
 		shardReaderManager.close();
-		shardWriteManager.close();
+		if (shardWriteManager != null) {
+			shardWriteManager.close();
+		}
+		if (shardReadManager != null) {
+			shardReadManager.close();
+		}
 	}
 
 	public void index(String uniqueId, long timestamp, DocumentContainer mongoDocument, DocumentContainer metadata) throws Exception {
@@ -381,6 +456,21 @@ public class ZuliaShard {
 		}
 		finally {
 			shardReaderManager.decRef(shardReader);
+		}
+	}
+
+	public ShardWriteManager getShardWriteManager() {
+		return shardWriteManager;
+	}
+
+	public ShardReadManager getShardReadManager() {
+		return shardReadManager;
+	}
+
+	public void refreshReaders() throws IOException {
+		shardReaderManager.maybeRefreshBlocking();
+		if (!primary) {
+			replicaNeedsWarming = true;
 		}
 	}
 

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/CommitSnapshot.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/CommitSnapshot.java
@@ -1,0 +1,91 @@
+package io.zulia.server.index.replication;
+
+import io.zulia.server.index.ShardWriteManager;
+import org.apache.lucene.index.IndexCommit;
+import org.apache.lucene.store.Directory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+
+
+record CommitSnapshot(ShardWriteManager writeManager, IndexCommit indexCommit, IndexCommit taxoCommit, Directory indexDirectory,
+		Collection<String> indexFiles, Directory taxoDirectory, Collection<String> taxoFiles, String indexName, int shardNumber) implements AutoCloseable {
+
+	private final static Logger LOG = LoggerFactory.getLogger(CommitSnapshot.class);
+
+	static CommitSnapshot tryTake(ShardWriteManager writeManager, String indexName, int shardNumber) throws IOException {
+		IndexCommit indexCommit;
+		try {
+			indexCommit = writeManager.snapshotIndex();
+		}
+		catch (IllegalStateException noCommitYet) {
+			LOG.debug("Skipping replication for {}:s{}: {}", indexName, shardNumber, noCommitYet.getMessage());
+			return new CommitSnapshot(writeManager, null, null, null, null, null, null, indexName, shardNumber);
+		}
+		// snapshotIndex pins indexCommit; release on failure or it leaks into SnapshotDeletionPolicy.
+		IndexCommit taxoCommit = null;
+		try {
+			boolean hasTaxonomy = writeManager.hasTaxonomy();
+			if (hasTaxonomy) {
+				taxoCommit = writeManager.snapshotTaxo();
+			}
+			Collection<String> indexFiles = indexCommit.getFileNames();
+			Collection<String> taxoFiles = hasTaxonomy ? taxoCommit.getFileNames() : null;
+			return new CommitSnapshot(writeManager, indexCommit, taxoCommit, writeManager.getIndexDirectory(), indexFiles,
+					hasTaxonomy ? writeManager.getTaxoDirectory() : null, taxoFiles, indexName, shardNumber);
+		}
+		catch (IOException | RuntimeException e) {
+			releaseAfterFailure(writeManager, indexCommit, taxoCommit, indexName, shardNumber, e);
+			throw e;
+		}
+	}
+
+	private static void releaseAfterFailure(ShardWriteManager writeManager, IndexCommit indexCommit, IndexCommit taxoCommit, String indexName, int shardNumber,
+			Exception primaryException) {
+		if (taxoCommit != null) {
+			try {
+				writeManager.releaseTaxoSnapshot(taxoCommit);
+			}
+			catch (Exception suppressed) {
+				primaryException.addSuppressed(suppressed);
+			}
+		}
+		try {
+			writeManager.releaseSnapshot(indexCommit);
+		}
+		catch (Exception suppressed) {
+			primaryException.addSuppressed(suppressed);
+		}
+		LOG.warn("Released snapshot for {}:s{} after take failure: {}", indexName, shardNumber, primaryException.getMessage());
+	}
+
+	boolean isEmpty() {
+		return indexCommit == null;
+	}
+
+	long generation() {
+		return indexCommit.getGeneration();
+	}
+
+	@Override
+	public void close() {
+		if (taxoCommit != null) {
+			try {
+				writeManager.releaseTaxoSnapshot(taxoCommit);
+			}
+			catch (Exception e) {
+				LOG.warn("Failed to release taxonomy snapshot for {}:s{}", indexName, shardNumber, e);
+			}
+		}
+		if (indexCommit != null) {
+			try {
+				writeManager.releaseSnapshot(indexCommit);
+			}
+			catch (Exception e) {
+				LOG.warn("Failed to release index snapshot for {}:s{}", indexName, shardNumber, e);
+			}
+		}
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/DirectSegmentReplicator.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/DirectSegmentReplicator.java
@@ -1,0 +1,97 @@
+package io.zulia.server.index.replication;
+
+import com.google.protobuf.UnsafeByteOperations;
+import io.grpc.stub.ClientCallStreamObserver;
+import io.zulia.message.ZuliaBase.Node;
+import io.zulia.message.ZuliaServiceOuterClass.GetSegmentFileInfoRequest;
+import io.zulia.message.ZuliaServiceOuterClass.GetSegmentFileInfoResponse;
+import io.zulia.message.ZuliaServiceOuterClass.SegmentFileData;
+import io.zulia.message.ZuliaServiceOuterClass.SegmentFileInfo;
+import io.zulia.message.ZuliaServiceOuterClass.SendSegmentFilesResponse;
+import io.zulia.server.connection.client.InternalClient;
+import io.zulia.server.connection.client.InternalRpcConnection;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+public class DirectSegmentReplicator {
+
+	private static final long INFO_TIMEOUT_SECONDS = 30;
+
+	private static final String COMPRESSION = "gzip";
+
+	private final InternalClient internalClient;
+	private final Node replicaNode;
+	private final long responseTimeoutMinutes;
+	private final ReplicationRateLimiter rateLimiter;
+
+	public DirectSegmentReplicator(InternalClient internalClient, Node replicaNode, long responseTimeoutMinutes, ReplicationRateLimiter rateLimiter) {
+		this.internalClient = internalClient;
+		this.replicaNode = replicaNode;
+		this.responseTimeoutMinutes = responseTimeoutMinutes;
+		this.rateLimiter = rateLimiter;
+	}
+
+	public GetSegmentFileInfoResponse getSegmentFileInfo(String indexName, int shardNumber, boolean taxonomy) throws Exception {
+		InternalRpcConnection rpcConnection = internalClient.getConnection(replicaNode);
+		GetSegmentFileInfoRequest request = GetSegmentFileInfoRequest.newBuilder().setIndexName(indexName).setShardNumber(shardNumber).setTaxonomy(taxonomy)
+				.build();
+		// Bounded deadline so a hung replica can't hold the primary's shard lock indefinitely.
+		return rpcConnection.getService().withCompression(COMPRESSION).withDeadlineAfter(INFO_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+				.internalGetSegmentFileInfo(request);
+	}
+
+	public SendSegmentFilesResponse sendSegmentFiles(String indexName, int shardNumber, boolean taxonomy, List<SegmentFileInfo> filesToSend,
+			Directory sourceDirectory, long generation) throws Exception {
+
+		InternalRpcConnection rpcConnection = internalClient.getConnection(replicaNode);
+
+		SendResponseObserver responseObserver = new SendResponseObserver();
+
+		// Deadline on the call (not just responseFuture.get) so expiry cancels the stream and completes exceptionally.
+		ClientCallStreamObserver<SegmentFileData> requestObserver = (ClientCallStreamObserver<SegmentFileData>) rpcConnection.getAsyncService()
+				.withCompression(COMPRESSION).withDeadlineAfter(responseTimeoutMinutes, TimeUnit.MINUTES).internalSendSegmentFiles(responseObserver);
+
+		try {
+			for (SegmentFileInfo fileInfo : filesToSend) {
+				String fileName = fileInfo.getFileName();
+				try (IndexInput input = sourceDirectory.openInput(fileName, IOContext.READONCE)) {
+					long remaining = input.length();
+
+					while (remaining > 0) {
+						int toRead = (int) Math.min(ReplicationLimits.CHUNK_SIZE, remaining);
+						// Acquire byte permits before the disk read so a stalled rate limiter doesn't pin a buffer.
+						rateLimiter.acquire(toRead);
+						// Fresh byte[] each chunk: unsafeWrap takes ownership, so the buffer must not be mutated after.
+						byte[] buffer = new byte[toRead];
+						input.readBytes(buffer, 0, toRead);
+						remaining -= toRead;
+
+						responseObserver.awaitReady(requestObserver);
+
+						SegmentFileData chunk = SegmentFileData.newBuilder().setIndexName(indexName).setShardNumber(shardNumber).setTaxonomy(taxonomy)
+								.setFileName(fileName).setData(UnsafeByteOperations.unsafeWrap(buffer)).setGeneration(generation)
+								.setLastChunk(remaining == 0).build();
+
+						requestObserver.onNext(chunk);
+					}
+				}
+			}
+			requestObserver.onCompleted();
+		}
+		catch (Exception e) {
+			try {
+				requestObserver.onError(e);
+			}
+			catch (Exception suppressed) {
+				e.addSuppressed(suppressed);
+			}
+			throw e;
+		}
+
+		return responseObserver.await(responseTimeoutMinutes, TimeUnit.MINUTES);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/PublishRequest.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/PublishRequest.java
@@ -1,0 +1,10 @@
+package io.zulia.server.index.replication;
+
+import io.zulia.message.ZuliaBase.Node;
+import org.apache.lucene.store.Directory;
+
+import java.util.Collection;
+
+public record PublishRequest(String indexName, int shardNumber, Node replicaNode, Directory sourceDirectory, Collection<String> sourceFiles, long generation,
+		boolean taxonomy) {
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/PushSegmentPublisher.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/PushSegmentPublisher.java
@@ -1,0 +1,141 @@
+package io.zulia.server.index.replication;
+
+import io.zulia.message.ZuliaBase.Node;
+import io.zulia.message.ZuliaServiceOuterClass.GetSegmentFileInfoResponse;
+import io.zulia.message.ZuliaServiceOuterClass.SegmentFileInfo;
+import io.zulia.server.connection.client.InternalClient;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.util.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class PushSegmentPublisher implements SegmentPublisher {
+
+	private final static Logger LOG = LoggerFactory.getLogger(PushSegmentPublisher.class);
+
+	private final InternalClient internalClient;
+	private final int responseTimeoutMinutes;
+	private final ReplicationRateLimiter rateLimiter;
+
+	public PushSegmentPublisher(InternalClient internalClient, int responseTimeoutMinutes, ReplicationRateLimiter rateLimiter) {
+		this.internalClient = internalClient;
+		this.responseTimeoutMinutes = responseTimeoutMinutes;
+		this.rateLimiter = rateLimiter;
+	}
+
+	@Override
+	public void publish(PublishRequest request) throws Exception {
+		Node replicaNode = request.replicaNode();
+		int shardNumber = request.shardNumber();
+		String indexName = request.indexName();
+		boolean taxonomy = request.taxonomy();
+		Directory sourceDirectory = request.sourceDirectory();
+		long generation = request.generation();
+
+		DirectSegmentReplicator replicator = new DirectSegmentReplicator(internalClient, replicaNode, responseTimeoutMinutes, rateLimiter);
+
+		GetSegmentFileInfoResponse replicaInfo = replicator.getSegmentFileInfo(indexName, shardNumber, taxonomy);
+		checkLuceneVersion(replicaInfo, replicaNode);
+		Map<String, SegmentFileInfo> replicaFileMap = indexByName(replicaInfo);
+
+		Map<String, ReplicaFileInfo> sourceInfos = readSourceInfos(sourceDirectory, request.sourceFiles(), indexName, shardNumber);
+
+		// Segment names are per-index, so equal length does not imply equal content; if segments_N differs, ship all.
+		boolean segmentsHeaderDiffers = segmentsHeaderDiffers(sourceInfos, replicaFileMap);
+
+		List<SegmentFileInfo> filesToSend = new ArrayList<>(sourceInfos.size());
+		for (Map.Entry<String, ReplicaFileInfo> entry : sourceInfos.entrySet()) {
+			String name = entry.getKey();
+			ReplicaFileInfo info = entry.getValue();
+			SegmentFileInfo existing = replicaFileMap.get(name);
+			boolean shouldSend = segmentsHeaderDiffers || existing == null || existing.getLength() != info.length();
+			if (shouldSend) {
+				filesToSend.add(SegmentFileInfo.newBuilder().setFileName(name).setLength(info.length()).setChecksum(info.checksum()).build());
+			}
+		}
+
+		if (filesToSend.isEmpty()) {
+			LOG.debug("No files to replicate for {}:s{} {} to {}:{}", indexName, shardNumber, taxonomy ? "taxonomy" : "index", replicaNode.getServerAddress(),
+					replicaNode.getServicePort());
+			return;
+		}
+
+		// segments_N must be sent last, so a mid-stream refresh on the replica can't see a commit pointing at
+		// files it doesn't have yet. SegmentInfos.files() returns a HashSet, so it needs a sort to put it last
+		filesToSend.sort(Comparator.comparing(info -> ReplicationUtil.isSegmentsFile(info.getFileName())));
+
+		LOG.info("Replicating {} files for {}:s{} {} to {}:{}", filesToSend.size(), indexName, shardNumber, taxonomy ? "taxonomy" : "index",
+				replicaNode.getServerAddress(), replicaNode.getServicePort());
+
+		replicator.sendSegmentFiles(indexName, shardNumber, taxonomy, filesToSend, sourceDirectory, generation);
+
+		LOG.info("Completed replication for {}:s{} {} to {}:{} at generation {}", indexName, shardNumber, taxonomy ? "taxonomy" : "index",
+				replicaNode.getServerAddress(), replicaNode.getServicePort(), generation);
+	}
+
+	// Replica Lucene must be >= primary; Lucene is not forward-compatible. Fail fast before bytes hit disk.
+	private static void checkLuceneVersion(GetSegmentFileInfoResponse replicaInfo, Node replicaNode) throws ReplicationStreamException {
+		Version primaryVersion = Version.LATEST;
+		String replicaVersionStr = replicaInfo.getLuceneVersion();
+		String replicaAddress = replicaNode.getServerAddress() + ":" + replicaNode.getServicePort();
+		if (replicaVersionStr.isEmpty()) {
+			throw new ReplicationStreamException("Replica " + replicaAddress + " did not report a Lucene version; refusing to replicate");
+		}
+		Version replicaVersion;
+		try {
+			replicaVersion = Version.parse(replicaVersionStr);
+		}
+		catch (ParseException e) {
+			throw new ReplicationStreamException("Replica " + replicaAddress + " reported unparseable Lucene version '" + replicaVersionStr + "'");
+		}
+		if (!replicaVersion.onOrAfter(primaryVersion)) {
+			throw new ReplicationStreamException(
+					"Replica " + replicaAddress + " is on Lucene " + replicaVersionStr + " but primary is on " + primaryVersion
+							+ "; replica must be at or newer than primary (upgrade replicas first during a rolling upgrade)");
+		}
+	}
+
+	private static Map<String, SegmentFileInfo> indexByName(GetSegmentFileInfoResponse replicaInfo) {
+		Map<String, SegmentFileInfo> result = new LinkedHashMap<>(Math.max(16, replicaInfo.getFilesCount() * 2));
+		for (SegmentFileInfo fileInfo : replicaInfo.getFilesList()) {
+			result.put(fileInfo.getFileName(), fileInfo);
+		}
+		return result;
+	}
+
+	private static Map<String, ReplicaFileInfo> readSourceInfos(Directory sourceDirectory, Collection<String> sourceFiles, String indexName, int shardNumber)
+			throws IOException {
+		Map<String, ReplicaFileInfo> result = new LinkedHashMap<>(Math.max(16, sourceFiles.size() * 2));
+		for (String sourceFile : sourceFiles) {
+			ReplicaFileInfo info = ReplicationUtil.readFileInfo(sourceDirectory, sourceFile);
+			if (info == null) {
+				throw new IOException("Source file " + sourceFile + " is unreadable from a held snapshot for " + indexName + ":s" + shardNumber);
+			}
+			result.put(sourceFile, info);
+		}
+		return result;
+	}
+
+	private static boolean segmentsHeaderDiffers(Map<String, ReplicaFileInfo> sourceInfos, Map<String, SegmentFileInfo> replicaFileMap) {
+		for (Map.Entry<String, ReplicaFileInfo> entry : sourceInfos.entrySet()) {
+			if (!ReplicationUtil.isSegmentsFile(entry.getKey())) {
+				continue;
+			}
+			ReplicaFileInfo info = entry.getValue();
+			SegmentFileInfo existing = replicaFileMap.get(entry.getKey());
+			if (existing == null || existing.getLength() != info.length() || !existing.getChecksum().equals(info.checksum())) {
+				return true;
+			}
+		}
+		return false;
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaDirectoryApplier.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaDirectoryApplier.java
@@ -1,0 +1,122 @@
+package io.zulia.server.index.replication;
+
+import io.zulia.server.index.ShardReadManager;
+import io.zulia.server.index.ZuliaShard;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexOutput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.NoSuchFileException;
+import java.util.List;
+
+public class ReplicaDirectoryApplier {
+
+	private final static Logger LOG = LoggerFactory.getLogger(ReplicaDirectoryApplier.class);
+
+	// Not "segments-" so SegmentInfos cannot pick a half-written pending file as a candidate commit.
+	private static final String PENDING_PREFIX = "pending-";
+
+	private final ZuliaShard replicaShard;
+
+	private IndexOutput currentOutput;
+	private Directory currentDirectory;
+	private String currentLogicalName;
+	private String currentWriteName;
+
+	public ReplicaDirectoryApplier(ZuliaShard replicaShard) {
+		if (replicaShard == null || replicaShard.getShardReadManager() == null) {
+			throw new IllegalArgumentException("Replica shard must have a ShardReadManager (got " + replicaShard + ")");
+		}
+		this.replicaShard = replicaShard;
+	}
+
+	public void writeBytes(boolean taxonomy, String fileName, byte[] data, int offset, int length) throws IOException {
+		ensureOpen(taxonomy, fileName);
+		currentOutput.writeBytes(data, offset, length);
+	}
+
+	public void finishFile() throws IOException {
+		if (currentOutput == null) {
+			return;
+		}
+		try {
+			currentOutput.close();
+		}
+		finally {
+			currentOutput = null;
+		}
+		if (ReplicationUtil.isSegmentsFile(currentLogicalName)) {
+			currentDirectory.sync(List.of(currentWriteName));
+			currentDirectory.rename(currentWriteName, currentLogicalName);
+			currentDirectory.syncMetaData();
+		}
+		currentLogicalName = null;
+		currentWriteName = null;
+		currentDirectory = null;
+	}
+
+	// Throws on refresh failure so the caller does not advance the generation marker and old reader files stay valid.
+	public void commit() throws IOException {
+		try {
+			replicaShard.refreshReaders();
+		}
+		catch (Exception e) {
+			throw new IOException("refreshReaders failed for " + replicaShard + ":s" + replicaShard.getShardNumber(), e);
+		}
+
+		ShardReadManager readManager = replicaShard.getShardReadManager();
+		if (readManager != null) {
+			readManager.cleanupUnreferencedFiles();
+		}
+	}
+
+	public void abort() {
+		if (currentOutput != null) {
+			try {
+				currentOutput.close();
+			}
+			catch (Exception ignored) {
+			}
+			currentOutput = null;
+		}
+		currentLogicalName = null;
+		currentWriteName = null;
+		currentDirectory = null;
+	}
+
+	private void ensureOpen(boolean taxonomy, String fileName) throws IOException {
+		if (currentOutput != null && fileName.equals(currentLogicalName)) {
+			return;
+		}
+		if (currentOutput != null) {
+			finishFile();
+		}
+
+		ShardReadManager readManager = replicaShard.getShardReadManager();
+		Directory directory = taxonomy ? readManager.getTaxoDirectory() : readManager.getIndexDirectory();
+		boolean segmentsFile = ReplicationUtil.isSegmentsFile(fileName);
+		String writeName = segmentsFile ? PENDING_PREFIX + fileName : fileName;
+
+		// createOutput is CREATE_NEW; clear any stale pending file or bootstrap segment with the same name.
+		deleteIfExists(directory, writeName);
+
+		currentDirectory = directory;
+		currentLogicalName = fileName;
+		currentWriteName = writeName;
+		currentOutput = directory.createOutput(writeName, IOContext.DEFAULT);
+	}
+
+	private static void deleteIfExists(Directory directory, String fileName) {
+		try {
+			directory.deleteFile(fileName);
+		}
+		catch (NoSuchFileException e) {
+		}
+		catch (Exception e) {
+			LOG.debug("Could not remove stale pending file {}: {}", fileName, e.getMessage());
+		}
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaFileInfo.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaFileInfo.java
@@ -1,0 +1,4 @@
+package io.zulia.server.index.replication;
+
+public record ReplicaFileInfo(String name, long length, String checksum) {
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaReplicationState.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaReplicationState.java
@@ -1,0 +1,8 @@
+package io.zulia.server.index.replication;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+@Serdeable
+public record ReplicaReplicationState(String serverAddress, int servicePort, Long lastReplicatedGeneration, Long lagGenerations, Long lastSuccessMs,
+		Long msSinceLastSuccess, int consecutiveFailures, boolean circuitOpen, long backoffUntilMs) {
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaShardKey.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaShardKey.java
@@ -1,0 +1,10 @@
+package io.zulia.server.index.replication;
+
+import io.zulia.message.ZuliaBase.Node;
+
+public record ReplicaShardKey(String serverAddress, int servicePort, int shardNumber) {
+
+	public static ReplicaShardKey of(Node replicaNode, int shardNumber) {
+		return new ReplicaShardKey(replicaNode.getServerAddress(), replicaNode.getServicePort(), shardNumber);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaState.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicaState.java
@@ -1,0 +1,52 @@
+package io.zulia.server.index.replication;
+
+class ReplicaState {
+
+	private static final int FAILURE_THRESHOLD = 3;
+	private static final long BASE_BACKOFF_MS = 10_000;
+	private static final long MAX_BACKOFF_MS = 5 * 60_000;
+
+	static final Snapshot EMPTY_SNAPSHOT = new Snapshot(null, null, 0, false, 0);
+
+	private Long generation;
+	private Long lastSuccessMs;
+	private int consecutiveFailures;
+	private long backoffUntilMs;
+
+	synchronized boolean isCircuitOpen() {
+		return backoffUntilMs > System.currentTimeMillis();
+	}
+
+	synchronized Long getGeneration() {
+		return generation;
+	}
+
+	synchronized void recordSuccess(long replicatedGeneration) {
+		this.generation = replicatedGeneration;
+		this.lastSuccessMs = System.currentTimeMillis();
+		this.consecutiveFailures = 0;
+		this.backoffUntilMs = 0;
+	}
+
+	synchronized FailureOutcome recordFailure() {
+		consecutiveFailures++;
+		long openedBackoffMs = 0;
+		if (consecutiveFailures >= FAILURE_THRESHOLD) {
+			int exponent = consecutiveFailures - FAILURE_THRESHOLD;
+			openedBackoffMs = Math.min(MAX_BACKOFF_MS, BASE_BACKOFF_MS << Math.min(exponent, 10));
+			backoffUntilMs = System.currentTimeMillis() + openedBackoffMs;
+		}
+		return new FailureOutcome(consecutiveFailures, openedBackoffMs);
+	}
+
+	synchronized Snapshot snapshot(long now) {
+		return new Snapshot(generation, lastSuccessMs, consecutiveFailures, backoffUntilMs > now, backoffUntilMs);
+	}
+
+	// openedBackoffMs is 0 unless this failure (re-)opened the breaker, in which case it is the new backoff.
+	record FailureOutcome(int consecutiveFailures, long openedBackoffMs) {
+	}
+
+	record Snapshot(Long generation, Long lastSuccessMs, int consecutiveFailures, boolean circuitOpen, long backoffUntilMs) {
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationLimits.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationLimits.java
@@ -1,0 +1,11 @@
+package io.zulia.server.index.replication;
+
+public final class ReplicationLimits {
+
+	public static final int CHUNK_SIZE = 1024 * 1024;
+	// Receiver cap; kept above CHUNK_SIZE so a sender bump does not require a coordinated receiver release.
+	public static final int MAX_CHUNK_BYTES = 8 * 1024 * 1024;
+
+	private ReplicationLimits() {
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationRateLimiter.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationRateLimiter.java
@@ -1,0 +1,43 @@
+package io.zulia.server.index.replication;
+
+public class ReplicationRateLimiter {
+
+	private final long bytesPerSecond;
+	private long availableBytes;
+	private long lastRefillNanos;
+
+	public ReplicationRateLimiter(long bytesPerSecond) {
+		this.bytesPerSecond = bytesPerSecond;
+		this.availableBytes = Math.max(0, bytesPerSecond);
+		this.lastRefillNanos = System.nanoTime();
+	}
+
+	public synchronized void acquire(int bytes) throws InterruptedException {
+		if (bytesPerSecond <= 0 || bytes <= 0) {
+			return;
+		}
+		while (true) {
+			refill();
+			if (availableBytes >= bytes) {
+				availableBytes -= bytes;
+				return;
+			}
+			long needed = bytes - availableBytes;
+			long waitMs = Math.max(1, (needed * 1000L) / bytesPerSecond);
+			wait(waitMs);
+		}
+	}
+
+	private void refill() {
+		long now = System.nanoTime();
+		long elapsedNanos = now - lastRefillNanos;
+		if (elapsedNanos <= 0) {
+			return;
+		}
+		long add = (elapsedNanos * bytesPerSecond) / 1_000_000_000L;
+		if (add > 0) {
+			availableBytes = Math.min(bytesPerSecond, availableBytes + add);
+			lastRefillNanos = now;
+		}
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationShardState.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationShardState.java
@@ -1,0 +1,9 @@
+package io.zulia.server.index.replication;
+
+import io.micronaut.serde.annotation.Serdeable;
+
+import java.util.List;
+
+@Serdeable
+public record ReplicationShardState(int shardNumber, Long lastAttemptedGeneration, List<ReplicaReplicationState> replicas) {
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationStreamException.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationStreamException.java
@@ -1,0 +1,10 @@
+package io.zulia.server.index.replication;
+
+import java.io.IOException;
+
+public class ReplicationStreamException extends IOException {
+
+	public ReplicationStreamException(String message) {
+		super(message);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationUtil.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ReplicationUtil.java
@@ -1,0 +1,41 @@
+package io.zulia.server.index.replication;
+
+import org.apache.lucene.codecs.CodecUtil;
+import org.apache.lucene.index.IndexFileNames;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class ReplicationUtil {
+
+	private final static Logger LOG = LoggerFactory.getLogger(ReplicationUtil.class);
+
+	private ReplicationUtil() {
+	}
+
+	public static boolean isSegmentsFile(String fileName) {
+		return fileName != null && fileName.startsWith(IndexFileNames.SEGMENTS);
+	}
+
+	// Returns null if the file disappears or is unreadable; caller decides skip vs fail.
+	public static ReplicaFileInfo readFileInfo(Directory directory, String fileName) {
+		try {
+			long length = directory.fileLength(fileName);
+			String checksum = "";
+			if (isSegmentsFile(fileName)) {
+				try (IndexInput input = directory.openInput(fileName, IOContext.READONCE)) {
+					checksum = Long.toHexString(CodecUtil.retrieveChecksum(input));
+				}
+			}
+			return new ReplicaFileInfo(fileName, length, checksum);
+		}
+		catch (IOException e) {
+			LOG.warn("Failed to read file info for {}: {}", fileName, e.getMessage());
+			return null;
+		}
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/SegmentPublisher.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/SegmentPublisher.java
@@ -1,0 +1,9 @@
+package io.zulia.server.index.replication;
+
+public interface SegmentPublisher {
+
+	void publish(PublishRequest request) throws Exception;
+
+	default void close() {
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/SegmentReplicationManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/SegmentReplicationManager.java
@@ -1,0 +1,259 @@
+package io.zulia.server.index.replication;
+
+import io.zulia.message.ZuliaBase.Node;
+import io.zulia.message.ZuliaIndex.IndexShardMapping;
+import io.zulia.message.ZuliaIndex.ShardMapping;
+import io.zulia.server.connection.client.InternalClient;
+import io.zulia.server.index.ShardWriteManager;
+import io.zulia.server.index.ZuliaShard;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+public class SegmentReplicationManager {
+
+	private final static Logger LOG = LoggerFactory.getLogger(SegmentReplicationManager.class);
+
+	private static final int MAX_CONCURRENT_REPLICATIONS = 4;
+	private static final int SHUTDOWN_TIMEOUT_SECONDS = 30;
+	private static final long CHILD_INTERRUPT_DRAIN_SECONDS = 5;
+
+	private final SegmentPublisher publisher;
+	private final IndexShardMapping indexShardMapping;
+	private final String indexName;
+	private final boolean hasAnyReplicas;
+	private final Map<Integer, List<Node>> replicaNodesByShard;
+
+	private final Map<Integer, ShardState> shardStates = new ConcurrentHashMap<>();
+	private final Map<ReplicaShardKey, ReplicaState> replicaStates = new ConcurrentHashMap<>();
+
+	private final Semaphore replicationSemaphore = new Semaphore(MAX_CONCURRENT_REPLICATIONS);
+	private final ExecutorService replicationExecutor = Executors.newVirtualThreadPerTaskExecutor();
+	private volatile boolean shutdown = false;
+
+	public SegmentReplicationManager(InternalClient internalClient, IndexShardMapping indexShardMapping, String indexName, int responseTimeoutMinutes,
+			ReplicationRateLimiter rateLimiter) {
+		this(new PushSegmentPublisher(internalClient, responseTimeoutMinutes, rateLimiter), indexShardMapping, indexName);
+	}
+
+	public SegmentReplicationManager(SegmentPublisher publisher, IndexShardMapping indexShardMapping, String indexName) {
+		this.publisher = publisher;
+		this.indexShardMapping = indexShardMapping;
+		this.indexName = indexName;
+		this.replicaNodesByShard = indexShardMapping.getShardMappingList().stream()
+				.collect(Collectors.toUnmodifiableMap(ShardMapping::getShardNumber, ShardMapping::getReplicaNodeList));
+		this.hasAnyReplicas = replicaNodesByShard.values().stream().anyMatch(l -> !l.isEmpty());
+	}
+
+	public void replicateAfterCommit(ZuliaShard primaryShard) {
+		if (shutdown || !hasAnyReplicas || getReplicaNodes(primaryShard.getShardNumber()).isEmpty()) {
+			return;
+		}
+
+		try {
+			replicationExecutor.submit(() -> {
+				try {
+					replicationSemaphore.acquire();
+					try {
+						doReplicate(primaryShard);
+					}
+					finally {
+						replicationSemaphore.release();
+					}
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					LOG.warn("Replication interrupted for {}:s{}", indexName, primaryShard.getShardNumber());
+				}
+				catch (Exception e) {
+					LOG.error("Failed to replicate {}:s{}", indexName, primaryShard.getShardNumber(), e);
+				}
+			});
+		}
+		catch (RejectedExecutionException e) {
+			// Shutdown race: hook fires on the commit path and must not propagate. Watchdog will retry.
+			LOG.debug("Replication rejected for {}:s{} during shutdown", indexName, primaryShard.getShardNumber());
+		}
+	}
+
+	// Catches replicas that flapped or fell behind during quiet periods with no commit hook.
+	public void watchdogTick(Iterable<ZuliaShard> primaryShards) {
+		if (shutdown || !hasAnyReplicas) {
+			return;
+		}
+		for (ZuliaShard primary : primaryShards) {
+			replicateAfterCommit(primary);
+		}
+	}
+
+	public void shutdown() {
+		shutdown = true;
+		replicationExecutor.shutdown();
+		try {
+			if (!replicationExecutor.awaitTermination(SHUTDOWN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+				LOG.warn("Replication tasks for {} did not complete in {} seconds, forcing shutdown", indexName, SHUTDOWN_TIMEOUT_SECONDS);
+				replicationExecutor.shutdownNow();
+				if (!replicationExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+					LOG.error("Replication tasks for {} did not terminate after forced shutdown", indexName);
+				}
+			}
+		}
+		catch (InterruptedException e) {
+			replicationExecutor.shutdownNow();
+			Thread.currentThread().interrupt();
+		}
+		try {
+			publisher.close();
+		}
+		catch (Exception e) {
+			LOG.warn("Publisher close failed for {}", indexName, e);
+		}
+		LOG.info("Segment replication manager shut down for {}", indexName);
+	}
+
+	private void doReplicate(ZuliaShard primaryShard) throws Exception {
+		if (shutdown) {
+			return;
+		}
+
+		ShardWriteManager writeManager = primaryShard.getShardWriteManager();
+		if (writeManager == null) {
+			return;
+		}
+
+		int shardNumber = primaryShard.getShardNumber();
+		List<Node> replicaNodes = getReplicaNodes(shardNumber);
+		if (replicaNodes.isEmpty()) {
+			return;
+		}
+
+		ShardState shardState = shardStates.computeIfAbsent(shardNumber, k -> new ShardState());
+		shardState.getLock().lockInterruptibly();
+		try (CommitSnapshot snapshot = CommitSnapshot.tryTake(writeManager, indexName, shardNumber)) {
+			if (snapshot.isEmpty()) {
+				return;
+			}
+
+			long generation = snapshot.generation();
+			Long lastAttempted = shardState.getLastAttemptedGeneration();
+			if (lastAttempted != null && lastAttempted >= generation && allReplicasAtOrAfter(shardNumber, replicaNodes, generation)) {
+				return;
+			}
+
+			List<Thread> threads = new ArrayList<>(replicaNodes.size());
+			for (Node replicaNode : replicaNodes) {
+				Thread thread = Thread.ofVirtual().name(indexName + ":s" + shardNumber + "-replicate-" + replicaNode.getServerAddress() + ":"
+						+ replicaNode.getServicePort()).start(() -> replicateToReplica(shardNumber, replicaNode, snapshot, generation));
+				threads.add(thread);
+			}
+			joinAll(threads);
+
+			// Advance unconditionally; allReplicasAtOrAfter at the top of the method forces retry for laggards.
+			shardState.setLastAttemptedGeneration(generation);
+		}
+		finally {
+			shardState.getLock().unlock();
+		}
+	}
+
+	// Taxonomy publishes before index: new-taxo/old-index is safe, new-index/old-taxo fails ordinal lookup.
+	private void replicateToReplica(int shardNumber, Node replicaNode, CommitSnapshot snapshot, long generation) {
+		ReplicaShardKey key = ReplicaShardKey.of(replicaNode, shardNumber);
+		ReplicaState state = replicaStates.computeIfAbsent(key, k -> new ReplicaState());
+		if (state.isCircuitOpen()) {
+			LOG.debug("Circuit open for {}:s{} to {}:{}, skipping replication", indexName, shardNumber, replicaNode.getServerAddress(),
+					replicaNode.getServicePort());
+			return;
+		}
+		try {
+			if (snapshot.taxoDirectory() != null) {
+				publisher.publish(new PublishRequest(indexName, shardNumber, replicaNode, snapshot.taxoDirectory(), snapshot.taxoFiles(), generation, true));
+			}
+			publisher.publish(new PublishRequest(indexName, shardNumber, replicaNode, snapshot.indexDirectory(), snapshot.indexFiles(), generation, false));
+			state.recordSuccess(generation);
+		}
+		catch (Exception e) {
+			ReplicaState.FailureOutcome outcome = state.recordFailure();
+			if (outcome.openedBackoffMs() > 0) {
+				LOG.warn("Circuit opened for {}: {} consecutive failures, backing off {}ms", key, outcome.consecutiveFailures(), outcome.openedBackoffMs());
+			}
+			LOG.warn("Failed to replicate {}:s{} to {}:{}: {}", indexName, shardNumber, replicaNode.getServerAddress(), replicaNode.getServicePort(),
+					e.getMessage());
+		}
+	}
+
+	private boolean allReplicasAtOrAfter(int shardNumber, List<Node> replicaNodes, long generation) {
+		for (Node node : replicaNodes) {
+			ReplicaState state = replicaStates.get(ReplicaShardKey.of(node, shardNumber));
+			Long replicaGen = (state == null) ? null : state.getGeneration();
+			if (replicaGen == null || replicaGen < generation) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// On interrupt, drain children before returning; the finally above releases the IndexCommit they read from.
+	private void joinAll(List<Thread> threads) {
+		try {
+			for (Thread thread : threads) {
+				thread.join();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			for (Thread t : threads) {
+				t.interrupt();
+			}
+			long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(CHILD_INTERRUPT_DRAIN_SECONDS);
+			for (Thread t : threads) {
+				long remainingNanos = deadlineNanos - System.nanoTime();
+				if (remainingNanos <= 0) {
+					break;
+				}
+				try {
+					t.join(TimeUnit.NANOSECONDS.toMillis(remainingNanos));
+				}
+				catch (InterruptedException ignored) {
+					break;
+				}
+			}
+		}
+	}
+
+	private List<Node> getReplicaNodes(int shardNumber) {
+		return replicaNodesByShard.getOrDefault(shardNumber, List.of());
+	}
+
+	public List<ReplicationShardState> getReplicationState() {
+		List<ReplicationShardState> result = new ArrayList<>(replicaNodesByShard.size());
+		long now = System.currentTimeMillis();
+		for (ShardMapping shardMapping : indexShardMapping.getShardMappingList()) {
+			int shardNumber = shardMapping.getShardNumber();
+			ShardState shardState = shardStates.get(shardNumber);
+			Long primaryGen = (shardState == null) ? null : shardState.getLastAttemptedGeneration();
+			List<ReplicaReplicationState> replicaSnapshots = new ArrayList<>(shardMapping.getReplicaNodeList().size());
+			for (Node replicaNode : shardMapping.getReplicaNodeList()) {
+				ReplicaState state = replicaStates.get(ReplicaShardKey.of(replicaNode, shardNumber));
+				ReplicaState.Snapshot snap = (state == null) ? ReplicaState.EMPTY_SNAPSHOT : state.snapshot(now);
+				Long lagGenerations = (primaryGen != null && snap.generation() != null) ? primaryGen - snap.generation() : null;
+				Long msSinceLastSuccess = (snap.lastSuccessMs() != null) ? now - snap.lastSuccessMs() : null;
+				replicaSnapshots.add(new ReplicaReplicationState(replicaNode.getServerAddress(), replicaNode.getServicePort(), snap.generation(), lagGenerations,
+						snap.lastSuccessMs(), msSinceLastSuccess, snap.consecutiveFailures(), snap.circuitOpen(), snap.backoffUntilMs()));
+			}
+			result.add(new ReplicationShardState(shardNumber, primaryGen, Collections.unmodifiableList(replicaSnapshots)));
+		}
+		return Collections.unmodifiableList(result);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/SendResponseObserver.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/SendResponseObserver.java
@@ -1,0 +1,61 @@
+package io.zulia.server.index.replication;
+
+import io.grpc.stub.ClientCallStreamObserver;
+import io.grpc.stub.ClientResponseObserver;
+import io.zulia.message.ZuliaServiceOuterClass.SegmentFileData;
+import io.zulia.message.ZuliaServiceOuterClass.SendSegmentFilesResponse;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class SendResponseObserver implements ClientResponseObserver<SegmentFileData, SendSegmentFilesResponse> {
+
+	private final CompletableFuture<SendSegmentFilesResponse> responseFuture = new CompletableFuture<>();
+	private final Object readyLock = new Object();
+
+	@Override
+	public void beforeStart(ClientCallStreamObserver<SegmentFileData> requestStream) {
+		requestStream.setOnReadyHandler(() -> {
+			synchronized (readyLock) {
+				readyLock.notifyAll();
+			}
+		});
+	}
+
+	@Override
+	public void onNext(SendSegmentFilesResponse response) {
+		responseFuture.complete(response);
+	}
+
+	@Override
+	public void onError(Throwable t) {
+		responseFuture.completeExceptionally(t);
+	}
+
+	@Override
+	public void onCompleted() {
+		if (!responseFuture.isDone()) {
+			responseFuture.completeExceptionally(new ReplicationStreamException("Stream completed without response"));
+		}
+	}
+
+	void awaitReady(ClientCallStreamObserver<?> observer) throws InterruptedException {
+		while (!observer.isReady()) {
+			if (responseFuture.isDone()) {
+				return;
+			}
+			synchronized (readyLock) {
+				if (observer.isReady() || responseFuture.isDone()) {
+					return;
+				}
+				readyLock.wait(100);
+			}
+		}
+	}
+
+	SendSegmentFilesResponse await(long timeout, TimeUnit unit) throws ExecutionException, InterruptedException, TimeoutException {
+		return responseFuture.get(timeout, unit);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/replication/ShardState.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/replication/ShardState.java
@@ -1,0 +1,21 @@
+package io.zulia.server.index.replication;
+
+import java.util.concurrent.locks.ReentrantLock;
+
+class ShardState {
+
+	private final ReentrantLock lock = new ReentrantLock();
+	private volatile Long lastAttemptedGeneration;
+
+	ReentrantLock getLock() {
+		return lock;
+	}
+
+	Long getLastAttemptedGeneration() {
+		return lastAttemptedGeneration;
+	}
+
+	void setLastAttemptedGeneration(Long lastAttemptedGeneration) {
+		this.lastAttemptedGeneration = lastAttemptedGeneration;
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/ReplicationController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/ReplicationController.java
@@ -1,0 +1,47 @@
+package io.zulia.server.rest.controllers;
+
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.PathVariable;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.http.hateoas.JsonError;
+import io.micronaut.scheduling.TaskExecutors;
+import io.micronaut.scheduling.annotation.ExecuteOn;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.zulia.ZuliaRESTConstants;
+import io.zulia.server.index.ZuliaIndexManager;
+import io.zulia.server.index.replication.ReplicationShardState;
+import io.zulia.server.node.ZuliaNode;
+
+import java.util.List;
+
+@Controller
+@Tag(name = "Replication")
+@ApiResponses({ @ApiResponse(responseCode = "400", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
+		@ApiResponse(responseCode = "404", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
+		@ApiResponse(responseCode = "500", content = { @Content(schema = @Schema(implementation = JsonError.class)) }),
+		@ApiResponse(responseCode = "503", content = { @Content(schema = @Schema(implementation = JsonError.class)) }) })
+@ExecuteOn(TaskExecutors.VIRTUAL)
+public class ReplicationController {
+
+	private final ZuliaNode zuliaNode;
+
+	public ReplicationController(ZuliaNode zuliaNode) {
+		this.zuliaNode = zuliaNode;
+	}
+
+	@Get(ZuliaRESTConstants.REPLICATION_URL + "/{indexName}")
+	@Produces(ZuliaRESTConstants.UTF8_JSON)
+	@Operation(summary = "Get replication state",
+			description = "Per-shard and per-replica replication progress for the given index. Only shards whose primary lives on this node have populated state.")
+	public List<ReplicationShardState> getReplicationState(@Parameter(description = "Index name") @PathVariable String indexName) throws Exception {
+		ZuliaIndexManager indexManager = zuliaNode.getIndexManager();
+		return indexManager.getReplicationState(indexName);
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/ReplicationTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/ReplicationTest.java
@@ -1,0 +1,173 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.ScoredQuery;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.SearchResult;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.message.ZuliaBase.PrimaryReplicaSettings;
+import io.zulia.server.test.node.shared.RestNodeExtension;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class ReplicationTest {
+
+	@RegisterExtension
+	static final RestNodeExtension nodeExtension = new RestNodeExtension(2);
+
+	private static final String INDEX = "replicationTest";
+	private static final int DOC_COUNT = 50;
+
+	private static final long REPLICATION_WAIT_MS = 30_000;
+	private static final long REPLICATION_POLL_INTERVAL_MS = 200;
+
+	@Test
+	@Order(1)
+	public void createIndexWithReplica() throws Exception {
+		ZuliaWorkPool client = nodeExtension.getGrpcClient();
+
+		ClientIndexConfig config = new ClientIndexConfig();
+		config.addDefaultSearchField("title");
+		config.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		config.addFieldConfig(FieldConfigBuilder.createString("title").indexAs(DefaultAnalyzers.STANDARD).sort());
+		config.addFieldConfig(FieldConfigBuilder.createInt("seq").index().sort());
+		config.setIndexName(INDEX);
+		config.setNumberOfShards(1);
+		config.setNumberOfReplicas(1);
+		config.setShardCommitInterval(10); // commit every 10 docs to trigger replication
+
+		client.createIndex(config);
+	}
+
+	@Test
+	@Order(2)
+	public void indexDocumentsAndReplicate() throws Exception {
+		ZuliaWorkPool client = nodeExtension.getGrpcClient();
+
+		for (int i = 0; i < DOC_COUNT; i++) {
+			Document doc = new Document();
+			doc.put("id", String.valueOf(i));
+			doc.put("title", "doc " + i);
+			doc.put("seq", i);
+			Store store = new Store(String.valueOf(i), INDEX);
+			store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(doc));
+			client.store(store);
+		}
+
+		// Optimize forces a final commit so the replica converges to a deterministic last generation
+		// regardless of where the doc counter landed relative to shardCommitInterval.
+		client.optimizeIndex(INDEX);
+
+		long primaryHits = countHits(PrimaryReplicaSettings.PRIMARY_ONLY);
+		Assertions.assertEquals(DOC_COUNT, primaryHits, "primary should have all docs after optimize");
+
+		long replicaHits = waitForReplicaCount(DOC_COUNT);
+		Assertions.assertEquals(DOC_COUNT, replicaHits, "replica did not converge to primary count within " + REPLICATION_WAIT_MS + "ms");
+	}
+
+	@Test
+	@Order(3)
+	public void primaryIfAvailableReturnsCorrectCount() throws Exception {
+		long hits = countHits(PrimaryReplicaSettings.PRIMARY_IF_AVAILABLE);
+		Assertions.assertEquals(DOC_COUNT, hits);
+	}
+
+	@Test
+	@Order(4)
+	public void additionalWritesContinueReplicating() throws Exception {
+		ZuliaWorkPool client = nodeExtension.getGrpcClient();
+
+		int extra = 25;
+		for (int i = DOC_COUNT; i < DOC_COUNT + extra; i++) {
+			Document doc = new Document();
+			doc.put("id", String.valueOf(i));
+			doc.put("title", "extra " + i);
+			doc.put("seq", i);
+			Store store = new Store(String.valueOf(i), INDEX);
+			store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(doc));
+			client.store(store);
+		}
+
+		client.optimizeIndex(INDEX);
+
+		int expected = DOC_COUNT + extra;
+		long replicaHits = waitForReplicaCount(expected);
+		Assertions.assertEquals(expected, replicaHits, "replica did not catch up after additional writes");
+	}
+
+	@Test
+	@Order(5)
+	public void fetchFromReplicaServesDocument() throws Exception {
+		Search search = new Search(INDEX).setPrimaryReplicaSettings(PrimaryReplicaSettings.REPLICA_ONLY);
+		search.addQuery(new ScoredQuery("seq:42"));
+		SearchResult result = nodeExtension.getGrpcClient().search(search);
+		Assertions.assertEquals(1, result.getTotalHits(), "replica should serve a doc indexed earlier in the suite");
+	}
+
+	@Test
+	@Order(6)
+	public void replicationStateEndpointReportsProgress() throws Exception {
+		// Both nodes return the full shard mapping, but only the primary has lastAttemptedGeneration set.
+		// Find the node that actually owns the primary by matching that field in the body.
+		String primaryBody = fetchReplicationStateFromPrimary();
+		Assertions.assertNotNull(primaryBody, "no REST node reported populated primary state");
+		Assertions.assertTrue(primaryBody.contains("\"shardNumber\":0"), "expected shard 0 in response: " + primaryBody);
+		Assertions.assertTrue(primaryBody.contains("lastAttemptedGeneration"), "expected lastAttemptedGeneration in response: " + primaryBody);
+		Assertions.assertTrue(primaryBody.contains("\"replicas\""), "expected replicas array: " + primaryBody);
+	}
+
+	private long countHits(PrimaryReplicaSettings setting) throws Exception {
+		Search search = new Search(INDEX).setPrimaryReplicaSettings(setting);
+		search.setAmount(0);
+		return nodeExtension.getGrpcClient().search(search).getTotalHits();
+	}
+
+	private long waitForReplicaCount(long expected) throws Exception {
+		long deadline = System.currentTimeMillis() + REPLICATION_WAIT_MS;
+		long replicaHits = -1;
+		while (System.currentTimeMillis() < deadline) {
+			replicaHits = countHits(PrimaryReplicaSettings.REPLICA_ONLY);
+			if (replicaHits == expected) {
+				return replicaHits;
+			}
+			Thread.sleep(REPLICATION_POLL_INTERVAL_MS);
+		}
+		return replicaHits;
+	}
+
+	private String fetchReplicationStateFromPrimary() throws Exception {
+		HttpClient http = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(2)).build();
+		// TestHelper assigns ports starting at 20001 (service) / 20002 (rest), incrementing per node.
+		int[] restPorts = { 20002, 20004 };
+		String fallback = null;
+		for (int port : restPorts) {
+			HttpRequest req = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/replication/" + INDEX)).timeout(Duration.ofSeconds(5)).GET()
+					.build();
+			HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+			if (resp.statusCode() != 200 || resp.body().isBlank()) {
+				continue;
+			}
+			if (resp.body().contains("lastAttemptedGeneration")) {
+				return resp.body();
+			}
+			fallback = resp.body();
+		}
+		return fallback;
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/replication/SegmentReplicationManagerTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/replication/SegmentReplicationManagerTest.java
@@ -1,0 +1,125 @@
+package io.zulia.server.test.replication;
+
+import io.zulia.message.ZuliaBase.Node;
+import io.zulia.message.ZuliaIndex.IndexShardMapping;
+import io.zulia.message.ZuliaIndex.ShardMapping;
+import io.zulia.server.index.replication.ReplicaReplicationState;
+import io.zulia.server.index.replication.ReplicationShardState;
+import io.zulia.server.index.replication.SegmentPublisher;
+import io.zulia.server.index.replication.SegmentReplicationManager;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Unit tests for the {@link SegmentReplicationManager} coordination layer. Exercises the paths that don't
+ * require a real Lucene shard: the no-replica short-circuit, observability shape, and shutdown idempotency.
+ * The end-to-end path (real shards, real transfer) is covered by {@code ReplicationTest}.
+ */
+public class SegmentReplicationManagerTest {
+
+	private static final String INDEX = "unitTest";
+
+	@Test
+	public void noReplicasShortCircuitsBeforeTouchingShard() throws Exception {
+		IndexShardMapping mapping = mappingWith(2, 0);
+		AtomicInteger publishCalls = new AtomicInteger();
+		SegmentPublisher publisher = req -> publishCalls.incrementAndGet();
+
+		SegmentReplicationManager manager = new SegmentReplicationManager(publisher, mapping, INDEX);
+		try {
+			// hasAnyReplicas == false short-circuits before touching the shard, so passing null is safe and
+			// also proves the early-return path doesn't dereference the shard.
+			manager.replicateAfterCommit(null);
+			manager.watchdogTick(List.of());
+
+			// Give the executor a moment in case the short-circuit is wrong and a task slipped through.
+			Thread.sleep(100);
+			Assertions.assertEquals(0, publishCalls.get(), "publisher must not be invoked when no replicas exist");
+		}
+		finally {
+			manager.shutdown();
+		}
+	}
+
+	@Test
+	public void replicationStateBeforeAnyAttemptIsEmpty() {
+		IndexShardMapping mapping = mappingWith(3, 2);
+		SegmentReplicationManager manager = new SegmentReplicationManager(req -> {
+		}, mapping, INDEX);
+		try {
+			List<ReplicationShardState> state = manager.getReplicationState();
+			Assertions.assertEquals(3, state.size(), "one entry per shard");
+			for (ReplicationShardState shard : state) {
+				Assertions.assertNull(shard.lastAttemptedGeneration(), "no attempt yet → null");
+				Assertions.assertEquals(2, shard.replicas().size(), "two replicas per shard");
+				for (ReplicaReplicationState replica : shard.replicas()) {
+					Assertions.assertNull(replica.lastReplicatedGeneration());
+					Assertions.assertNull(replica.lagGenerations());
+					Assertions.assertNull(replica.lastSuccessMs());
+					Assertions.assertNull(replica.msSinceLastSuccess());
+					Assertions.assertEquals(0, replica.consecutiveFailures());
+					Assertions.assertFalse(replica.circuitOpen());
+				}
+			}
+		}
+		finally {
+			manager.shutdown();
+		}
+	}
+
+	@Test
+	public void shutdownIsIdempotent() {
+		SegmentReplicationManager manager = new SegmentReplicationManager(req -> {
+		}, mappingWith(1, 1), INDEX);
+		manager.shutdown();
+		// A second call must not throw (e.g. on a duplicate executor.shutdown() or publisher.close()).
+		manager.shutdown();
+	}
+
+	@Test
+	public void watchdogAfterShutdownDoesNothing() {
+		AtomicInteger publishCalls = new AtomicInteger();
+		SegmentPublisher publisher = req -> publishCalls.incrementAndGet();
+		SegmentReplicationManager manager = new SegmentReplicationManager(publisher, mappingWith(1, 1), INDEX);
+		manager.shutdown();
+
+		// After shutdown, watchdog ticks must be silent — they would otherwise race with state-map clearing
+		// or attempt to submit to a closed executor.
+		manager.watchdogTick(List.of());
+		Assertions.assertEquals(0, publishCalls.get());
+	}
+
+	@Test
+	public void replicateAfterCommitDoesNotThrowOnPublisherFailure() {
+		// We can't drive doReplicate to the publisher without a real ShardWriteManager, but we can at least
+		// prove the submission path swallows a faulty publisher's exceptions instead of letting them bubble
+		// out of the commit hook (which would fail user writes).
+		IndexShardMapping mapping = mappingWith(0, 0); // no shards at all → trivially no work
+		SegmentPublisher angryPublisher = req -> {
+			throw new RuntimeException("simulated publisher failure");
+		};
+		SegmentReplicationManager manager = new SegmentReplicationManager(angryPublisher, mapping, INDEX);
+		try {
+			Assertions.assertDoesNotThrow(() -> manager.replicateAfterCommit(null));
+		}
+		finally {
+			manager.shutdown();
+		}
+	}
+
+	private static IndexShardMapping mappingWith(int shardCount, int replicasPerShard) {
+		IndexShardMapping.Builder mapping = IndexShardMapping.newBuilder().setIndexName(INDEX).setNumberOfShards(shardCount);
+		for (int s = 0; s < shardCount; s++) {
+			ShardMapping.Builder shard = ShardMapping.newBuilder().setShardNumber(s)
+					.setPrimaryNode(Node.newBuilder().setServerAddress("host-primary-" + s).setServicePort(40000 + s).build());
+			for (int r = 0; r < replicasPerShard; r++) {
+				shard.addReplicaNode(Node.newBuilder().setServerAddress("host-replica-" + s + "-" + r).setServicePort(50000 + s * 10 + r).build());
+			}
+			mapping.addShardMapping(shard);
+		}
+		return mapping.build();
+	}
+}


### PR DESCRIPTION
Adds Lucene segment replication: a primary fans new commits out to its
configured replica nodes via a per-shard generation gate, virtual-thread
executor, and per-replica circuit breaker. Adds two internal gRPC RPCs:
`InternalGetSegmentFileInfo` (unary: replica reports its current file list and
`segments_N` footer checksums) and `InternalSendSegmentFiles` (bidi stream:
primary pushes byte chunks). The receiver stages `segments_N` under a
`pending-` prefix and atomically renames it on commit so a refresh mid-stream
cannot observe a torn header. A 30s watchdog re-fires replication on every
primary shard to recover from missed checkpoints (replica unreachable, circuit
open, inbound semaphore exhausted); on a healthy cluster every tick hits the
generation gate and returns. A `/replication/{indexName}` REST endpoint
reports per-shard and per-replica progress (last attempted generation, lag,
last-success timestamp, circuit-breaker state).