### PR TITLE
Date fields now accept String/Number (epoch-millisecond) date values  / RangeFilter Improvements / Date Range bug fix

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/command/factory/DateOnlyRangeFilter.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/factory/DateOnlyRangeFilter.java
@@ -1,5 +1,6 @@
 package io.zulia.client.command.factory;
 
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
@@ -11,6 +12,6 @@ public class DateOnlyRangeFilter extends RangeFilter<Date> {
 
 	@Override
 	public String getAsString(Date val) {
-		return DateTimeFormatter.ISO_LOCAL_DATE.format(val.toInstant());
+		return DateTimeFormatter.ISO_LOCAL_DATE.format(val.toInstant().atZone(ZoneOffset.UTC));
 	}
 }

--- a/zulia-client/src/main/java/io/zulia/client/command/factory/RangeFilter.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/factory/RangeFilter.java
@@ -3,7 +3,7 @@ package io.zulia.client.command.factory;
 import io.zulia.client.command.builder.FilterQuery;
 
 /**
- * Templated class to handle range filters. Generates appropriate query to populate a FilterQuery object
+ * Templated class to handle range filters. Generates the appropriate query to populate a FilterQuery object
  *
  * @param <T> data type of value to filter on
  */
@@ -54,25 +54,39 @@ public class RangeFilter<T> {
 	}
 
 	/**
-	 * Convert contents to string for query
+	 * Builds the range query string without any exclusion, e.g. {@code field:[min TO max]}. The bracket style reflects
+	 * the endpoint behavior and a missing endpoint is written as {@code *}.
+	 *
+	 * @return the base range query string
+	 */
+	public String getBaseQuery() {
+		String minString = minValue == null ? "*" : getAsString(minValue);
+		String maxString = maxValue == null ? "*" : getAsString(maxValue);
+
+		// default to inclusive endpoints and flip to exclusive '{' / '}' per the endpoint behavior
+		char open = (minValue != null && (behavior == RangeBehavior.EXCLUSIVE || behavior == RangeBehavior.INCLUDE_MAX)) ? '{' : '[';
+		char close = (maxValue != null && (behavior == RangeBehavior.EXCLUSIVE || behavior == RangeBehavior.INCLUDE_MIN)) ? '}' : ']';
+
+		return field + ":" + open + minString + " TO " + maxString + close;
+	}
+
+	/**
+	 * Builds the full range query string, prefixing {@code -} when the range is excluded.
+	 *
+	 * @return the range query string, negated with a leading {@code -} when excluded
+	 */
+	public String toQueryString() {
+		return exclude ? "-" + getBaseQuery() : getBaseQuery();
+	}
+
+	/**
+	 * Convert contents to a FilterQuery for searching. Exclusion is applied as a FILTER_NOT query type rather than a
+	 * leading {@code -} on the query string.
 	 *
 	 * @return Filter Query matching these requirements
 	 */
 	public FilterQuery toQuery() {
-		String minString = minValue == null ? "*" : getAsString(minValue);
-		String maxString = maxValue == null ? "*" : getAsString(maxValue);
-		char open = '[';
-		char close = ']';
-
-		// Build endpoints if applicable
-		if (minValue != null && (behavior == RangeBehavior.EXCLUSIVE || behavior == RangeBehavior.INCLUDE_MAX)) {
-			open = '{';
-		}
-		// Build endpoints if applicable
-		if (maxValue != null && (behavior == RangeBehavior.EXCLUSIVE || behavior == RangeBehavior.INCLUDE_MIN)) {
-			close = '}';
-		}
-		FilterQuery query = new FilterQuery(field + ":" + open + minString + " TO " + maxString + close);
+		FilterQuery query = new FilterQuery(getBaseQuery());
 
 		if (exclude) {
 			query.exclude();

--- a/zulia-client/src/main/java/io/zulia/client/result/SearchResult.java
+++ b/zulia-client/src/main/java/io/zulia/client/result/SearchResult.java
@@ -16,7 +16,9 @@ import org.bson.Document;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SearchResult extends Result {
@@ -188,6 +190,36 @@ public class SearchResult extends Result {
 			}
 		}
 		return null;
+	}
+
+	/**
+	 * Facet counts for a field as a map of facet value to count, preserving the returned (count-descending) order.
+	 * Returns an empty map when the field was not faceted.
+	 */
+	public Map<String, Long> getFacetCountsAsMap(String fieldName) {
+		return toFacetCountMap(getFacetCounts(fieldName));
+	}
+
+	/**
+	 * Facet counts for a field and drill-down path as a map of facet value to count, preserving the returned
+	 * (count-descending) order. Returns an empty map when the field/path was not faceted.
+	 */
+	public Map<String, Long> getFacetCountsAsMap(String fieldName, String... paths) {
+		return toFacetCountMap(getFacetCountsForPath(fieldName, paths));
+	}
+
+	public Map<String, Long> getFacetCountsAsMap(String fieldName, List<String> paths) {
+		return toFacetCountMap(getFacetCountsForPath(fieldName, paths));
+	}
+
+	private static Map<String, Long> toFacetCountMap(List<FacetCount> facetCounts) {
+		Map<String, Long> counts = new LinkedHashMap<>();
+		if (facetCounts != null) {
+			for (FacetCount facetCount : facetCounts) {
+				counts.put(facetCount.getFacet(), facetCount.getCount());
+			}
+		}
+		return counts;
 	}
 
 	public int getFacetGroupCount() {

--- a/zulia-client/src/test/java/io/zulia/client/command/factory/FilterFactoryTest.java
+++ b/zulia-client/src/test/java/io/zulia/client/command/factory/FilterFactoryTest.java
@@ -1,0 +1,73 @@
+package io.zulia.client.command.factory;
+
+import io.zulia.message.ZuliaQuery;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+public class FilterFactoryTest {
+
+	@Test
+	public void rangeDate() {
+		// a Date carries a time; the calendar date is taken in UTC, so a non-midnight instant still maps to its UTC day
+		Date start = Date.from(LocalDate.of(2014, 10, 5).atTime(23, 30).atZone(ZoneOffset.UTC).toInstant());
+		Date end = Date.from(LocalDate.of(2014, 12, 31).atStartOfDay(ZoneOffset.UTC).toInstant());
+
+		// base query string: brackets reflect endpoint behavior, * marks a missing endpoint, no exclusion
+		Assertions.assertEquals("date:[2014-10-05 TO 2014-12-31]", FilterFactory.rangeDate("date").setRange(start, end).getBaseQuery());
+		Assertions.assertEquals("date:[2014-10-05 TO *]", FilterFactory.rangeDate("date").setMinValue(start).getBaseQuery());
+		Assertions.assertEquals("date:[* TO 2014-12-31]", FilterFactory.rangeDate("date").setMaxValue(end).getBaseQuery());
+		Assertions.assertEquals("date:{2014-10-05 TO 2014-12-31}",
+				FilterFactory.rangeDate("date").setRange(start, end).setEndpointBehavior(RangeBehavior.EXCLUSIVE).getBaseQuery());
+		Assertions.assertEquals("date:[2014-10-05 TO 2014-12-31}",
+				FilterFactory.rangeDate("date").setRange(start, end).setEndpointBehavior(RangeBehavior.INCLUDE_MIN).getBaseQuery());
+		Assertions.assertEquals("date:{2014-10-05 TO 2014-12-31]",
+				FilterFactory.rangeDate("date").setRange(start, end).setEndpointBehavior(RangeBehavior.INCLUDE_MAX).getBaseQuery());
+
+		// toQueryString prefixes - when excluded; the base query is never negated
+		Assertions.assertEquals("date:[2014-10-05 TO 2014-12-31]", FilterFactory.rangeDate("date").setRange(start, end).toQueryString());
+		Assertions.assertEquals("-date:[2014-10-05 TO 2014-12-31]", FilterFactory.rangeDate("date").setRange(start, end).setExclude().toQueryString());
+
+		// toQuery uses the base query string and applies exclusion as the FILTER_NOT query type
+		ZuliaQuery.Query included = FilterFactory.rangeDate("date").setRange(start, end).toQuery().getQuery();
+		Assertions.assertEquals("date:[2014-10-05 TO 2014-12-31]", included.getQ());
+		Assertions.assertEquals(ZuliaQuery.Query.QueryType.FILTER, included.getQueryType());
+
+		ZuliaQuery.Query excluded = FilterFactory.rangeDate("date").setRange(start, end).setExclude().toQuery().getQuery();
+		Assertions.assertEquals("date:[2014-10-05 TO 2014-12-31]", excluded.getQ());
+		Assertions.assertEquals(ZuliaQuery.Query.QueryType.FILTER_NOT, excluded.getQueryType());
+	}
+
+	@Test
+	public void rangeLocalDate() {
+		LocalDate start = LocalDate.of(2014, 1, 1);
+		LocalDate end = LocalDate.of(2014, 12, 31);
+
+		// base query string: brackets reflect endpoint behavior, * marks a missing endpoint, no exclusion
+		Assertions.assertEquals("date:[2014-01-01 TO 2014-12-31]", FilterFactory.rangeLocalDate("date").setRange(start, end).getBaseQuery());
+		Assertions.assertEquals("date:[2014-10-05 TO *]", FilterFactory.rangeLocalDate("date").setMinValue(LocalDate.of(2014, 10, 5)).getBaseQuery());
+		Assertions.assertEquals("date:[* TO 2014-10-05]", FilterFactory.rangeLocalDate("date").setMaxValue(LocalDate.of(2014, 10, 5)).getBaseQuery());
+		Assertions.assertEquals("date:{2014-01-01 TO 2014-12-31}",
+				FilterFactory.rangeLocalDate("date").setRange(start, end).setEndpointBehavior(RangeBehavior.EXCLUSIVE).getBaseQuery());
+		Assertions.assertEquals("date:[2014-01-01 TO 2014-12-31}",
+				FilterFactory.rangeLocalDate("date").setRange(start, end).setEndpointBehavior(RangeBehavior.INCLUDE_MIN).getBaseQuery());
+		Assertions.assertEquals("date:{2014-01-01 TO 2014-12-31]",
+				FilterFactory.rangeLocalDate("date").setRange(start, end).setEndpointBehavior(RangeBehavior.INCLUDE_MAX).getBaseQuery());
+
+		// toQueryString prefixes - when excluded; the base query is never negated
+		Assertions.assertEquals("date:[2014-01-01 TO 2014-12-31]", FilterFactory.rangeLocalDate("date").setRange(start, end).toQueryString());
+		Assertions.assertEquals("-date:[2014-01-01 TO 2014-12-31]", FilterFactory.rangeLocalDate("date").setRange(start, end).setExclude().toQueryString());
+
+		// toQuery uses the base query string and applies exclusion as the FILTER_NOT query type
+		ZuliaQuery.Query included = FilterFactory.rangeLocalDate("date").setRange(start, end).toQuery().getQuery();
+		Assertions.assertEquals("date:[2014-01-01 TO 2014-12-31]", included.getQ());
+		Assertions.assertEquals(ZuliaQuery.Query.QueryType.FILTER, included.getQueryType());
+
+		ZuliaQuery.Query excluded = FilterFactory.rangeLocalDate("date").setRange(start, end).setExclude().toQuery().getQuery();
+		Assertions.assertEquals("date:[2014-01-01 TO 2014-12-31]", excluded.getQ());
+		Assertions.assertEquals(ZuliaQuery.Query.QueryType.FILTER_NOT, excluded.getQueryType());
+	}
+}

--- a/zulia-common/src/main/java/io/zulia/util/ZuliaDateUtil.java
+++ b/zulia-common/src/main/java/io/zulia/util/ZuliaDateUtil.java
@@ -11,14 +11,20 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 import java.time.format.SignStyle;
 import java.time.temporal.ChronoField;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 public class ZuliaDateUtil {
 
+	// zone offset is optional and when omitted, the timestamp is assumed to be UTC (OFFSET_SECONDS defaults to 0 only when
+	// not parsed from the text, so an explicit offset such as Z or +05:30 is honored)
 	public static final DateTimeFormatter YEAR_MONTH_DAY_TIME = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4).appendLiteral('-')
 			.appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('-').appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER)
-			.appendLiteral('T').append(ISO_LOCAL_TIME).appendOffsetId().toFormatter();
+			.appendLiteral('T').append(ISO_LOCAL_TIME).optionalStart().appendOffsetId().optionalEnd().parseDefaulting(ChronoField.OFFSET_SECONDS, 0)
+			.toFormatter();
 
 	public static final DateTimeFormatter YEAR_MONTH_DAY = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4).appendLiteral('-')
 			.appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).appendLiteral('-').appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NEVER)
