### PR TITLE
Pull out document filtering logic to ZuliaUtil and optimize Document filtering path / ScoredDoc handling

### DIFF
--- a/zulia-common/src/main/java/io/zulia/util/FieldAndSubFields.java
+++ b/zulia-common/src/main/java/io/zulia/util/FieldAndSubFields.java
@@ -1,12 +1,15 @@
-package io.zulia.server.util;
+package io.zulia.util;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class FieldAndSubFields {
+
+	public static final FieldAndSubFields NO_FIELDS = new FieldAndSubFields(List.of());
 
 	private final Map<String, Set<String>> topLevelToChildren = new HashMap<>();
 	private final Set<String> topLevelFields = new HashSet<>();

--- a/zulia-common/src/main/java/io/zulia/util/ZuliaUtil.java
+++ b/zulia-common/src/main/java/io/zulia/util/ZuliaUtil.java
@@ -249,11 +249,19 @@ public class ZuliaUtil {
 
 	}
 
+	public static void filterDocument(org.bson.Document mongoDocument, Collection<String> returnFields) {
+		filterDocument(mongoDocument, new FieldAndSubFields(returnFields), FieldAndSubFields.NO_FIELDS);
+	}
+
 	public static void filterDocument(org.bson.Document mongoDocument, FieldAndSubFields returnFields) {
 		filterDocument(mongoDocument, returnFields, FieldAndSubFields.NO_FIELDS);
 	}
 
-	public static void filterDocument( org.bson.Document mongoDocument, FieldAndSubFields returnFields, FieldAndSubFields maskFields) {
+	public static void filterDocument(org.bson.Document mongoDocument, Collection<String> returnFields, Collection<String> maskFields) {
+		filterDocument(mongoDocument, new FieldAndSubFields(returnFields), new FieldAndSubFields(maskFields));
+	}
+
+	public static void filterDocument(org.bson.Document mongoDocument, FieldAndSubFields returnFields, FieldAndSubFields maskFields) {
 
 		boolean hasReturn = !returnFields.getTopLevelFields().isEmpty();
 		boolean hasMask = !maskFields.getTopLevelFields().isEmpty();

--- a/zulia-common/src/main/java/io/zulia/util/ZuliaUtil.java
+++ b/zulia-common/src/main/java/io/zulia/util/ZuliaUtil.java
@@ -18,9 +18,12 @@ import org.bson.json.JsonWriterSettings;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -243,6 +246,83 @@ public class ZuliaUtil {
 			vectorFloat[i] = vector.get(i);
 		}
 		return vectorFloat;
+
+	}
+
+	public static void filterDocument(org.bson.Document mongoDocument, FieldAndSubFields returnFields) {
+		filterDocument(mongoDocument, returnFields, FieldAndSubFields.NO_FIELDS);
+	}
+
+	public static void filterDocument( org.bson.Document mongoDocument, FieldAndSubFields returnFields, FieldAndSubFields maskFields) {
+
+		boolean hasReturn = !returnFields.getTopLevelFields().isEmpty();
+		boolean hasMask = !maskFields.getTopLevelFields().isEmpty();
+
+		if (!hasReturn && hasMask) {
+			Map<String, Set<String>> topLevelToChildren = maskFields.getTopLevelToChildren();
+			for (String topLevelField : maskFields.getTopLevelFields()) {
+				if (!topLevelToChildren.containsKey(topLevelField)) {
+					mongoDocument.remove(topLevelField);
+				}
+				else {
+					Object subDoc = mongoDocument.get(topLevelField);
+					ZuliaUtil.handleLists(subDoc, subDocItem -> {
+						if (subDocItem instanceof org.bson.Document) {
+
+							Collection<String> subFieldsToMask =
+									topLevelToChildren.get(topLevelField) != null ? topLevelToChildren.get(topLevelField) : Collections.emptyList();
+
+							filterDocument(FieldAndSubFields.NO_FIELDS, new FieldAndSubFields(subFieldsToMask), (org.bson.Document) subDocItem);
+						}
+						else if (subDocItem == null) {
+
+						}
+						else {
+							//TODO: warn user?
+						}
+					});
+				}
+			}
+		}
+		else if (hasReturn) {
+			Set<String> topLevelFieldsToReturn = returnFields.getTopLevelFields();
+			Set<String> topLevelFieldsToMask = maskFields.getTopLevelFields();
+			Map<String, Set<String>> topLevelToChildrenToMask = maskFields.getTopLevelToChildren();
+			Map<String, Set<String>> topLevelToChildrenToReturn = returnFields.getTopLevelToChildren();
+
+			ArrayList<String> allDocumentKeys = new ArrayList<>(mongoDocument.keySet());
+			for (String topLevelField : allDocumentKeys) {
+
+				if ((!topLevelFieldsToReturn.contains(topLevelField) && !topLevelToChildrenToMask.containsKey(topLevelField))
+						|| topLevelFieldsToMask.contains(topLevelField) && !topLevelToChildrenToMask.containsKey(topLevelField)) {
+					mongoDocument.remove(topLevelField);
+				}
+
+				if (topLevelToChildrenToReturn.containsKey(topLevelField) || topLevelToChildrenToMask.containsKey(topLevelField)) {
+					Object subDoc = mongoDocument.get(topLevelField);
+					ZuliaUtil.handleLists(subDoc, subDocItem -> {
+						if (subDocItem instanceof org.bson.Document) {
+
+							Collection<String> subFieldsToReturn = topLevelToChildrenToReturn.get(topLevelField) != null ?
+									topLevelToChildrenToReturn.get(topLevelField) :
+									Collections.emptyList();
+
+							Collection<String> subFieldsToMask =
+									topLevelToChildrenToMask.get(topLevelField) != null ? topLevelToChildrenToMask.get(topLevelField) : Collections.emptyList();
+
+							filterDocument(new FieldAndSubFields(subFieldsToReturn), new FieldAndSubFields(subFieldsToMask), (org.bson.Document) subDocItem);
+						}
+						else if (subDocItem == null) {
+
+						}
+						else {
+							//TODO: warn user?
+						}
+					});
+
+				}
+			}
+		}
 
 	}
 }

--- a/zulia-common/src/main/java/io/zulia/util/ZuliaUtil.java
+++ b/zulia-common/src/main/java/io/zulia/util/ZuliaUtil.java
@@ -18,9 +18,12 @@ import org.bson.json.JsonWriterSettings;
 
 import java.io.File;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -243,6 +246,83 @@ public class ZuliaUtil {
 			vectorFloat[i] = vector.get(i);
 		}
 		return vectorFloat;
+
+	}
+
+	public static void filterDocument(org.bson.Document mongoDocument, FieldAndSubFields returnFields) {
+		filterDocument(mongoDocument, returnFields, FieldAndSubFields.NO_FIELDS);
+	}
+
+	public static void filterDocument( org.bson.Document mongoDocument, FieldAndSubFields returnFields, FieldAndSubFields maskFields) {
+
+		boolean hasReturn = !returnFields.getTopLevelFields().isEmpty();
+		boolean hasMask = !maskFields.getTopLevelFields().isEmpty();
+
+		if (!hasReturn && hasMask) {
+			Map<String, Set<String>> topLevelToChildren = maskFields.getTopLevelToChildren();
+			for (String topLevelField : maskFields.getTopLevelFields()) {
+				if (!topLevelToChildren.containsKey(topLevelField)) {
+					mongoDocument.remove(topLevelField);
+				}
+				else {
+					Object subDoc = mongoDocument.get(topLevelField);
+					ZuliaUtil.handleLists(subDoc, subDocItem -> {
+						if (subDocItem instanceof org.bson.Document) {
+
+							Collection<String> subFieldsToMask =
+									topLevelToChildren.get(topLevelField) != null ? topLevelToChildren.get(topLevelField) : Collections.emptyList();
+
+							filterDocument((org.bson.Document) subDocItem, FieldAndSubFields.NO_FIELDS, new FieldAndSubFields(subFieldsToMask));
+						}
+						else if (subDocItem == null) {
+
+						}
+						else {
+							//TODO: warn user?
+						}
+					});
+				}
+			}
+		}
+		else if (hasReturn) {
+			Set<String> topLevelFieldsToReturn = returnFields.getTopLevelFields();
+			Set<String> topLevelFieldsToMask = maskFields.getTopLevelFields();
+			Map<String, Set<String>> topLevelToChildrenToMask = maskFields.getTopLevelToChildren();
+			Map<String, Set<String>> topLevelToChildrenToReturn = returnFields.getTopLevelToChildren();
+
+			ArrayList<String> allDocumentKeys = new ArrayList<>(mongoDocument.keySet());
+			for (String topLevelField : allDocumentKeys) {
+
+				if ((!topLevelFieldsToReturn.contains(topLevelField) && !topLevelToChildrenToMask.containsKey(topLevelField))
+						|| topLevelFieldsToMask.contains(topLevelField) && !topLevelToChildrenToMask.containsKey(topLevelField)) {
+					mongoDocument.remove(topLevelField);
+				}
+
+				if (topLevelToChildrenToReturn.containsKey(topLevelField) || topLevelToChildrenToMask.containsKey(topLevelField)) {
+					Object subDoc = mongoDocument.get(topLevelField);
+					ZuliaUtil.handleLists(subDoc, subDocItem -> {
+						if (subDocItem instanceof org.bson.Document) {
+
+							Collection<String> subFieldsToReturn = topLevelToChildrenToReturn.get(topLevelField) != null ?
+									topLevelToChildrenToReturn.get(topLevelField) :
+									Collections.emptyList();
+
+							Collection<String> subFieldsToMask =
+									topLevelToChildrenToMask.get(topLevelField) != null ? topLevelToChildrenToMask.get(topLevelField) : Collections.emptyList();
+
+							filterDocument((org.bson.Document) subDocItem, new FieldAndSubFields(subFieldsToReturn), new FieldAndSubFields(subFieldsToMask));
+						}
+						else if (subDocItem == null) {
+
+						}
+						else {
+							//TODO: warn user?
+						}
+					});
+
+				}
+			}
+		}
 
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/DocumentScoredDocLeafHandler.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/DocumentScoredDocLeafHandler.java
@@ -9,7 +9,7 @@ import io.zulia.message.ZuliaQuery;
 import io.zulia.server.analysis.highlight.ZuliaHighlighter;
 import io.zulia.server.field.FieldTypeUtil;
 import io.zulia.server.util.BytesRefUtil;
-import io.zulia.server.util.FieldAndSubFields;
+import io.zulia.util.FieldAndSubFields;
 import io.zulia.util.ZuliaUtil;
 import io.zulia.util.document.DocumentHelper;
 import org.apache.lucene.analysis.TokenStream;
@@ -23,12 +23,7 @@ import org.apache.lucene.util.BytesRef;
 import org.xerial.snappy.Snappy;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import static io.zulia.ZuliaFieldConstants.STORED_DOC_FIELD;
 import static io.zulia.ZuliaFieldConstants.STORED_ID_FIELD;
@@ -36,7 +31,6 @@ import static io.zulia.ZuliaFieldConstants.STORED_META_FIELD;
 
 public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuery.ScoredResult> {
 
-	private static final FieldAndSubFields NO_FIELDS = new FieldAndSubFields(List.of());
 
 	private BinaryDocValues idDocValues;
 
@@ -151,7 +145,7 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 						}
 
 						if (needsDocFiltering) {
-							filterDocument(fieldsToReturnObj, fieldsToMaskObj, mongoDoc);
+							ZuliaUtil.filterDocument(mongoDoc, fieldsToReturnObj, fieldsToMaskObj);
 							rdBuilder.setDocument(ZuliaUtil.mongoDocumentToByteString(mongoDoc));
 						}
 						else {
@@ -180,78 +174,7 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 		return owned ? UnsafeByteOperations.unsafeWrap(storedBytes) : ByteString.copyFrom(storedBytes);
 	}
 
-	private void filterDocument(FieldAndSubFields returnFields, FieldAndSubFields maskFields, org.bson.Document mongoDocument) {
 
-		boolean hasReturn = !returnFields.getTopLevelFields().isEmpty();
-		boolean hasMask = !maskFields.getTopLevelFields().isEmpty();
-
-		if (!hasReturn && hasMask) {
-			Map<String, Set<String>> topLevelToChildren = maskFields.getTopLevelToChildren();
-			for (String topLevelField : maskFields.getTopLevelFields()) {
-				if (!topLevelToChildren.containsKey(topLevelField)) {
-					mongoDocument.remove(topLevelField);
-				}
-				else {
-					Object subDoc = mongoDocument.get(topLevelField);
-					ZuliaUtil.handleLists(subDoc, subDocItem -> {
-						if (subDocItem instanceof org.bson.Document) {
-
-							Collection<String> subFieldsToMask =
-									topLevelToChildren.get(topLevelField) != null ? topLevelToChildren.get(topLevelField) : Collections.emptyList();
-
-							filterDocument(NO_FIELDS, new FieldAndSubFields(subFieldsToMask), (org.bson.Document) subDocItem);
-						}
-						else if (subDocItem == null) {
-
-						}
-						else {
-							//TODO: warn user?
-						}
-					});
-				}
-			}
-		}
-		else if (hasReturn) {
-			Set<String> topLevelFieldsToReturn = returnFields.getTopLevelFields();
-			Set<String> topLevelFieldsToMask = maskFields.getTopLevelFields();
-			Map<String, Set<String>> topLevelToChildrenToMask = maskFields.getTopLevelToChildren();
-			Map<String, Set<String>> topLevelToChildrenToReturn = returnFields.getTopLevelToChildren();
-
-			ArrayList<String> allDocumentKeys = new ArrayList<>(mongoDocument.keySet());
-			for (String topLevelField : allDocumentKeys) {
-
-				if ((!topLevelFieldsToReturn.contains(topLevelField) && !topLevelToChildrenToMask.containsKey(topLevelField))
-						|| topLevelFieldsToMask.contains(topLevelField) && !topLevelToChildrenToMask.containsKey(topLevelField)) {
-					mongoDocument.remove(topLevelField);
-				}
-
-				if (topLevelToChildrenToReturn.containsKey(topLevelField) || topLevelToChildrenToMask.containsKey(topLevelField)) {
-					Object subDoc = mongoDocument.get(topLevelField);
-					ZuliaUtil.handleLists(subDoc, subDocItem -> {
-						if (subDocItem instanceof org.bson.Document) {
-
-							Collection<String> subFieldsToReturn = topLevelToChildrenToReturn.get(topLevelField) != null ?
-									topLevelToChildrenToReturn.get(topLevelField) :
-									Collections.emptyList();
-
-							Collection<String> subFieldsToMask =
-									topLevelToChildrenToMask.get(topLevelField) != null ? topLevelToChildrenToMask.get(topLevelField) : Collections.emptyList();
-
-							filterDocument(new FieldAndSubFields(subFieldsToReturn), new FieldAndSubFields(subFieldsToMask), (org.bson.Document) subDocItem);
-						}
-						else if (subDocItem == null) {
-
-						}
-						else {
-							//TODO: warn user?
-						}
-					});
-
-				}
-			}
-		}
-
-	}
 
 	private void handleSortValues(List<SortMeta> sortMetas, ScoreDoc scoreDoc, ZuliaQuery.ScoredResult.Builder srBuilder) {
 		FieldDoc result = (FieldDoc) scoreDoc;

--- a/zulia-server/src/main/java/io/zulia/server/index/DocumentScoredDocLeafHandler.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/DocumentScoredDocLeafHandler.java
@@ -1,6 +1,7 @@
 package io.zulia.server.index;
 
 import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
 import io.zulia.ZuliaFieldConstants;
 import io.zulia.message.ZuliaBase;
 import io.zulia.message.ZuliaIndex;
@@ -9,7 +10,6 @@ import io.zulia.server.analysis.highlight.ZuliaHighlighter;
 import io.zulia.server.field.FieldTypeUtil;
 import io.zulia.server.util.BytesRefUtil;
 import io.zulia.server.util.FieldAndSubFields;
-import io.zulia.util.ResultHelper;
 import io.zulia.util.ZuliaUtil;
 import io.zulia.util.document.DocumentHelper;
 import org.apache.lucene.analysis.TokenStream;
@@ -35,6 +35,9 @@ import static io.zulia.ZuliaFieldConstants.STORED_ID_FIELD;
 import static io.zulia.ZuliaFieldConstants.STORED_META_FIELD;
 
 public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuery.ScoredResult> {
+
+	private static final FieldAndSubFields NO_FIELDS = new FieldAndSubFields(List.of());
+
 	private BinaryDocValues idDocValues;
 
 	private BinaryDocValues metaDocValues;
@@ -51,8 +54,8 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 
 	private final boolean needsAnalysis;
 
-	private final List<String> fieldsToReturn;
-	private final List<String> fieldsToMask;
+	private final FieldAndSubFields fieldsToReturnObj;
+	private final FieldAndSubFields fieldsToMaskObj;
 	private final List<SortMeta> sortMetas;
 	private final List<ZuliaHighlighter> highlighterList;
 	private final List<AnalysisHandler> analysisHandlerList;
@@ -64,8 +67,8 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 		this.shardNumber = shardNumber;
 		meta = ZuliaQuery.FetchType.META.equals(fetchType) || ZuliaQuery.FetchType.ALL.equals(fetchType);
 		full = ZuliaQuery.FetchType.FULL.equals(fetchType) || ZuliaQuery.FetchType.ALL.equals(fetchType);
-		this.fieldsToReturn = fieldsToReturn;
-		this.fieldsToMask = fieldsToMask;
+		this.fieldsToReturnObj = new FieldAndSubFields(fieldsToReturn);
+		this.fieldsToMaskObj = new FieldAndSubFields(fieldsToMask);
 		this.highlighterList = highlighterList;
 		this.analysisHandlerList = analysisHandlerList;
 		this.needsHighlight = !highlighterList.isEmpty();
@@ -118,40 +121,45 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 			rdBuilder.setIndexName(indexName);
 			rdBuilder.setUniqueId(idInfo.getId());
 			rdBuilder.setTimestamp(idInfo.getTimestamp());
+			boolean compressed = idInfo.getCompressedDoc();
+
 			if (meta) {
 				if (metaDocValues != null && metaDocValues.advanceExact(localDocId)) {
 					byte[] metaBytes = BytesRefUtil.getByteArray(metaDocValues.binaryValue());
-					if (idInfo.getCompressedDoc()) {
+					if (compressed) {
 						metaBytes = Snappy.uncompress(metaBytes);
 					}
-					rdBuilder.setMetadata(ByteString.copyFrom(metaBytes));
+					rdBuilder.setMetadata(storedByteString(metaBytes, compressed));
 				}
 			}
 
 			if (full) {
 				if (fullDocValues != null && fullDocValues.advanceExact(localDocId)) {
 					byte[] docBytes = BytesRefUtil.getByteArray(fullDocValues.binaryValue());
-					if (idInfo.getCompressedDoc()) {
+					if (compressed) {
 						docBytes = Snappy.uncompress(docBytes);
 					}
-					rdBuilder.setDocument(ByteString.copyFrom(docBytes));
 
 					if (needsHighlight || needsAnalysis || needsDocFiltering) {
-						org.bson.Document mongoDoc = ResultHelper.getDocumentFromResultDocument(rdBuilder);
-						if (mongoDoc != null) {
-							if (needsHighlight) {
-								handleHighlight(highlighterList, srBuilder, mongoDoc);
-							}
-							if (needsAnalysis) {
-								AnalysisHandler.handleDocument(mongoDoc, analysisHandlerList, srBuilder);
-							}
-
-							if (needsDocFiltering) {
-								filterDocument(fieldsToReturn, fieldsToMask, mongoDoc);
-								ByteString document = ZuliaUtil.mongoDocumentToByteString(mongoDoc);
-								rdBuilder.setDocument(document);
-							}
+						// Decode straight from the bytes in hand instead of round-tripping through a ByteString and back
+						org.bson.Document mongoDoc = ZuliaUtil.byteArrayToMongoDocument(docBytes);
+						if (needsHighlight) {
+							handleHighlight(highlighterList, srBuilder, mongoDoc);
 						}
+						if (needsAnalysis) {
+							AnalysisHandler.handleDocument(mongoDoc, analysisHandlerList, srBuilder);
+						}
+
+						if (needsDocFiltering) {
+							filterDocument(fieldsToReturnObj, fieldsToMaskObj, mongoDoc);
+							rdBuilder.setDocument(ZuliaUtil.mongoDocumentToByteString(mongoDoc));
+						}
+						else {
+							rdBuilder.setDocument(storedByteString(docBytes, compressed));
+						}
+					}
+					else {
+						rdBuilder.setDocument(storedByteString(docBytes, compressed));
 					}
 				}
 
@@ -167,12 +175,19 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 		return srBuilder.build();
 	}
 
-	private void filterDocument(Collection<String> fieldsToReturn, Collection<String> fieldsToMask, org.bson.Document mongoDocument) {
+	private static ByteString storedByteString(byte[] storedBytes, boolean owned) {
+		// A freshly decompressed array is uniquely owned and safe to wrap; an uncompressed array may alias Lucene's reusable buffer
+		return owned ? UnsafeByteOperations.unsafeWrap(storedBytes) : ByteString.copyFrom(storedBytes);
+	}
 
-		if (fieldsToReturn.isEmpty() && !fieldsToMask.isEmpty()) {
-			FieldAndSubFields fieldsToMaskObj = new FieldAndSubFields(fieldsToMask);
-			for (String topLevelField : fieldsToMaskObj.getTopLevelFields()) {
-				Map<String, Set<String>> topLevelToChildren = fieldsToMaskObj.getTopLevelToChildren();
+	private void filterDocument(FieldAndSubFields returnFields, FieldAndSubFields maskFields, org.bson.Document mongoDocument) {
+
+		boolean hasReturn = !returnFields.getTopLevelFields().isEmpty();
+		boolean hasMask = !maskFields.getTopLevelFields().isEmpty();
+
+		if (!hasReturn && hasMask) {
+			Map<String, Set<String>> topLevelToChildren = maskFields.getTopLevelToChildren();
+			for (String topLevelField : maskFields.getTopLevelFields()) {
 				if (!topLevelToChildren.containsKey(topLevelField)) {
 					mongoDocument.remove(topLevelField);
 				}
@@ -184,7 +199,7 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 							Collection<String> subFieldsToMask =
 									topLevelToChildren.get(topLevelField) != null ? topLevelToChildren.get(topLevelField) : Collections.emptyList();
 
-							filterDocument(Collections.emptyList(), subFieldsToMask, (org.bson.Document) subDocItem);
+							filterDocument(NO_FIELDS, new FieldAndSubFields(subFieldsToMask), (org.bson.Document) subDocItem);
 						}
 						else if (subDocItem == null) {
 
@@ -196,14 +211,11 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 				}
 			}
 		}
-		else if (!fieldsToReturn.isEmpty()) {
-			FieldAndSubFields fieldsToReturnObj = new FieldAndSubFields(fieldsToReturn);
-			FieldAndSubFields fieldsToMaskObj = new FieldAndSubFields(fieldsToMask);
-
-			Set<String> topLevelFieldsToReturn = fieldsToReturnObj.getTopLevelFields();
-			Set<String> topLevelFieldsToMask = fieldsToMaskObj.getTopLevelFields();
-			Map<String, Set<String>> topLevelToChildrenToMask = fieldsToMaskObj.getTopLevelToChildren();
-			Map<String, Set<String>> topLevelToChildrenToReturn = fieldsToReturnObj.getTopLevelToChildren();
+		else if (hasReturn) {
+			Set<String> topLevelFieldsToReturn = returnFields.getTopLevelFields();
+			Set<String> topLevelFieldsToMask = maskFields.getTopLevelFields();
+			Map<String, Set<String>> topLevelToChildrenToMask = maskFields.getTopLevelToChildren();
+			Map<String, Set<String>> topLevelToChildrenToReturn = returnFields.getTopLevelToChildren();
 
 			ArrayList<String> allDocumentKeys = new ArrayList<>(mongoDocument.keySet());
 			for (String topLevelField : allDocumentKeys) {
@@ -225,7 +237,7 @@ public class DocumentScoredDocLeafHandler extends ScoredDocLeafHandler<ZuliaQuer
 							Collection<String> subFieldsToMask =
 									topLevelToChildrenToMask.get(topLevelField) != null ? topLevelToChildrenToMask.get(topLevelField) : Collections.emptyList();
 
-							filterDocument(subFieldsToReturn, subFieldsToMask, (org.bson.Document) subDocItem);
+							filterDocument(new FieldAndSubFields(subFieldsToReturn), new FieldAndSubFields(subFieldsToMask), (org.bson.Document) subDocItem);
 						}
 						else if (subDocItem == null) {
 

--- a/zulia-server/src/main/java/io/zulia/server/index/ScoredDocLeafHandler.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ScoredDocLeafHandler.java
@@ -31,7 +31,7 @@ public abstract class ScoredDocLeafHandler<T> {
 			for (int i = 0; i < scoreDocs.length; i++) {
 				zuliaResults[i] = new IndexedScoreDoc(i, scoreDocs[i]);
 			}
-			Arrays.sort(zuliaResults, Comparator.comparing(IndexedScoreDoc::getDocId));
+			Arrays.sort(zuliaResults, Comparator.comparingInt(IndexedScoreDoc::getDocId));
 			T[] results = resultArrayConstructor.apply(zuliaResults.length);
 
 			int docId = zuliaResults[0].getDocId();
@@ -52,7 +52,6 @@ public abstract class ScoredDocLeafHandler<T> {
 				results[indexedScoreDoc.index] = handleDocument(currentLeaf, docId, currentLeaf.docBase, indexedScoreDoc.scoreDoc);
 			}
 
-			Arrays.sort(zuliaResults, Comparator.comparing(IndexedScoreDoc::index));
 			return results;
 		}
 		return resultArrayConstructor.apply(0);


### PR DESCRIPTION
* Pull out document filtering logic to ZuliaUtil
* Remove dead sort and avoid int boxing in ScoredDocLeafHandler
* Reduce per-document copies and allocations in DocumentScoredDocLeafHandler
The query result path (run once per returned document) made
redundant full-document byte copies and rebuilt field-projection structures on
every hit.
