### PR TITLE
zulia-data spreadsheet I/O fixes and DataInputStream buffering refactor

### DIFF
--- a/zulia-data/src/main/java/io/zulia/data/input/DataInputStream.java
+++ b/zulia-data/src/main/java/io/zulia/data/input/DataInputStream.java
@@ -2,12 +2,25 @@ package io.zulia.data.input;
 
 import io.zulia.data.common.DataStreamMeta;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 public interface DataInputStream {
 
-	InputStream openInputStream() throws IOException;
+	/**
+	 * Provides the underlying stream. Implementations return the raw stream, which may or may not be buffered.
+	 */
+	InputStream openRawInputStream() throws IOException;
+
+	/**
+	 * Returns a stream safe for direct reads. The returned stream is buffered; when the raw stream is already a
+	 * {@link BufferedInputStream} it is returned unchanged to avoid double buffering.
+	 */
+	default InputStream openInputStream() throws IOException {
+		InputStream in = openRawInputStream();
+		return in instanceof BufferedInputStream ? in : new BufferedInputStream(in);
+	}
 
 	DataStreamMeta getMeta();
 

--- a/zulia-data/src/main/java/io/zulia/data/input/FileDataInputStream.java
+++ b/zulia-data/src/main/java/io/zulia/data/input/FileDataInputStream.java
@@ -2,7 +2,6 @@ package io.zulia.data.input;
 
 import io.zulia.data.common.DataStreamMeta;
 
-import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -31,13 +30,14 @@ public class FileDataInputStream implements DataInputStream {
 	}
 
 	@Override
-	public InputStream openInputStream() throws IOException {
+	public InputStream openRawInputStream() throws IOException {
 
 		InputStream in = new FileInputStream(file);
 		if (DataStreamMeta.isGzipExtension(file.getName())) {
-			in = new GZIPInputStream(in);
+			// set the inflater's read buffer to 64KB chunks rather than the 512-byte default
+			in = new GZIPInputStream(in, 1 << 16);
 		}
-		return new BufferedInputStream(in);
+		return in;
 	}
 
 	@Override

--- a/zulia-data/src/main/java/io/zulia/data/input/SingleUseDataInputStream.java
+++ b/zulia-data/src/main/java/io/zulia/data/input/SingleUseDataInputStream.java
@@ -28,7 +28,7 @@ public class SingleUseDataInputStream implements DataInputStream {
 	}
 
 	@Override
-	public synchronized InputStream openInputStream() throws IOException {
+	public synchronized InputStream openRawInputStream() throws IOException {
 		if (inputStream == null) {
 			throw new IOException("SingleUseDataInputStream can only be used once");
 		}

--- a/zulia-data/src/main/java/io/zulia/data/input/SingleUseDataInputStream.java
+++ b/zulia-data/src/main/java/io/zulia/data/input/SingleUseDataInputStream.java
@@ -2,6 +2,7 @@ package io.zulia.data.input;
 
 import io.zulia.data.common.DataStreamMeta;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -20,6 +21,10 @@ public class SingleUseDataInputStream implements DataInputStream {
 
 	public static SingleUseDataInputStream from(InputStream inputStream, String contentType, String filename) throws IOException {
 		return new SingleUseDataInputStream(inputStream, new DataStreamMeta(contentType, filename));
+	}
+
+	public static SingleUseDataInputStream from(byte[] bytes, String filename) throws IOException {
+		return from(new ByteArrayInputStream(bytes), filename);
 	}
 
 	private SingleUseDataInputStream(InputStream inputStream, DataStreamMeta meta) {

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/delimited/DelimitedSource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/delimited/DelimitedSource.java
@@ -5,7 +5,6 @@ import de.siegmar.fastcsv.reader.CsvRecord;
 import io.zulia.data.common.HeaderMapping;
 import io.zulia.data.source.spreadsheet.SpreadsheetSource;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -15,6 +14,7 @@ public abstract class DelimitedSource<T extends DelimitedRecord, S extends Delim
 	private final S delimitedSourceConfig;
 	private final CsvReader.CsvReaderBuilder csvReaderBuilder;
 	private CsvReader<CsvRecord> csvRecords;
+	private Iterator<CsvRecord> recordIterator;
 	private List<String> nextRow;
 	private HeaderMapping headerMapping;
 
@@ -27,23 +27,24 @@ public abstract class DelimitedSource<T extends DelimitedRecord, S extends Delim
 	protected abstract CsvReader.CsvReaderBuilder createParser(S delimitedSourceConfig);
 
 	public void reset() throws IOException {
-		//csvReaderBuilder.stopParsing();
+		close();
 		open();
 	}
 
 	protected void open() throws IOException {
-		csvRecords = csvReaderBuilder.ofCsvRecord(new BufferedInputStream(delimitedSourceConfig.getDataInputStream().openInputStream()));
+		// FileDataInputStream already returns a BufferedInputStream and FastCSV buffers internally, so no extra wrapping
+		csvRecords = csvReaderBuilder.ofCsvRecord(delimitedSourceConfig.getDataInputStream().openInputStream());
+		recordIterator = csvRecords.iterator();
 
 		if (delimitedSourceConfig.hasHeaders()) {
-
-			List<String> headerRow = csvRecords.iterator().next().getFields();
+			if (!recordIterator.hasNext()) {
+				throw new IOException("Headers are required but the delimited source is empty");
+			}
+			List<String> headerRow = recordIterator.next().getFields();
 			headerMapping = new HeaderMapping(delimitedSourceConfig.getHeaderConfig(), headerRow);
-
 		}
 
-		if (csvRecords.iterator().hasNext()) {
-			nextRow = csvRecords.iterator().next().getFields();
-		}
+		nextRow = recordIterator.hasNext() ? recordIterator.next().getFields() : null;
 	}
 
 	public boolean hasHeader(String field) {
@@ -83,12 +84,7 @@ public abstract class DelimitedSource<T extends DelimitedRecord, S extends Delim
 			@Override
 			public T next() {
 				T t = createRecord(delimitedSourceConfig, nextRow.toArray(new String[0]));
-				if (csvRecords.iterator().hasNext()) {
-					nextRow = csvRecords.iterator().next().getFields();
-				}
-				else {
-					nextRow = null;
-				}
+				nextRow = recordIterator.hasNext() ? recordIterator.next().getFields() : null;
 				return t;
 			}
 
@@ -107,11 +103,14 @@ public abstract class DelimitedSource<T extends DelimitedRecord, S extends Delim
 
 	@Override
 	public void close() {
-		try {
-			csvRecords.close();
-		}
-		catch (IOException e) {
-			throw new RuntimeException("Could not close the CSV Records", e);
+		if (csvRecords != null) {
+			try {
+				csvRecords.close();
+			}
+			catch (IOException e) {
+				throw new RuntimeException("Could not close the CSV Records", e);
+			}
+			csvRecords = null;
 		}
 	}
 }

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/DefaultExcelCellHandler.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/DefaultExcelCellHandler.java
@@ -51,11 +51,11 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 	public Integer cellToInt(Cell cell) {
 
 		if (isCellNumeric(cell)) {
-			return (int) cell.getNumericCellValue();
+			return Math.toIntExact((long) cell.getNumericCellValue());
 		}
 		else if (isCellFormula(cell)) {
 			if (cell.getCachedFormulaResultType().equals(CellType.NUMERIC)) {
-				return (int) cell.getNumericCellValue();
+				return Math.toIntExact((long) cell.getNumericCellValue());
 			}
 		}
 		else if (isCellString(cell)) {
@@ -152,7 +152,7 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 	public String formatNumericCellAsString(Cell cell) {
 		Number numericCellValue = cell.getNumericCellValue();
 		if ((numericCellValue.doubleValue() == Math.floor(numericCellValue.doubleValue())) && !Double.isInfinite(numericCellValue.doubleValue())) {
-			return String.valueOf(numericCellValue.intValue());
+			return String.valueOf(numericCellValue.longValue());
 		}
 		else {
 			return String.valueOf(numericCellValue.doubleValue());

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSource.java
@@ -81,6 +81,9 @@ public class ExcelSource implements SpreadsheetSource<ExcelRecord>, AutoCloseabl
 
 	public ExcelSource switchSheet(String name) {
 		sheet = reader.getSheet(name);
+		if (sheet == null) {
+			throw new IllegalArgumentException("No sheet named " + name);
+		}
 		initializeSheet();
 		return this;
 	}
@@ -100,19 +103,19 @@ public class ExcelSource implements SpreadsheetSource<ExcelRecord>, AutoCloseabl
 	}
 
 	private void initializeSheet() {
-		numberOfRowsForSheet = sheet.getLastRowNum() + 1;
-		Row row = sheet.getRow(0);
+		// getLastRowNum() returns 0 for an empty sheet (ambiguous with a single row at index 0), so disambiguate on physical rows
+		numberOfRowsForSheet = (sheet.getPhysicalNumberOfRows() == 0) ? 0 : sheet.getLastRowNum() + 1;
+		Row firstRow = sheet.getRow(0);
 
-		int numberOfColumns = row.getLastCellNum();
+		int numberOfColumns = (firstRow == null) ? 0 : firstRow.getLastCellNum();
 
 		if (excelSourceConfig.hasHeaders()) {
 			ExcelCellHandler excelCellHandler = excelSourceConfig.getExcelCellHandler();
 
 			List<String> headerRow = new ArrayList<>();
-			Row header = sheet.getRow(0);
-			if (header != null) {
-				for (int i = 0; i < row.getLastCellNum(); i++) {
-					Cell cell = row.getCell(i);
+			if (firstRow != null) {
+				for (int i = 0; i < firstRow.getLastCellNum(); i++) {
+					Cell cell = firstRow.getCell(i);
 					headerRow.add(excelCellHandler.cellToString(cell));
 				}
 			}

--- a/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/excel/ExcelTarget.java
+++ b/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/excel/ExcelTarget.java
@@ -100,9 +100,12 @@ public class ExcelTarget extends SpreadsheetTarget<CellReference, ExcelTargetCon
 		this.sheet.addMergedRegion(new CellRangeAddress(firstRow, lastRow, firstCol, lastCol));
 	}
 
+	@Override
 	public void close() throws IOException {
-		try (OutputStream stream = excelDataTargetConfig.getDataStream().openOutputStream()) {
-			this.workbook.write(stream);
+		// closing the SXSSFWorkbook deletes the temporary files it writes to disk and releases the underlying
+		// workbook resources
+		try (workbook; OutputStream stream = excelDataTargetConfig.getDataStream().openOutputStream()) {
+			workbook.write(stream);
 		}
 	}
 

--- a/zulia-data/src/test/java/io/zulia/data/test/DataSourceTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/DataSourceTest.java
@@ -1,5 +1,7 @@
 package io.zulia.data.test;
 
+import io.zulia.data.common.DataStreamMeta;
+import io.zulia.data.input.DataInputStream;
 import io.zulia.data.input.SingleUseDataInputStream;
 import io.zulia.data.output.SingleUseDataOutputStream;
 import io.zulia.data.source.spreadsheet.SpreadsheetRecord;
@@ -11,7 +13,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.FilterInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.List;
 
 public class DataSourceTest {
@@ -67,6 +73,86 @@ public class DataSourceTest {
 			Assertions.assertEquals("header1", dataSource.getHeaders().getFirst());
 		}
 
+	}
+
+	@Test
+	void trulyEmptyDelimitedSourceWithHeadersThrowsIOException() throws IOException {
+		// a file with no rows at all (not even a header line) should surface a clear IOException rather than letting
+		// FastCSV's NoSuchElementException escape when headers are required
+		SingleUseDataInputStream dataInputStream = SingleUseDataInputStream.from(new ByteArrayInputStream(new byte[0]), "test.csv");
+		Assertions.assertThrows(IOException.class, () -> SpreadsheetSourceFactory.fromStreamWithHeaders(dataInputStream));
+	}
+
+	@Test
+	void reIterationDoesNotLeakStreams() throws IOException {
+		byte[] csv = "header1,header2\nvalue1,1\nvalue3,2\n".getBytes(StandardCharsets.UTF_8);
+		CountingDataInputStream dataInputStream = new CountingDataInputStream(csv, "test.csv");
+
+		try (SpreadsheetSource<?> dataSource = SpreadsheetSourceFactory.fromStreamWithHeaders(dataInputStream)) {
+			Assertions.assertEquals(2, countRows(dataSource));
+			// fully consuming then iterating again triggers reset()/open(); the previous reader must be closed first
+			Assertions.assertEquals(2, countRows(dataSource));
+		}
+
+		Assertions.assertTrue(dataInputStream.openCount() >= 2, "re-iteration should have reopened the source");
+		Assertions.assertEquals(0, dataInputStream.unclosedCount(), "every opened underlying stream should be closed");
+	}
+
+	private static int countRows(SpreadsheetSource<?> dataSource) {
+		int rows = 0;
+		for (SpreadsheetRecord ignored : dataSource) {
+			rows++;
+		}
+		return rows;
+	}
+
+	/**
+	 * A DataInputStream that hands back a fresh, tracked stream over the same bytes on every openRawInputStream() call so a
+	 * test can assert how many streams were opened and that all of them were closed.
+	 */
+	private static final class CountingDataInputStream implements DataInputStream {
+		private final byte[] data;
+		private final DataStreamMeta meta;
+		private final List<CountingInputStream> opened = new ArrayList<>();
+
+		private CountingDataInputStream(byte[] data, String fileName) {
+			this.data = data;
+			this.meta = DataStreamMeta.fromFileName(fileName);
+		}
+
+		@Override
+		public InputStream openRawInputStream() {
+			CountingInputStream stream = new CountingInputStream(new ByteArrayInputStream(data));
+			opened.add(stream);
+			return stream;
+		}
+
+		@Override
+		public DataStreamMeta getMeta() {
+			return meta;
+		}
+
+		private int openCount() {
+			return opened.size();
+		}
+
+		private long unclosedCount() {
+			return opened.stream().filter(stream -> !stream.closed).count();
+		}
+	}
+
+	private static final class CountingInputStream extends FilterInputStream {
+		private boolean closed;
+
+		private CountingInputStream(InputStream in) {
+			super(in);
+		}
+
+		@Override
+		public void close() throws IOException {
+			closed = true;
+			super.close();
+		}
 	}
 
 }

--- a/zulia-data/src/test/java/io/zulia/data/test/ExcelSourceTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/ExcelSourceTest.java
@@ -1,0 +1,63 @@
+package io.zulia.data.test;
+
+import io.zulia.data.input.SingleUseDataInputStream;
+import io.zulia.data.source.spreadsheet.excel.ExcelRecord;
+import io.zulia.data.source.spreadsheet.excel.ExcelSource;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.function.Consumer;
+
+public class ExcelSourceTest {
+
+	@Test
+	void wholeNumberAboveIntMaxKeepsFullValueAsString() throws IOException {
+		// 3 billion exceeds Integer.MAX_VALUE so previously formatNumericCellAsString truncated it to "2147483647"
+		byte[] xlsx = sheetToWorkbookAsBytes(sheet -> sheet.createRow(0).createCell(0).setCellValue(3_000_000_000d));
+
+		try (ExcelSource source = ExcelSource.withDefaults(SingleUseDataInputStream.from(xlsx, "test.xlsx"))) {
+			ExcelRecord record = source.iterator().next();
+			Assertions.assertEquals("3000000000", record.getString(0));
+			Assertions.assertEquals(3_000_000_000L, record.getLong(0));
+			// an out-of-int-range cell now surfaces clearly instead of silently wrapping to 2147483647
+			Assertions.assertThrows(ArithmeticException.class, () -> record.getInt(0));
+		}
+	}
+
+	@Test
+	void emptySheetDoesNotThrowAndYieldsNoRows() throws IOException {
+		byte[] xlsx = sheetToWorkbookAsBytes(sheet -> {
+			// leave the sheet empty: constructing the source used to NPE on sheet.getRow(0)
+		});
+
+		try (ExcelSource source = ExcelSource.withDefaults(SingleUseDataInputStream.from(xlsx, "test.xlsx"))) {
+			int rows = 0;
+			for (ExcelRecord ignored : source) {
+				rows++;
+			}
+			Assertions.assertEquals(0, rows);
+		}
+	}
+
+	@Test
+	void switchToUnknownSheetThrowsIllegalArgument() throws IOException {
+		byte[] xlsx = sheetToWorkbookAsBytes(sheet -> sheet.createRow(0).createCell(0).setCellValue("value"));
+
+		try (ExcelSource source = ExcelSource.withDefaults(SingleUseDataInputStream.from(xlsx, "test.xlsx"))) {
+			Assertions.assertThrows(IllegalArgumentException.class, () -> source.switchSheet("missing"));
+		}
+	}
+
+	private static byte[] sheetToWorkbookAsBytes(Consumer<Sheet> sheetConsumer) throws IOException {
+		try (XSSFWorkbook wb = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			sheetConsumer.accept(wb.createSheet("Sheet1"));
+			wb.write(out);
+			return out.toByteArray();
+		}
+	}
+
+}

--- a/zulia-data/src/test/java/io/zulia/data/test/ExcelTargetTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/ExcelTargetTest.java
@@ -1,0 +1,49 @@
+package io.zulia.data.test;
+
+import io.zulia.data.output.SingleUseDataOutputStream;
+import io.zulia.data.target.spreadsheet.excel.ExcelTarget;
+import org.apache.poi.util.DefaultTempFileCreationStrategy;
+import org.apache.poi.util.TempFile;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Stream;
+
+public class ExcelTargetTest {
+
+	@Test
+	void closeDisposesStreamingTempFiles(@TempDir Path tempDir) throws IOException {
+		// route POI's streaming temp files into the test's temp dir (thread-local so other tests are unaffected)
+		TempFile.setThreadLocalTempFileCreationStrategy(new DefaultTempFileCreationStrategy(tempDir.toFile()));
+		try {
+			ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+			SingleUseDataOutputStream outputStream = SingleUseDataOutputStream.from(byteArrayOutputStream, "test.xlsx");
+
+			try (ExcelTarget target = ExcelTarget.withDefaults(outputStream)) {
+				// write well past the default in-memory window so rows spill to temp files on disk
+				for (int i = 0; i < 2500; i++) {
+					target.writeRow("value" + i, i);
+				}
+			}
+
+			Assertions.assertTrue(byteArrayOutputStream.size() > 0, "expected workbook bytes to be written");
+
+			// POI writes its streaming temp files directly into this dedicated dir, so after close() disposes them
+			// nothing should remain
+			try (Stream<Path> remaining = Files.list(tempDir)) {
+				List<Path> leaked = remaining.toList();
+				Assertions.assertTrue(leaked.isEmpty(), "temp dir should be empty after close, but found: " + leaked);
+			}
+		}
+		finally {
+			TempFile.setThreadLocalTempFileCreationStrategy(null);
+		}
+	}
+
+}


### PR DESCRIPTION

## Excel
* ExcelTarget now correctly delete SXSSFWorkbook temp files on close
`close()` now closes the `SXSSFWorkbook` via try-with-resources. The workbook
was never closed, so the temporary files it spills to disk (poi-sxssf-sheet*.xml
under java.io.tmpdir) were orphaned on every export and accumulated over time.
* DefaultExcelCellHandler::formatNumericCellAsString no longer truncates large whole numbers to int
* DefaultExcelCellHandler::cellToInt now throws an ArithmeticException instread of silently truncated to int range (matching the string branch with Integer.parseInt)
* `ExcelSource`::`switchSheet(String)` now throws `IllegalArgumentException("No sheet named ...")`
when `reader.getSheet(name)` returns null for an unknown name, instead of NPEing in
`initializeSheet()`.
* `ExcelSource`::`initializeSheet()` failed with a workbook with an empty or blank-first-row sheet with a NPE.
Row count now uses `getPhysicalNumberOfRows()` as well so a truly empty sheet reports zero rows rather than a
phantom one (POI's `getLastRowNum()` returns 0 for both empty and single-row sheets).

## DelimitedSource
* DelimitedSource now throws clear error on an empty file with headers.
* DelimitedSource is `close()` is now idempotent
* `reset()` now closes the existing `CsvReader` before reopening, so the prior
pass's reader and its underlying file handle are released instead of leaked
* The FastCSV iterator is captured once into a field rather than re-fetched on every read and
* The redundant per-call `BufferedInputStream` wrap is dropped since
`openInputStream()` already returns a buffered stream (will be guaranteed by contract in the coming refactor)

## DataInputStream Buffering / Improvements
* DataInputStream now declares openRawInputStream() as the user override
and provides `openInputStream()` as a `default` method that returns a buffered
stream, wrapping the raw stream in a `BufferedInputStream` unless it already is
one, so there is no double buffering. Every existing caller keeps
calling `openInputStream()` and now gets a guaranteed-buffered stream from any
implementation, with the wrap-once logic living in a single place.

* Previously only `FileDataInputStream` buffered its stream;
`SingleUseDataInputStream` returned the caller's raw stream, so whether
`openInputStream()` was buffered depended on the implementation.

* `FileDataInputStream` implements `openRawInputStream()` and no longer wraps the
stream itself (the interface default handles buffering). For gzipped files it
now constructs `GZIPInputStream` with a 64KB buffer instead of the 512-byte
default. The decompressed-side buffer is now added by the
`openInputStream()` default for callers that read it directly.