@@ -28,6 +34,28 @@ public class ZuliaDateUtil {
 			.appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NEVER).toFormatter();
 
 	public static final DateTimeFormatter YEAR_ONLY = new DateTimeFormatterBuilder().appendValue(ChronoField.YEAR, 4).toFormatter();
+
+	public record DateFormatSpec(String label, String pattern, String example) {
+		public String describe() {
+			return label + ": " + pattern + " (e.g. " + example + ")";
+		}
+	}
+
+	/**
+	 * Every date String layout accepted by {@link #getParseDate(String)} / {@link #parseToEpochMilli(String)} /
+	 * {@link #convertToDate(Object, String)}. Add a new format here when a new DateTimeFormatter is added / parsing is changed
+	 */
+	public static final List<DateFormatSpec> SUPPORTED_DATE_FORMATS = List.of(
+			new DateFormatSpec("timestamp with optional zone offset (assumed UTC when omitted)", "yyyy-MM-dd'T'HH:mm[:ss[.SSS]][XXX]", "2024-06-17T16:10:00Z"),
+			new DateFormatSpec("date", "yyyy-MM-dd", "2024-06-17"), new DateFormatSpec("year-month", "yyyy-MM", "2024-06"),
+			new DateFormatSpec("year", "yyyy", "2024"));
+
+	/**
+	 * Human-readable description of every supported date String layout, derived from {@link #SUPPORTED_DATE_FORMATS} so
+	 * indexing, sorting, faceting, and querying all report the same formats.
+	 */
+	public static final String SUPPORTED_DATE_STRING_FORMATS =
+			SUPPORTED_DATE_FORMATS.stream().map(DateFormatSpec::describe).collect(Collectors.joining("; ")) + "; '/' may be used in place of '-'";
 
 	public record DateBounds(long begin, long end) {
 
@@ -47,7 +75,6 @@ public class ZuliaDateUtil {
 				return new DateBounds(epochMilli, epochMilli);
 			}
 			catch (DateTimeParseException e) {
-				System.out.println(e.getMessage());
 				return null;
 			}
 		}
@@ -85,6 +112,51 @@ public class ZuliaDateUtil {
 
 		}
 
+	}
+
+	/**
+	 * Parses a date String to a single epoch milli suitable for indexing, sorting, or faceting a single value.
+	 * For partial dates (year, year-month, year-month-day) the start of the period (UTC) is used, matching the lower
+	 * bound used on the query side.
+	 *
+	 * @param dateString a date in one of the {@link #SUPPORTED_DATE_STRING_FORMATS}
+	 * @return the epoch milli, or {@code null} if the String cannot be parsed
+	 */
+	public static Long parseToEpochMilli(String dateString) {
+		DateBounds dateBounds = getParseDate(dateString);
+		return dateBounds == null ? null : dateBounds.begin();
+	}
+
+	/**
+	 * Resolves a stored field value to a {@link Date} for indexing, sorting, and faceting a date field. Accepts a
+	 * {@link Date} as-is, a {@link Number} treated as epoch milliseconds, or a String in one of the
+	 * {@link #SUPPORTED_DATE_STRING_FORMATS}. A {@code null} or blank value is treated as no value and returns
+	 * {@code null}.
+	 *
+	 * @param value        the value from the stored document
+	 * @param fieldContext description of the field used in error messages, e.g. {@code "field <publishDate>"}
+	 * @return the resolved Date, or {@code null} when there is no usable value
+	 * @throws IllegalArgumentException if the value is not a Date, Number, or parseable date String
+	 */
+	public static Date convertToDate(Object value, String fieldContext) {
+		return switch (value) {
+			case null -> null;
+			case Date date -> date;
+			case Number number -> new Date(number.longValue());
+			case String dateString -> {
+				if (dateString.isBlank()) {
+					yield null;
+				}
+				Long epochMilli = parseToEpochMilli(dateString);
+				if (epochMilli == null) {
+					throw new IllegalArgumentException("String value <" + dateString + "> for date " + fieldContext + " cannot be parsed. Supported formats: "
+							+ SUPPORTED_DATE_STRING_FORMATS);
+				}
+				yield new Date(epochMilli);
+			}
+			default -> throw new IllegalArgumentException(
+					"Expecting Date, epoch milliseconds Number, or date String for " + fieldContext + " and found <" + value.getClass().getSimpleName() + ">");
+		};
 	}
 
 }

--- a/zulia-query-parser/src/test/java/io/zulia/queryparser/test/QueryParserTest.java
+++ b/zulia-query-parser/src/test/java/io/zulia/queryparser/test/QueryParserTest.java
@@ -6,6 +6,7 @@ import io.zulia.message.ZuliaQuery;
 import io.zulia.server.analysis.ZuliaPerFieldAnalyzer;
 import io.zulia.server.config.ServerIndexConfig;
 import io.zulia.server.search.queryparser.ZuliaFlexibleQueryParser;
+import io.zulia.server.search.queryparser.parser.ParseException;
 import org.apache.lucene.search.Query;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -77,6 +78,52 @@ public class QueryParserTest {
 
 
 
+	}
+
+	@Test
+	public void offsetlessTimestampQueryTest() throws Exception {
+
+		ZuliaFlexibleQueryParser zuliaFlexibleQueryParser = dateFieldParser();
+
+		// timestamps are used as range bounds; an offset-less bound is assumed UTC, matching the explicit Z form
+		Query offsetless = zuliaFlexibleQueryParser.parse("added:[2024-06-17T16:10:00 TO 2024-06-18T08:00:00]");
+		Query explicitUtc = zuliaFlexibleQueryParser.parse("added:[2024-06-17T16:10:00Z TO 2024-06-18T08:00:00Z]");
+		Assertions.assertEquals(explicitUtc, offsetless);
+
+		// sanity: a different instant parses to a different range, so the equality above is not two empty parses
+		Query differentInstant = zuliaFlexibleQueryParser.parse("added:[2024-06-17T16:11:00Z TO 2024-06-18T08:00:00Z]");
+		Assertions.assertNotEquals(explicitUtc, differentInstant);
+	}
+
+	@Test
+	public void quotedTimestampQueryTest() throws Exception {
+
+		ZuliaFlexibleQueryParser zuliaFlexibleQueryParser = dateFieldParser();
+
+		// a bare timestamp point query fails because the ':' are read as field separators
+		Assertions.assertThrows(ParseException.class, () -> zuliaFlexibleQueryParser.parse("added:2024-06-17T16:10:00Z"));
+
+		// quoting it is the escape: it parses to the same single-instant range as the explicit [x TO x] range form
+		Query quoted = zuliaFlexibleQueryParser.parse("added:\"2024-06-17T16:10:00Z\"");
+		Query range = zuliaFlexibleQueryParser.parse("added:[2024-06-17T16:10:00Z TO 2024-06-17T16:10:00Z]");
+		Assertions.assertEquals(range, quoted);
+
+		// backslash-escaping the colons is the other escape and yields the same query
+		Query escaped = zuliaFlexibleQueryParser.parse("added:2024-06-17T16\\:10\\:00Z");
+		Assertions.assertEquals(quoted, escaped);
+
+		// quoting also accepts an offset-less timestamp (assumed UTC)
+		Query quotedOffsetless = zuliaFlexibleQueryParser.parse("added:\"2024-06-17T16:10:00\"");
+		Assertions.assertEquals(quoted, quotedOffsetless);
+	}
+
+	private static ZuliaFlexibleQueryParser dateFieldParser() throws Exception {
+		ZuliaIndex.IndexSettings.Builder builder = ZuliaIndex.IndexSettings.newBuilder();
+		builder.addFieldConfig(ZuliaIndex.FieldConfig.newBuilder().addIndexAs(ZuliaIndex.IndexAs.newBuilder().setIndexFieldName("added").build())
+				.setFieldType(ZuliaIndex.FieldConfig.FieldType.DATE).setStoredFieldName("added").build());
+
+		ServerIndexConfig serverIndexConfig = new ServerIndexConfig(builder.build());
+		return new ZuliaFlexibleQueryParser(new ZuliaPerFieldAnalyzer(serverIndexConfig), serverIndexConfig);
 	}
 
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardDocumentIndexer.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardDocumentIndexer.java
@@ -18,6 +18,7 @@ import io.zulia.server.index.field.IntFieldIndexer;
 import io.zulia.server.index.field.LongFieldIndexer;
 import io.zulia.server.index.field.StringFieldIndexer;
 import io.zulia.util.BooleanUtil;
+import io.zulia.util.ZuliaDateUtil;
 import io.zulia.util.ZuliaUtil;
 import io.zulia.util.ZuliaVersion;
 import io.zulia.util.document.DocumentHelper;
@@ -460,14 +461,9 @@ public class ShardDocumentIndexer {
 			}
 			else if (FieldTypeUtil.isDateFieldType(fieldType)) {
 				ZuliaUtil.handleListsUniqueValues(o, obj -> {
-					if (obj instanceof Date date) {
-						SortedNumericDocValuesField docValue = new SortedNumericDocValuesField(sortFieldName, date.getTime());
-						d.add(docValue);
-					}
-					else {
-						throw new RuntimeException(
-								"Expecting date for document field <" + storedFieldName + "> / sort field <" + sortFieldName + ">, found <" + o.getClass()
-										+ ">");
+					Date date = ZuliaDateUtil.convertToDate(obj, "document field <" + storedFieldName + "> / sort field <" + sortFieldName + ">");
+					if (date != null) {
+						d.add(new SortedNumericDocValuesField(sortFieldName, date.getTime()));
 					}
 				});
 			}
@@ -491,8 +487,10 @@ public class ShardDocumentIndexer {
 				if (FieldTypeUtil.isDateFieldType(fc.getFieldType())) {
 					ZuliaIndex.FacetAs.DateHandling dateHandling = fa.getDateHandling();
 					ZuliaUtil.handleListsUniqueValues(o, obj -> {
-						if (obj instanceof Date) {
-							LocalDate localDate = ((Date) (obj)).toInstant().atZone(ZoneId.of("UTC")).toLocalDate();
+						Date date = ZuliaDateUtil.convertToDate(obj,
+								"document field <" + fc.getStoredFieldName() + "> / facet <" + fa.getFacetName() + ">");
+						if (date != null) {
+							LocalDate localDate = date.toInstant().atZone(ZoneId.of("UTC")).toLocalDate();
 
 							if (ZuliaIndex.FacetAs.DateHandling.DATE_YYYYMMDD.equals(dateHandling)) {
 								facetFieldsForField.add(
@@ -507,11 +505,6 @@ public class ShardDocumentIndexer {
 							else {
 								throw new RuntimeException("Not handled date handling <" + dateHandling + "> for facet <" + fa.getFacetName() + ">");
 							}
-
-						}
-						else {
-							throw new RuntimeException("Cannot facet date for document field <" + fc.getStoredFieldName() + "> / facet <" + fa.getFacetName()
-									+ ">: excepted Date or Collection of Date, found <" + o.getClass().getSimpleName() + ">");
 						}
 					});
 				}
@@ -530,8 +523,10 @@ public class ShardDocumentIndexer {
 				if (FieldConfig.FieldType.DATE.equals(fc.getFieldType())) {
 					ZuliaIndex.FacetAs.DateHandling dateHandling = fa.getDateHandling();
 					ZuliaUtil.handleListsUniqueValues(o, obj -> {
-						if (obj instanceof Date) {
-							LocalDate localDate = ((Date) (obj)).toInstant().atZone(ZoneId.of("UTC")).toLocalDate();
+						Date dateValue = ZuliaDateUtil.convertToDate(obj,
+								"document field <" + fc.getStoredFieldName() + "> / facet <" + fa.getFacetName() + ">");
+						if (dateValue != null) {
+							LocalDate localDate = dateValue.toInstant().atZone(ZoneId.of("UTC")).toLocalDate();
 
 							if (ZuliaIndex.FacetAs.DateHandling.DATE_YYYYMMDD.equals(dateHandling)) {
 								String date = String.format("%02d%02d%02d", localDate.getYear(), localDate.getMonthValue(), localDate.getDayOfMonth());
@@ -546,11 +541,6 @@ public class ShardDocumentIndexer {
 							else {
 								throw new RuntimeException("Not handled date handling <" + dateHandling + "> for facet <" + fa.getFacetName() + ">");
 							}
-
-						}
-						else {
-							throw new RuntimeException("Cannot facet date for document field <" + fc.getStoredFieldName() + "> / facet <" + fa.getFacetName()
-									+ ">: excepted Date or Collection of Date, found <" + o.getClass().getSimpleName() + ">");
 						}
 					});
 				}

--- a/zulia-server/src/main/java/io/zulia/server/index/field/DateFieldIndexer.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/field/DateFieldIndexer.java
@@ -2,6 +2,7 @@ package io.zulia.server.index.field;
 
 import io.zulia.message.ZuliaIndex.FieldConfig.FieldType;
 import io.zulia.server.field.FieldTypeUtil;
+import io.zulia.util.ZuliaDateUtil;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.LongPoint;
@@ -18,14 +19,9 @@ public class DateFieldIndexer extends FieldIndexer {
 
 	@Override
 	protected void handleValue(Document d, String storedFieldName, Object value, String indexedFieldName) throws Exception {
-		if (value != null) {
-			if (value instanceof Date date) {
-				d.add(createField(date, indexedFieldName));
-			}
-			else {
-				throw new Exception(
-						"Expecting collection of Date or Date for field <" + storedFieldName + "> and found <" + value.getClass().getSimpleName() + ">");
-			}
+		Date date = ZuliaDateUtil.convertToDate(value, "field <" + storedFieldName + ">");
+		if (date != null) {
+			d.add(createField(date, indexedFieldName));
 		}
 	}
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/DateStringTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/DateStringTest.java
@@ -1,0 +1,236 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.CountFacet;
+import io.zulia.client.command.builder.FilterQuery;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.command.builder.Sort;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.SearchResult;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.message.ZuliaIndex.FacetAs;
+import io.zulia.message.ZuliaQuery.FacetCount;
+import io.zulia.server.test.node.shared.NodeExtension;
+import io.zulia.util.ZuliaDateUtil;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Verifies that a DATE field accepts date values supplied as Strings (e.g. "2024-06-17T16:10:00Z", "2024-06-17",
+ * an offset-less "2024-03-15T08:30:00", or a year/year-month) as well as epoch milliseconds as a Number, across all
+ * paths that consume a date: indexing (range queries), sorting, and faceting (flat and hierarchical). Blank values
+ * are skipped like absent fields, and unparseable strings are rejected with a message listing every supported format.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class DateStringTest {
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(3);
+
+	private static final String INDEX_NAME = "dateStringTest";
+
+	// real Date used for the control document, also the latest date in the set
+	private static final Date CONTROL_DATE = Date.from(LocalDate.of(2025, Month.DECEMBER, 25).atStartOfDay(ZoneId.of("UTC")).toInstant());
+
+	// epoch milliseconds (a long) for 2023-07-04, supplied as a Number rather than a String
+	private static final long EPOCH_MILLIS_2023 = Date.from(LocalDate.of(2023, Month.JULY, 4).atStartOfDay(ZoneId.of("UTC")).toInstant()).getTime();
+
+	@Test
+	@Order(1)
+	public void createIndexAndStore() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("id");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		// one DATE field exercised for indexing, sorting, a flat facet ("added") and a hierarchical facet ("addedHier")
+		indexConfig.addFieldConfig(FieldConfigBuilder.createDate("added").index().sort().facetAs(FacetAs.DateHandling.DATE_YYYY_MM_DD)
+				.facetAsHierarchical("addedHier", FacetAs.DateHandling.DATE_YYYY_MM_DD));
+		indexConfig.setIndexName(INDEX_NAME);
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setShardCommitInterval(2); //force some commits
+
+		zuliaWorkPool.createIndex(indexConfig);
+
+		// added supplied in every supported form
+		store(zuliaWorkPool, "0", "2024-06-17T16:10:00Z");  // full timestamp with offset
+		store(zuliaWorkPool, "1", "2024-06-17");            // date only -> start of day UTC
+		store(zuliaWorkPool, "2", "2024/06/18");            // slash separator, date only
+		store(zuliaWorkPool, "3", "2022");                  // year only -> 2022-01-01
+		store(zuliaWorkPool, "4", "2022-03");               // year-month -> 2022-03-01
+		store(zuliaWorkPool, "5", CONTROL_DATE);            // real java.util.Date control
+		store(zuliaWorkPool, "6", "");                      // blank -> skipped (no date indexed)
+		store(zuliaWorkPool, "7", "2024-03-15T08:30:00");   // timestamp without offset -> assumed UTC
+		store(zuliaWorkPool, "8", EPOCH_MILLIS_2023);       // epoch milliseconds as a Number
+	}
+
+	@Test
+	@Order(2)
+	public void rangeQuery() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// all 9 docs are stored, including the blank one (its date is simply not indexed)
+		SearchResult all = zuliaWorkPool.search(new Search(INDEX_NAME).setAmount(100).setRealtime(true));
+		Assertions.assertEquals(9, all.getTotalHits());
+
+		// the timestamp doc (id 0) and the date-only doc (id 1) both fall on 2024-06-17
+		SearchResult onDay = zuliaWorkPool.search(new Search(INDEX_NAME).setAmount(100).setRealtime(true).addQuery(new FilterQuery("added:2024-06-17")));
+		Assertions.assertEquals(2, onDay.getTotalHits());
+
+		// a year query covers the whole year: 2024-06-17 (x2), 2024-06-18, and the offset-less 2024-03-15
+		SearchResult onYear = zuliaWorkPool.search(new Search(INDEX_NAME).setAmount(100).setRealtime(true).addQuery(new FilterQuery("added:2024")));
+		Assertions.assertEquals(4, onYear.getTotalHits());
+
+		// explicit range with a full timestamp upper bound matches every parsed form within it
+		SearchResult range = zuliaWorkPool.search(
+				new Search(INDEX_NAME).setAmount(100).setRealtime(true).addQuery(new FilterQuery("added:[2022-02-01 TO 2024-06-17T23:59:59Z]")));
+		Assertions.assertEquals(5, range.getTotalHits()); // 2022-03-01, 2023-07-04, 2024-03-15, 2024-06-17 (x2)
+	}
+
+	@Test
+	@Order(3)
+	public void sort() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		Search ascending = new Search(INDEX_NAME).setAmount(10).setRealtime(true);
+		ascending.addSort(new Sort("added").ascending().missingLast());
+		Assertions.assertEquals("3", zuliaWorkPool.search(ascending).getFirstDocument().get("id")); // 2022-01-01 is earliest
+
+		// missingFirst ranks the missing value lowest, so in descending order the latest real date comes first
+		Search descending = new Search(INDEX_NAME).setAmount(10).setRealtime(true);
+		descending.addSort(new Sort("added").descending().missingFirst());
+		Assertions.assertEquals("5", zuliaWorkPool.search(descending).getFirstDocument().get("id")); // control 2025-12-25 is latest
+
+		// the blank doc has no sort value, so it lands last when missing values sort last
+		Search ascendingMissingLast = new Search(INDEX_NAME).setAmount(10).setRealtime(true);
+		ascendingMissingLast.addSort(new Sort("added").ascending().missingLast());
+		Assertions.assertEquals("6", zuliaWorkPool.search(ascendingMissingLast).getDocuments().getLast().get("id"));
+	}
+
+	@Test
+	@Order(4)
+	public void flatFacet() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		SearchResult facetResult = zuliaWorkPool.search(
+				new Search(INDEX_NAME).setAmount(0).setRealtime(true).addCountFacet(new CountFacet("added").setTopN(20)));
+
+		Map<String, Long> counts = facetCounts(facetResult, "added");
+
+		Assertions.assertEquals(2L, (long) counts.get("2024-06-17")); // id 0 (timestamp) + id 1 (date)
+		Assertions.assertEquals(1L, (long) counts.get("2024-06-18")); // id 2 (slash separator)
+		Assertions.assertEquals(1L, (long) counts.get("2022-01-01")); // id 3 (year only)
+		Assertions.assertEquals(1L, (long) counts.get("2022-03-01")); // id 4 (year-month)
+		Assertions.assertEquals(1L, (long) counts.get("2025-12-25")); // id 5 (control Date)
+		Assertions.assertEquals(1L, (long) counts.get("2024-03-15")); // id 7 (offset-less timestamp)
+		Assertions.assertEquals(1L, (long) counts.get("2023-07-04")); // id 8 (epoch millis Number)
+		Assertions.assertNull(counts.get("1970-01-01")); // blank (id 6) produced no facet
+	}
+
+	@Test
+	@Order(5)
+	public void hierarchicalFacet() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// top level of a hierarchical date facet is the year
+		SearchResult facetResult = zuliaWorkPool.search(
+				new Search(INDEX_NAME).setAmount(0).setRealtime(true).addCountFacet(new CountFacet("addedHier").setTopN(20)));
+
+		Map<String, Long> yearCounts = facetCounts(facetResult, "addedHier");
+
+		Assertions.assertEquals(4L, (long) yearCounts.get("2024")); // id 0, 1, 2, 7
+		Assertions.assertEquals(2L, (long) yearCounts.get("2022")); // id 3, 4
+		Assertions.assertEquals(1L, (long) yearCounts.get("2025")); // id 5
+		Assertions.assertEquals(1L, (long) yearCounts.get("2023")); // id 8 (epoch millis Number)
+
+		// drill into 2024 -> month 3 (offset-less timestamp) and month 6 (the rest)
+		SearchResult drill = zuliaWorkPool.search(new Search(INDEX_NAME).setAmount(0).setRealtime(true).addCountFacet(new CountFacet("addedHier", "2024")));
+		Map<String, Long> monthCounts = new HashMap<>();
+		for (FacetCount facetCount : drill.getFacetCountsForPath("addedHier", "2024")) {
+			monthCounts.put(facetCount.getFacet(), facetCount.getCount());
+		}
+		Assertions.assertEquals(3L, (long) monthCounts.get("6")); // id 0, 1, 2
+		Assertions.assertEquals(1L, (long) monthCounts.get("3")); // id 7
+	}
+
+	@Test
+	@Order(6)
+	public void invalidStringRejected() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		Document badDocument = new Document();
+		badDocument.put("id", "bad");
+		badDocument.put("added", "not-a-date");
+
+		// unparseable date string fails the store (the sort path validates first, then indexing)
+		Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.store(new Store("bad", INDEX_NAME, ResultDocBuilder.from(badDocument))));
+	}
+
+	@Test
+	@Order(7)
+	public void convertToDateContract() {
+		// null and blank are treated as no value (skipped), not errors
+		Assertions.assertNull(ZuliaDateUtil.convertToDate(null, "field <added>"));
+		Assertions.assertNull(ZuliaDateUtil.convertToDate("", "field <added>"));
+		Assertions.assertNull(ZuliaDateUtil.convertToDate("   ", "field <added>"));
+
+		// Date passes through unchanged
+		Date real = new Date(1_700_000_000_000L);
+		Assertions.assertSame(real, ZuliaDateUtil.convertToDate(real, "field <added>"));
+
+		// a Number is interpreted as epoch milliseconds
+		Assertions.assertEquals(new Date(1_700_000_000_000L), ZuliaDateUtil.convertToDate(1_700_000_000_000L, "field <added>"));
+
+		// an offset-less timestamp is assumed to be UTC
+		Assertions.assertEquals(Date.from(LocalDateTime.of(2024, 3, 15, 8, 30, 0).toInstant(ZoneOffset.UTC)),
+				ZuliaDateUtil.convertToDate("2024-03-15T08:30:00", "field <added>"));
+
+		// an explicit offset is honored rather than overridden to UTC
+		Assertions.assertEquals(Date.from(LocalDateTime.of(2024, 3, 15, 8, 30, 0).toInstant(ZoneOffset.ofHoursMinutes(5, 30))),
+				ZuliaDateUtil.convertToDate("2024-03-15T08:30:00+05:30", "field <added>"));
+
+		// an unparseable string is rejected with a message listing every supported format
+		IllegalArgumentException badString = Assertions.assertThrows(IllegalArgumentException.class,
+				() -> ZuliaDateUtil.convertToDate("not-a-date", "field <added>"));
+		Assertions.assertTrue(badString.getMessage().contains("cannot be parsed"), badString.getMessage());
+		Assertions.assertTrue(badString.getMessage().contains(ZuliaDateUtil.SUPPORTED_DATE_STRING_FORMATS), badString.getMessage());
+
+		// an unsupported type is rejected
+		IllegalArgumentException badType = Assertions.assertThrows(IllegalArgumentException.class,
+				() -> ZuliaDateUtil.convertToDate(List.of(1, 2), "field <added>"));
+		Assertions.assertTrue(badType.getMessage().contains("Expecting Date"), badType.getMessage());
+	}
+
+	private static Map<String, Long> facetCounts(SearchResult searchResult, String field) {
+		Map<String, Long> counts = new HashMap<>();
+		for (FacetCount facetCount : searchResult.getFacetCounts(field)) {
+			counts.put(facetCount.getFacet(), facetCount.getCount());
+		}
+		return counts;
+	}
+
+	private static void store(ZuliaWorkPool zuliaWorkPool, String id, Object added) throws Exception {
+		Document document = new Document();
+		document.put("id", id);
+		document.put("added", added);
+		zuliaWorkPool.store(new Store(id, INDEX_NAME, ResultDocBuilder.from(document)));
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/DateStringTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/DateStringTest.java
@@ -12,7 +12,6 @@ import io.zulia.client.result.SearchResult;
 import io.zulia.doc.ResultDocBuilder;
 import io.zulia.fields.FieldConfigBuilder;
 import io.zulia.message.ZuliaIndex.FacetAs;
-import io.zulia.message.ZuliaQuery.FacetCount;
 import io.zulia.server.test.node.shared.NodeExtension;
 import io.zulia.util.ZuliaDateUtil;
 import org.bson.Document;
@@ -29,7 +28,6 @@ import java.time.Month;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -133,7 +131,7 @@ public class DateStringTest {
 		SearchResult facetResult = zuliaWorkPool.search(
 				new Search(INDEX_NAME).setAmount(0).setRealtime(true).addCountFacet(new CountFacet("added").setTopN(20)));
 
-		Map<String, Long> counts = facetCounts(facetResult, "added");
+		Map<String, Long> counts = facetResult.getFacetCountsAsMap("added");
 
 		Assertions.assertEquals(2L, (long) counts.get("2024-06-17")); // id 0 (timestamp) + id 1 (date)
 		Assertions.assertEquals(1L, (long) counts.get("2024-06-18")); // id 2 (slash separator)
@@ -154,7 +152,7 @@ public class DateStringTest {
 		SearchResult facetResult = zuliaWorkPool.search(
 				new Search(INDEX_NAME).setAmount(0).setRealtime(true).addCountFacet(new CountFacet("addedHier").setTopN(20)));
 
-		Map<String, Long> yearCounts = facetCounts(facetResult, "addedHier");
+		Map<String, Long> yearCounts = facetResult.getFacetCountsAsMap("addedHier");
 
 		Assertions.assertEquals(4L, (long) yearCounts.get("2024")); // id 0, 1, 2, 7
 		Assertions.assertEquals(2L, (long) yearCounts.get("2022")); // id 3, 4
@@ -163,10 +161,7 @@ public class DateStringTest {
 
 		// drill into 2024 -> month 3 (offset-less timestamp) and month 6 (the rest)
 		SearchResult drill = zuliaWorkPool.search(new Search(INDEX_NAME).setAmount(0).setRealtime(true).addCountFacet(new CountFacet("addedHier", "2024")));
-		Map<String, Long> monthCounts = new HashMap<>();
-		for (FacetCount facetCount : drill.getFacetCountsForPath("addedHier", "2024")) {
-			monthCounts.put(facetCount.getFacet(), facetCount.getCount());
-		}
+		Map<String, Long> monthCounts = drill.getFacetCountsAsMap("addedHier", "2024");
 		Assertions.assertEquals(3L, (long) monthCounts.get("6")); // id 0, 1, 2
 		Assertions.assertEquals(1L, (long) monthCounts.get("3")); // id 7
 	}
@@ -217,14 +212,6 @@ public class DateStringTest {
 		IllegalArgumentException badType = Assertions.assertThrows(IllegalArgumentException.class,
 				() -> ZuliaDateUtil.convertToDate(List.of(1, 2), "field <added>"));
 		Assertions.assertTrue(badType.getMessage().contains("Expecting Date"), badType.getMessage());
-	}
-
-	private static Map<String, Long> facetCounts(SearchResult searchResult, String field) {
-		Map<String, Long> counts = new HashMap<>();
-		for (FacetCount facetCount : searchResult.getFacetCounts(field)) {
-			counts.put(facetCount.getFacet(), facetCount.getCount());
-		}
-		return counts;
 	}
 
 	private static void store(ZuliaWorkPool zuliaWorkPool, String id, Object added) throws Exception {


### PR DESCRIPTION
- Date fields now accept String/Number (epoch-millisecond) date values
  *  Date Strings of `2024-06-17T16:10:00Z`, offsetless `2024-06-17T16:10:00` assumes UTC, `2024-06-17`, `2024-06`, `2024` are suppported.   Can be `-` or `/` seperated.  `null`/blank is treated as no value and skipped.
- Align indexing, sorting, and faceting (flat and hierarchical) in `ShardDocumentIndexer`/`DateFieldIndexer` all route through `convertToDate`.
- Zone offset is now optional for queries (UTC default)
- Fixed `FilterFactory.rangeDate`, which threw `UnsupportedTemporalTypeException` (`ISO_LOCAL_DATE` on an `Instant`) for any populated date bound.  It now derives the calendar date in UTC
- `RangeFilter` now has `getBaseQuery()` (range string, no negation) and `toQueryString()` (prefixes `-` when excluded).  `toQuery()` builds from `getBaseQuery()` and keeps applying exclusion as the `FILTER_NOT` query type, so its behavior is unchanged.
- Added `DateStringTest` (zulia-server) and `FilterFactoryTest` (zulia-client)
