### PR TITLE
Add more-like-this (MLT) query support

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/command/builder/MoreLikeThisQuery.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/builder/MoreLikeThisQuery.java
@@ -1,0 +1,133 @@
+package io.zulia.client.command.builder;
+
+import io.zulia.message.ZuliaQuery;
+
+import java.util.Collection;
+import java.util.List;
+
+public class MoreLikeThisQuery implements QueryBuilder {
+
+	private final ZuliaQuery.Query.Builder queryBuilder;
+	private final ZuliaQuery.MoreLikeThisParams.Builder mltBuilder;
+
+	/**
+	 * Create an MLT query specifying text fields for lexical similarity.
+	 * Add source documents via addDocumentId() and/or addLikeText().
+	 */
+	public MoreLikeThisQuery(String... fields) {
+		this(List.of(fields));
+	}
+
+	/**
+	 * Create an MLT query specifying text fields for lexical similarity.
+	 */
+	public MoreLikeThisQuery(Collection<String> fields) {
+		this.queryBuilder = ZuliaQuery.Query.newBuilder().setQueryType(ZuliaQuery.Query.QueryType.MORE_LIKE_THIS);
+		this.mltBuilder = ZuliaQuery.MoreLikeThisParams.newBuilder().addAllField(fields);
+	}
+
+	public MoreLikeThisQuery addDocumentId(String docId) {
+		mltBuilder.addDocumentId(docId);
+		return this;
+	}
+
+	public MoreLikeThisQuery addLikeText(String text) {
+		mltBuilder.addLikeText(text);
+		return this;
+	}
+
+	public MoreLikeThisQuery addLikeVector(float[] vector) {
+		ZuliaQuery.VectorInput.Builder vi = ZuliaQuery.VectorInput.newBuilder();
+		for (float v : vector) {
+			vi.addValues(v);
+		}
+		mltBuilder.addLikeVector(vi);
+		return this;
+	}
+
+	public MoreLikeThisQuery setVectorField(String field) {
+		mltBuilder.setVectorField(field);
+		return this;
+	}
+
+	public MoreLikeThisQuery setVectorTopN(int topN) {
+		mltBuilder.setVectorTopN(topN);
+		return this;
+	}
+
+	public static MoreLikeThisQuery forDocuments(Collection<String> fields, String... docIds) {
+		MoreLikeThisQuery q = new MoreLikeThisQuery(fields);
+		for (String docId : docIds) {
+			q.addDocumentId(docId);
+		}
+		return q;
+	}
+
+	public static MoreLikeThisQuery forText(Collection<String> fields, String... texts) {
+		MoreLikeThisQuery q = new MoreLikeThisQuery(fields);
+		for (String text : texts) {
+			q.addLikeText(text);
+		}
+		return q;
+	}
+
+	public MoreLikeThisQuery setMinTermFreq(int minTermFreq) {
+		mltBuilder.setMinTermFreq(minTermFreq);
+		return this;
+	}
+
+	public MoreLikeThisQuery setMaxQueryTerms(int maxQueryTerms) {
+		mltBuilder.setMaxQueryTerms(maxQueryTerms);
+		return this;
+	}
+
+	public MoreLikeThisQuery setMinDocFreq(int minDocFreq) {
+		mltBuilder.setMinDocFreq(minDocFreq);
+		return this;
+	}
+
+	public MoreLikeThisQuery setMaxDocFreq(int maxDocFreq) {
+		mltBuilder.setMaxDocFreq(maxDocFreq);
+		return this;
+	}
+
+	public MoreLikeThisQuery setMinWordLen(int minWordLen) {
+		mltBuilder.setMinWordLen(minWordLen);
+		return this;
+	}
+
+	public MoreLikeThisQuery setMaxWordLen(int maxWordLen) {
+		mltBuilder.setMaxWordLen(maxWordLen);
+		return this;
+	}
+
+	public MoreLikeThisQuery setMaxNumTokensParsed(int maxNumTokensParsed) {
+		mltBuilder.setMaxNumTokensParsed(maxNumTokensParsed);
+		return this;
+	}
+
+	public MoreLikeThisQuery setTextWeight(float textWeight) {
+		mltBuilder.setTextWeight(textWeight);
+		return this;
+	}
+
+	public MoreLikeThisQuery setVectorWeight(float vectorWeight) {
+		mltBuilder.setVectorWeight(vectorWeight);
+		return this;
+	}
+
+	public MoreLikeThisQuery setMinShouldMatch(int minShouldMatch) {
+		queryBuilder.setMm(minShouldMatch);
+		return this;
+	}
+
+	public MoreLikeThisQuery setIncludeSourceDocs(boolean includeSourceDocs) {
+		mltBuilder.setIncludeSourceDocs(includeSourceDocs);
+		return this;
+	}
+
+	@Override
+	public ZuliaQuery.Query getQuery() {
+		return queryBuilder.setMoreLikeThisParams(mltBuilder).build();
+	}
+}

--- a/zulia-common/src/main/proto/zulia_query.proto
+++ b/zulia-common/src/main/proto/zulia_query.proto
@@ -6,6 +6,30 @@ import "DDSketch.proto";
 
 option java_package = "io.zulia.message";
 
+message VectorInput {
+    repeated float values = 1;
+}
+
+message MoreLikeThisParams {
+    repeated string documentId = 1;     // Source doc IDs (fetched server-side for text + vectors).  If an ID exists in multiple queried indexes, the first index in request order wins
+    repeated string likeText = 2;       // User-supplied raw text sources
+    repeated string field = 3;          // STRING fields used for lexical similarity.  The source text is read from these fields of each documentId doc, and the generated term query searches these same fields. Required when likeText/documentId text is used; omit for vector-only queries
+    string vectorField = 4;             // Vector field for semantic similarity (optional)
+    uint32 vectorTopN = 5;              // KNN top-N for vector search (default 100)
+    repeated VectorInput likeVector = 6;// User-supplied vectors (averaged with fetched doc vectors)
+    repeated float resolvedVector = 7;  // Server-resolved centroid (internal, set after fetch+average)
+    uint32 minTermFreq = 8;            // default 2
+    uint32 maxQueryTerms = 9;          // default 25
+    uint32 minDocFreq = 10;            // default 5
+    uint32 maxDocFreq = 11;            // 0 = unlimited
+    uint32 minWordLen = 12;            // default 0
+    uint32 maxWordLen = 13;            // 0 = unlimited
+    uint32 maxNumTokensParsed = 14;    // default 5000
+    float textWeight = 15;             // Boost on lexical clause in hybrid mode (0 = default 1.0)
+    float vectorWeight = 16;           // Boost on vector clause in hybrid mode (0 = default 1.0)
+    bool includeSourceDocs = 17;       // If false (default), documents referenced by documentId are excluded from results (by unique ID, across all queried indexes)
+}
+
 message Query {
 
     reserved 6, 7, 9, 12; //old dismax,dismaxTie,vectorSimilarity,legacy
@@ -21,6 +45,7 @@ message Query {
         NUMERIC_SET = 7;
         NUMERIC_SET_NOT = 8;
         VECTOR_SHOULD = 9; // vector clause that contributes score but does not constrain the result set to HNSW top-K
+        MORE_LIKE_THIS = 10;
     }
 
     enum Operator {
@@ -47,6 +72,7 @@ message Query {
     NumericSet numericSet = 15;
 
     float boost = 16; // score multiplier applied to this clause; 0 = unset (treated as 1.0); ignored for non-scoring clause types
+    MoreLikeThisParams moreLikeThisParams = 17;
 }
 
 message NumericSet {

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
@@ -1,5 +1,6 @@
 package io.zulia.server.index;
 
+import com.google.common.primitives.Floats;
 import com.google.protobuf.ProtocolStringList;
 import io.zulia.ZuliaFieldConstants;
 import io.zulia.message.ZuliaBase;
@@ -44,6 +45,7 @@ import io.zulia.server.field.FieldTypeUtil;
 import io.zulia.server.filestorage.DocumentStorage;
 import io.zulia.server.search.aggregation.AggregationSettings;
 import io.zulia.server.search.GeoDistUtil;
+import io.zulia.server.search.MoreLikeThisLazyQuery;
 import io.zulia.server.search.QueryCacheKey;
 import io.zulia.server.search.ShardQuery;
 import io.zulia.server.search.queryparser.SetQueryHelper;
@@ -511,10 +513,7 @@ public class ZuliaIndex {
 			throw new IllegalArgumentException("Vector must not be empty for cosine sim query");
 		}
 
-		float[] vector = new float[query.getVectorCount()];
-		for (int i = 0; i < query.getVectorCount(); i++) {
-			vector[i] = query.getVector(i);
-		}
+		float[] vector = Floats.toArray(query.getVectorList());
 
 		if (query.getQfList().isEmpty()) {
 			throw new IllegalArgumentException("Cosine sim query must give at least one query field (qf)");
@@ -531,6 +530,67 @@ public class ZuliaIndex {
 			}
 			return booleanQueryBuilder.build();
 		}
+	}
+
+	public Query handleMoreLikeThisQuery(ZuliaQuery.Query query) {
+		ZuliaQuery.MoreLikeThisParams mltParams = query.getMoreLikeThisParams();
+		List<String> textFields = mltParams.getFieldList();
+		List<String> likeTexts = mltParams.getLikeTextList();
+		String vectorField = mltParams.getVectorField();
+		List<Float> resolvedVector = mltParams.getResolvedVectorList();
+
+		boolean hasLexical = !textFields.isEmpty() && !likeTexts.isEmpty();
+		boolean hasVector = !vectorField.isEmpty() && !resolvedVector.isEmpty();
+
+		if (!hasLexical && !hasVector) {
+			throw new IllegalArgumentException("More-like-this query must have either text fields with like text, or a vector field with vectors");
+		}
+
+		Query lexicalQuery = null;
+		if (hasLexical) {
+			int minTermFreq = mltParams.getMinTermFreq() > 0 ? mltParams.getMinTermFreq() : 2;
+			int maxQueryTerms = mltParams.getMaxQueryTerms() > 0 ? mltParams.getMaxQueryTerms() : 25;
+			int minDocFreq = mltParams.getMinDocFreq() > 0 ? mltParams.getMinDocFreq() : 5;
+			int maxNumTokensParsed = mltParams.getMaxNumTokensParsed() > 0 ? mltParams.getMaxNumTokensParsed() : 5000;
+			lexicalQuery = new MoreLikeThisLazyQuery(likeTexts, textFields, zuliaPerFieldAnalyzer, minTermFreq, maxQueryTerms, minDocFreq,
+					mltParams.getMaxDocFreq(), mltParams.getMinWordLen(), mltParams.getMaxWordLen(), maxNumTokensParsed, query.getMm());
+		}
+
+		Query vectorQuery = null;
+		if (hasVector) {
+			int vectorTopN = mltParams.getVectorTopN() > 0 ? mltParams.getVectorTopN() : 100;
+			vectorQuery = new KnnFloatVectorQuery(vectorField, Floats.toArray(resolvedVector), vectorTopN);
+		}
+
+		Query mltQuery;
+		if (lexicalQuery == null) {
+			mltQuery = vectorQuery;
+		}
+		else if (vectorQuery == null) {
+			mltQuery = lexicalQuery;
+		}
+		else {
+			BooleanQuery.Builder combined = new BooleanQuery.Builder();
+			combined.add(applyWeight(lexicalQuery, mltParams.getTextWeight()), BooleanClause.Occur.SHOULD);
+			combined.add(applyWeight(vectorQuery, mltParams.getVectorWeight()), BooleanClause.Occur.SHOULD);
+			mltQuery = combined.build();
+		}
+
+		List<String> sourceDocIds = mltParams.getDocumentIdList();
+		if (!sourceDocIds.isEmpty() && !mltParams.getIncludeSourceDocs()) {
+			BooleanQuery.Builder excludingSources = new BooleanQuery.Builder();
+			excludingSources.add(mltQuery, BooleanClause.Occur.MUST);
+			for (String docId : sourceDocIds) {
+				excludingSources.add(new TermQuery(new Term(ZuliaFieldConstants.ID_FIELD, docId)), BooleanClause.Occur.MUST_NOT);
+			}
+			mltQuery = excludingSources.build();
+		}
+
+		return mltQuery;
+	}
+
+	private static Query applyWeight(Query query, float weight) {
+		return weight > 0 && weight != 1.0f ? new BoostQuery(query, weight) : query;
 	}
 
 	private BooleanQuery getPreFilter(List<ZuliaQuery.Query> vectorPreQueryList) throws Exception {
@@ -659,6 +719,10 @@ public class ZuliaIndex {
 		else if (query.getQueryType() == QueryType.VECTOR_SHOULD) {
 			luceneQuery = handleVectorQuery(query);
 			occur = BooleanClause.Occur.SHOULD;
+		}
+		else if (query.getQueryType() == QueryType.MORE_LIKE_THIS) {
+			luceneQuery = handleMoreLikeThisQuery(query);
+			occur = BooleanClause.Occur.MUST;
 		}
 		else {
 			luceneQuery = parseQueryToLucene(query);

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
@@ -20,8 +20,10 @@ import io.zulia.message.ZuliaIndex.UpdateIndexSettings;
 import io.zulia.message.ZuliaIndex.UpdateIndexSettings.Operation;
 import io.zulia.message.ZuliaIndex.UpdateIndexSettings.Operation.OperationType;
 import io.zulia.message.ZuliaQuery;
+import io.zulia.message.ZuliaQuery.FetchType;
 import io.zulia.message.ZuliaServiceOuterClass.*;
 import io.zulia.rest.dto.AssociatedMetadataDTO;
+import io.zulia.server.config.IndexFieldInfo;
 import io.zulia.server.config.IndexService;
 import io.zulia.server.config.NodeService;
 import io.zulia.server.config.ServerIndexConfig;
@@ -32,6 +34,7 @@ import io.zulia.server.connection.client.InternalClient;
 import io.zulia.server.connection.server.validation.CreateIndexRequestValidator;
 import io.zulia.server.connection.server.validation.QueryRequestValidator;
 import io.zulia.server.exceptions.IndexDoesNotExistException;
+import io.zulia.server.field.FieldTypeUtil;
 import io.zulia.server.filestorage.DocumentStorage;
 import io.zulia.server.filestorage.FileDocumentStorage;
 import io.zulia.server.filestorage.MongoDocumentStorage;
@@ -57,7 +60,9 @@ import io.zulia.server.index.router.StoreRequestRouter;
 import io.zulia.server.node.ZuliaNode;
 import io.zulia.server.util.MongoProvider;
 import io.zulia.util.IndexAliasUtil;
+import io.zulia.util.ResultHelper;
 import io.zulia.util.ZuliaUtil;
+import io.zulia.util.document.DocumentHelper;
 import io.zulia.util.pool.TaskExecutor;
 import io.zulia.util.pool.WorkPool;
 import org.apache.lucene.search.Query;
@@ -106,6 +111,7 @@ public class ZuliaIndexManager {
 	private final ReplicationRateLimiter replicationRateLimiter;
 
 	private static final int MONGO_DB_NAME_MAX_LENGTH = 63;
+	private static final int MLT_MAX_SOURCE_DOCS = 100;
 
 	public ZuliaIndexManager(ZuliaConfig zuliaConfig, NodeService nodeService) throws Exception {
 
@@ -377,10 +383,19 @@ public class ZuliaIndexManager {
 	}
 
 	public QueryResponse query(QueryRequest request) throws Exception {
+		if (request.getIndexCount() == 0) {
+			throw new IllegalArgumentException("Query requires at least one index");
+		}
+
 		request = new QueryRequestValidator().validateAndSetDefault(request);
 
 		if (zuliaConfig.isDebug() && !request.getDebug()) {
 			request = request.toBuilder().setDebug(true).build();
+		}
+
+		if (hasMLTQuery(request)) {
+			// Validate MLT params and resolve document IDs into text + vectors before query building
+			request = processMoreLikeThisQueries(request);
 		}
 
 		Map<String, Query> queryMap = new HashMap<>();
@@ -394,32 +409,270 @@ public class ZuliaIndexManager {
 		return federator.getResponse(request);
 	}
 
+	private QueryRequest processMoreLikeThisQueries(QueryRequest request) throws Exception {
+		List<ZuliaQuery.Query> queryList = request.getQueryList();
+
+		Map<String, ZuliaIndex> queriedIndexes = resolveQueryIndexes(request.getIndexList());
+
+		// Validate every MLT query against every queried index, then collect all (docId, indexName) fetches
+		BatchFetchRequest.Builder batchBuilder = BatchFetchRequest.newBuilder();
+		for (ZuliaQuery.Query q : queryList) {
+			if (q.getQueryType() != ZuliaQuery.Query.QueryType.MORE_LIKE_THIS) {
+				continue;
+			}
+			validateMoreLikeThisParams(q.getMoreLikeThisParams(), queriedIndexes);
+			for (String docId : q.getMoreLikeThisParams().getDocumentIdList()) {
+				for (String indexName : queriedIndexes.keySet()) {
+					batchBuilder.addFetchRequest(FetchRequest.newBuilder().setUniqueId(docId).setIndexName(indexName).setResultFetchType(FetchType.FULL)
+							.setRealtime(request.getRealtime()).build());
+				}
+			}
+		}
+
+		// Map<docId, parsed source document>; if a doc ID exists in multiple queried indexes, the first index in request order wins
+		Map<String, Document> sourceDocs = new HashMap<>();
+		Map<String, Integer> sourceDocRanks = new HashMap<>();
+		List<String> indexOrder = List.copyOf(queriedIndexes.keySet());
+		List<FetchResponse> fetchResponses = batchBuilder.getFetchRequestCount() == 0
+				? List.of()
+				: new BatchFetchRequestFederator(thisNode, currentOtherNodesActive, pool, internalClient, queriedIndexes).send(batchBuilder.build());
+		for (FetchResponse response : fetchResponses) {
+			if (!response.hasResultDocument()) {
+				continue;
+			}
+			ZuliaBase.ResultDocument rd = response.getResultDocument();
+			if (rd.getDocument().isEmpty()) {
+				continue;
+			}
+			int rank = indexOrder.indexOf(rd.getIndexName());
+			if (rank < 0) {
+				rank = indexOrder.size();
+			}
+			Integer existingRank = sourceDocRanks.get(rd.getUniqueId());
+			if (existingRank == null || rank < existingRank) {
+				sourceDocRanks.put(rd.getUniqueId(), rank);
+				sourceDocs.put(rd.getUniqueId(), ResultHelper.getDocumentFromResultDocument(rd));
+			}
+		}
+
+		QueryRequest.Builder requestBuilder = request.toBuilder().clearQuery();
+		for (ZuliaQuery.Query q : queryList) {
+			if (q.getQueryType() != ZuliaQuery.Query.QueryType.MORE_LIKE_THIS) {
+				requestBuilder.addQuery(q);
+				continue;
+			}
+			requestBuilder.addQuery(rewriteMoreLikeThisQuery(q, queriedIndexes, sourceDocs));
+		}
+
+		return requestBuilder.build();
+	}
+
+	private static boolean hasMLTQuery(QueryRequest queryRequest) {
+		return queryRequest.getQueryList().stream().anyMatch(q -> q.getQueryType() == ZuliaQuery.Query.QueryType.MORE_LIKE_THIS);
+	}
+
+	private void validateMoreLikeThisParams(ZuliaQuery.MoreLikeThisParams mltParams, Map<String, ZuliaIndex> queriedIndexes) {
+		String vectorField = mltParams.getVectorField();
+		List<String> textFields = mltParams.getFieldList();
+		boolean hasVectorField = !vectorField.isEmpty();
+
+		if (textFields.isEmpty() && !hasVectorField) {
+			throw new IllegalArgumentException("More-like-this query must specify text fields or a vector field");
+		}
+
+		if (mltParams.getDocumentIdCount() == 0 && mltParams.getLikeTextCount() == 0 && mltParams.getLikeVectorCount() == 0) {
+			throw new IllegalArgumentException("More-like-this query must specify at least one source: document ids, like text, or like vectors");
+		}
+
+		if (textFields.isEmpty() && mltParams.getLikeTextCount() > 0) {
+			throw new IllegalArgumentException("More-like-this query has like text but no text fields to analyze; specify text fields");
+		}
+
+		if (!hasVectorField && mltParams.getLikeVectorCount() > 0) {
+			throw new IllegalArgumentException("More-like-this query has like vectors but no vector field; specify a vector field");
+		}
+
+		if (mltParams.getDocumentIdCount() > MLT_MAX_SOURCE_DOCS) {
+			throw new IllegalArgumentException(
+					"More-like-this query exceeds the source document limit: got " + mltParams.getDocumentIdCount() + ", max " + MLT_MAX_SOURCE_DOCS);
+		}
+
+		FieldConfig.FieldType expectedVectorType = null;
+		String expectedVectorTypeIndex = null;
+		for (Map.Entry<String, ZuliaIndex> entry : queriedIndexes.entrySet()) {
+			String indexName = entry.getKey();
+			ServerIndexConfig indexConfig = entry.getValue().getIndexConfig();
+			for (String field : textFields) {
+				IndexFieldInfo info = indexConfig.getIndexFieldInfo(field);
+				if (info == null) {
+					throw new IllegalArgumentException("More-like-this text field <" + field + "> does not exist in index <" + indexName + ">");
+				}
+				if (!FieldTypeUtil.isStringFieldType(info.getFieldType())) {
+					throw new IllegalArgumentException(
+							"More-like-this text field <" + field + "> in index <" + indexName + "> must be a STRING field, got " + info.getFieldType());
+				}
+			}
+			if (hasVectorField) {
+				IndexFieldInfo info = indexConfig.getIndexFieldInfo(vectorField);
+				if (info == null) {
+					throw new IllegalArgumentException("More-like-this vector field <" + vectorField + "> does not exist in index <" + indexName + ">");
+				}
+				if (!FieldTypeUtil.isVectorFieldType(info.getFieldType())) {
+					throw new IllegalArgumentException(
+							"More-like-this vector field <" + vectorField + "> in index <" + indexName + "> must be VECTOR or UNIT_VECTOR, got "
+									+ info.getFieldType());
+				}
+				if (expectedVectorType == null) {
+					expectedVectorType = info.getFieldType();
+					expectedVectorTypeIndex = indexName;
+				}
+				else if (expectedVectorType != info.getFieldType()) {
+					throw new IllegalArgumentException(
+							"More-like-this vector field <" + vectorField + "> has inconsistent type across indexes: " + expectedVectorType + " in <"
+									+ expectedVectorTypeIndex + ">, " + info.getFieldType() + " in <" + indexName + ">");
+				}
+			}
+		}
+	}
+
+	private ZuliaQuery.Query rewriteMoreLikeThisQuery(ZuliaQuery.Query q, Map<String, ZuliaIndex> queriedIndexes, Map<String, Document> sourceDocs) {
+		ZuliaQuery.MoreLikeThisParams mltParams = q.getMoreLikeThisParams();
+		List<String> textFields = mltParams.getFieldList();
+		String vectorField = mltParams.getVectorField();
+		boolean hasVectorField = !vectorField.isEmpty();
+
+		List<String> resolvedTexts = new ArrayList<>(mltParams.getLikeTextList());
+		List<float[]> resolvedVectors = new ArrayList<>();
+		List<String> vectorSources = new ArrayList<>();
+
+		for (int i = 0; i < mltParams.getLikeVectorCount(); i++) {
+			ZuliaQuery.VectorInput vi = mltParams.getLikeVector(i);
+			float[] vec = new float[vi.getValuesCount()];
+			for (int j = 0; j < vi.getValuesCount(); j++) {
+				vec[j] = vi.getValues(j);
+			}
+			resolvedVectors.add(vec);
+			vectorSources.add("user-supplied likeVector[" + i + "]");
+		}
+
+		for (String docId : mltParams.getDocumentIdList()) {
+			Document bsonDoc = sourceDocs.get(docId);
+			if (bsonDoc == null) {
+				throw new IllegalArgumentException(
+						"More-like-this source document <" + docId + "> not found in any of the queried indexes " + queriedIndexes.keySet());
+			}
+			for (String field : textFields) {
+				Object value = DocumentHelper.getValueFromMongoDocument(bsonDoc, field);
+				if (value instanceof List<?> list) {
+					for (Object item : list) {
+						if (item != null) {
+							resolvedTexts.add(item.toString());
+						}
+					}
+				}
+				else if (value != null) {
+					resolvedTexts.add(value.toString());
+				}
+			}
+			if (hasVectorField) {
+				float[] vec = ZuliaUtil.getFloatArray(bsonDoc, vectorField, null);
+				if (vec != null) {
+					resolvedVectors.add(vec);
+					vectorSources.add("doc <" + docId + ">");
+				}
+			}
+		}
+
+		boolean hasLexical = !textFields.isEmpty() && !resolvedTexts.isEmpty();
+		boolean hasVector = hasVectorField && !resolvedVectors.isEmpty();
+		if (!hasLexical && !hasVector) {
+			List<String> missing = new ArrayList<>();
+			if (!textFields.isEmpty()) {
+				missing.add("text in fields " + textFields);
+			}
+			if (hasVectorField) {
+				missing.add("vectors in field <" + vectorField + ">");
+			}
+			throw new IllegalArgumentException(
+					"More-like-this source documents " + mltParams.getDocumentIdList() + " contained no " + String.join(" and no ", missing));
+		}
+
+		// documentId is kept so shards can exclude the source docs from results when includeSourceDocs is false
+		ZuliaQuery.MoreLikeThisParams.Builder resolvedParams = mltParams.toBuilder().clearLikeText().clearLikeVector().clearResolvedVector();
+		resolvedParams.addAllLikeText(resolvedTexts);
+
+		if (!resolvedVectors.isEmpty()) {
+			int dim = resolvedVectors.getFirst().length;
+			float[] centroid = new float[dim];
+			for (int i = 0; i < resolvedVectors.size(); i++) {
+				float[] vec = resolvedVectors.get(i);
+				if (vec.length != dim) {
+					throw new IllegalArgumentException(
+							"More-like-this vector dimension mismatch: " + vectorSources.get(i) + " has " + vec.length + " dims, expected " + dim);
+				}
+				for (int j = 0; j < dim; j++) {
+					centroid[j] += vec[j];
+				}
+			}
+			for (int i = 0; i < dim; i++) {
+				centroid[i] /= resolvedVectors.size();
+			}
+
+			boolean shouldNormalize = hasVectorField && queriedIndexes.values().iterator().next().getIndexConfig().getIndexFieldInfo(vectorField).getFieldType()
+					== FieldConfig.FieldType.UNIT_VECTOR;
+			if (shouldNormalize) {
+				float norm = 0f;
+				for (float v : centroid) {
+					norm += v * v;
+				}
+				norm = (float) Math.sqrt(norm);
+				if (norm > 0) {
+					for (int i = 0; i < dim; i++) {
+						centroid[i] /= norm;
+					}
+				}
+			}
+
+			for (float v : centroid) {
+				resolvedParams.addResolvedVector(v);
+			}
+		}
+
+		return q.toBuilder().setMoreLikeThisParams(resolvedParams).build();
+	}
+
 	private void populateIndexesAndIndexMap(QueryRequest queryRequest, Map<String, Query> queryMap, Set<ZuliaIndex> indexes) throws Exception {
 
-		for (String indexName : queryRequest.getIndexList()) {
+		for (Map.Entry<String, ZuliaIndex> entry : resolveQueryIndexes(queryRequest.getIndexList()).entrySet()) {
+			ZuliaIndex index = entry.getValue();
+			if (indexes.add(index)) {
+				queryMap.put(entry.getKey(), index.getQuery(queryRequest));
+			}
+		}
+	}
+
+	/**
+	 * Resolves the request's index names (expanding wildcard patterns and aliases) to a map of resolved index name to index, preserving request order.
+	 */
+	private Map<String, ZuliaIndex> resolveQueryIndexes(List<String> indexNames) throws IndexDoesNotExistException {
+		Map<String, ZuliaIndex> resolved = new LinkedHashMap<>();
+		for (String indexName : indexNames) {
 			if (isWildcardPattern(indexName)) {
 				List<String> matches = expandWildcard(indexName);
 				if (matches.isEmpty()) {
 					throw new IndexDoesNotExistException(indexName);
 				}
 				for (String matched : matches) {
-					ZuliaIndex index = indexMap.get(matched);
-					if (indexes.add(index)) {
-						Query query = index.getQuery(queryRequest);
-						queryMap.put(matched, query);
-					}
+					resolved.put(matched, indexMap.get(matched));
 				}
 			}
 			else {
 				for (String resolvedName : resolveAlias(indexName)) {
-					ZuliaIndex index = lookupIndex(indexName, resolvedName);
-					if (indexes.add(index)) {
-						Query query = index.getQuery(queryRequest);
-						queryMap.put(resolvedName, query);
-					}
+					resolved.put(resolvedName, lookupIndex(indexName, resolvedName));
 				}
 			}
 		}
+		return resolved;
 	}
 
 	private static boolean isWildcardPattern(String indexName) {

--- a/zulia-server/src/main/java/io/zulia/server/search/MoreLikeThisLazyQuery.java
+++ b/zulia-server/src/main/java/io/zulia/server/search/MoreLikeThisLazyQuery.java
@@ -1,0 +1,138 @@
+package io.zulia.server.search;
+
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.queries.mlt.MoreLikeThis;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A lazy {@link Query} wrapper that defers MoreLikeThis query construction until
+ * {@link #rewrite(IndexSearcher)} time, when an {@link IndexSearcher} (and its
+ * {@link org.apache.lucene.index.IndexReader} for IDF stats) is available.
+ * <p>
+ * MLT needs IDF statistics from the IndexReader, but query construction in
+ * {@code ZuliaIndex.getQuery()} happens before shard dispatch. Each shard rewrites
+ * this into a real {@link org.apache.lucene.search.BooleanQuery} using its own reader.
+ * <p>
+ * Per-shard IDF means term scoring varies across shards on a multi-shard index;
+ * this is the standard MLT trade-off in distributed search.
+ */
+public final class MoreLikeThisLazyQuery extends Query {
+
+	private final List<String> likeTexts;
+	private final List<String> fields;
+	private final Analyzer analyzer;
+	private final int minTermFreq;
+	private final int maxQueryTerms;
+	private final int minDocFreq;
+	private final int maxDocFreq;
+	private final int minWordLen;
+	private final int maxWordLen;
+	private final int maxNumTokensParsed;
+	private final int minShouldMatch;
+
+	public MoreLikeThisLazyQuery(Collection<String> likeTexts, Collection<String> fields, Analyzer analyzer, int minTermFreq, int maxQueryTerms, int minDocFreq,
+			int maxDocFreq, int minWordLen, int maxWordLen, int maxNumTokensParsed, int minShouldMatch) {
+		this.likeTexts = List.copyOf(likeTexts);
+		this.fields = List.copyOf(fields);
+		this.analyzer = analyzer;
+		this.minTermFreq = minTermFreq;
+		this.maxQueryTerms = maxQueryTerms;
+		this.minDocFreq = minDocFreq;
+		this.maxDocFreq = maxDocFreq;
+		this.minWordLen = minWordLen;
+		this.maxWordLen = maxWordLen;
+		this.maxNumTokensParsed = maxNumTokensParsed;
+		this.minShouldMatch = minShouldMatch;
+	}
+
+	@Override
+	public Query rewrite(IndexSearcher indexSearcher) throws IOException {
+		MoreLikeThis mlt = new MoreLikeThis(indexSearcher.getIndexReader());
+		mlt.setAnalyzer(analyzer);
+		mlt.setFieldNames(fields.toArray(String[]::new));
+		mlt.setMinTermFreq(minTermFreq);
+		mlt.setMaxQueryTerms(maxQueryTerms);
+		mlt.setMinDocFreq(minDocFreq);
+		if (maxDocFreq > 0) {
+			mlt.setMaxDocFreq(maxDocFreq);
+		}
+		mlt.setMinWordLen(minWordLen);
+		if (maxWordLen > 0) {
+			mlt.setMaxWordLen(maxWordLen);
+		}
+		mlt.setMaxNumTokensParsed(maxNumTokensParsed);
+		mlt.setBoost(true);
+
+		// Use the reader overload per-field; the Map<String, Collection<Object>> overload returned empty queries
+		// when given Reader values in Lucene 10.x. For multi-field, OR the per-field results together.
+		// minShouldMatch applies to the term disjunction of each field separately.
+		if (fields.size() == 1) {
+			return applyMinShouldMatch(mlt.like(fields.getFirst(), buildReaders()));
+		}
+
+		BooleanQuery.Builder combined = new BooleanQuery.Builder();
+		for (String field : fields) {
+			combined.add(applyMinShouldMatch(mlt.like(field, buildReaders())), BooleanClause.Occur.SHOULD);
+		}
+		return combined.build();
+	}
+
+	private Query applyMinShouldMatch(Query query) {
+		if (minShouldMatch <= 0 || !(query instanceof BooleanQuery booleanQuery)) {
+			return query;
+		}
+		BooleanQuery.Builder builder = new BooleanQuery.Builder().setMinimumNumberShouldMatch(minShouldMatch);
+		for (BooleanClause clause : booleanQuery) {
+			builder.add(clause);
+		}
+		return builder.build();
+	}
+
+	private StringReader[] buildReaders() {
+		StringReader[] readers = new StringReader[likeTexts.size()];
+		for (int i = 0; i < likeTexts.size(); i++) {
+			readers[i] = new StringReader(likeTexts.get(i));
+		}
+		return readers;
+	}
+
+	@Override
+	public void visit(QueryVisitor visitor) {
+		visitor.visitLeaf(this);
+	}
+
+	@Override
+	public String toString(String field) {
+		return "MoreLikeThisLazyQuery{fields=" + fields + ", texts=" + likeTexts.size() + ", minTermFreq=" + minTermFreq + ", maxQueryTerms=" + maxQueryTerms
+				+ ", minDocFreq=" + minDocFreq + ", maxDocFreq=" + maxDocFreq + ", minWordLen=" + minWordLen + ", maxWordLen=" + maxWordLen
+				+ ", maxNumTokensParsed=" + maxNumTokensParsed + ", minShouldMatch=" + minShouldMatch + "}";
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (!(o instanceof MoreLikeThisLazyQuery other))
+			return false;
+		return minTermFreq == other.minTermFreq && maxQueryTerms == other.maxQueryTerms && minDocFreq == other.minDocFreq && maxDocFreq == other.maxDocFreq
+				&& minWordLen == other.minWordLen && maxWordLen == other.maxWordLen && maxNumTokensParsed == other.maxNumTokensParsed
+				&& minShouldMatch == other.minShouldMatch && analyzer == other.analyzer && likeTexts.equals(other.likeTexts) && fields.equals(other.fields);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(likeTexts, fields, System.identityHashCode(analyzer), minTermFreq, maxQueryTerms, minDocFreq, maxDocFreq, minWordLen, maxWordLen,
+				maxNumTokensParsed, minShouldMatch);
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/MoreLikeThisTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/MoreLikeThisTest.java
@@ -1,0 +1,796 @@
+package io.zulia.server.test.node;
+
+import com.google.common.primitives.Floats;
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.FilterQuery;
+import io.zulia.client.command.builder.MoreLikeThisQuery;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.CompleteResult;
+import io.zulia.client.result.SearchResult;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.server.test.node.shared.NodeExtension;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class MoreLikeThisTest {
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(3);
+
+	public static final String MLT_TEST = "mltTest";
+	public static final String MLT_TEST_SECONDARY = "mltTestSecondary";
+
+	// Documents designed to have known text overlap:
+	// doc1-doc4: Java-related (share terms "java", "programming", "object", etc.)
+	// doc5-doc6: Python-related (share terms "python", "scripting", "language")
+	// doc7: JavaScript (shares some terms with Java docs)
+	// doc8-doc10: Machine learning (share terms "machine", "learning", "data")
+
+	@Test
+	@Order(1)
+	public void createIndex() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("content");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("title").indexAs(DefaultAnalyzers.STANDARD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("content").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("category").indexAs(DefaultAnalyzers.LC_KEYWORD).facet().sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createUnitVector("embedding").index());
+		indexConfig.setIndexName(MLT_TEST);
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setShardCommitInterval(20);
+
+		zuliaWorkPool.createIndex(indexConfig);
+
+		ClientIndexConfig secondary = new ClientIndexConfig();
+		secondary.addDefaultSearchField("content");
+		secondary.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		secondary.addFieldConfig(FieldConfigBuilder.createString("title").indexAs(DefaultAnalyzers.STANDARD).sort());
+		secondary.addFieldConfig(FieldConfigBuilder.createString("content").indexAs(DefaultAnalyzers.STANDARD));
+		secondary.addFieldConfig(FieldConfigBuilder.createString("category").indexAs(DefaultAnalyzers.LC_KEYWORD).facet().sort());
+		secondary.addFieldConfig(FieldConfigBuilder.createUnitVector("embedding").index());
+		secondary.setIndexName(MLT_TEST_SECONDARY);
+		secondary.setNumberOfShards(1);
+		secondary.setShardCommitInterval(20);
+		zuliaWorkPool.createIndex(secondary);
+	}
+
+	@Test
+	@Order(2)
+	public void index() throws Exception {
+		// Java-related documents
+		indexRecord("1", "Java Programming", "java programming language object oriented design patterns inheritance polymorphism", "java",
+				new float[] { 0.9f, 0.1f, 0.0f, 0.0f });
+		indexRecord("2", "Java Development",
+				"java development software engineering object oriented design best practices enterprise application development programming", "java",
+				new float[] { 0.85f, 0.15f, 0.0f, 0.0f });
+		indexRecord("3", "Java Virtual Machine", "java virtual machine bytecode compilation runtime environment programming language performance", "java",
+				new float[] { 0.8f, 0.1f, 0.1f, 0.0f });
+		indexRecord("4", "Java Spring Framework",
+				"java spring framework enterprise application development dependency injection inversion of control programming design patterns", "java",
+				new float[] { 0.82f, 0.18f, 0.0f, 0.0f });
+
+		// Python-related documents
+		indexRecord("5", "Python Scripting", "python scripting language dynamic typing interpreted programming easy to learn beginner friendly", "python",
+				new float[] { 0.1f, 0.9f, 0.0f, 0.0f });
+		indexRecord("6", "Python Data Science",
+				"python data science machine learning pandas numpy statistical analysis data visualization programming language", "python",
+				new float[] { 0.1f, 0.7f, 0.2f, 0.0f });
+
+		// JavaScript document
+		indexRecord("7", "JavaScript Web Development",
+				"javascript web browser frontend development programming language dynamic typing event driven asynchronous", "javascript",
+				new float[] { 0.4f, 0.4f, 0.2f, 0.0f });
+
+		// Machine learning documents
+		indexRecord("8", "Machine Learning Fundamentals",
+				"machine learning artificial intelligence neural networks deep learning training data models prediction classification", "ml",
+				new float[] { 0.0f, 0.2f, 0.8f, 0.0f });
+		indexRecord("9", "Deep Learning", "deep learning neural networks convolutional recurrent transformer architecture machine learning training data", "ml",
+				new float[] { 0.0f, 0.1f, 0.9f, 0.0f });
+		indexRecord("10", "Natural Language Processing",
+				"natural language processing text analysis sentiment classification machine learning deep learning word embeddings", "ml",
+				new float[] { 0.0f, 0.15f, 0.75f, 0.1f });
+
+		// Additional Java doc without vector
+		indexRecord("11", "Java Collections", "java collections framework list set map hashmap arraylist linked list data structures programming", "java",
+				null);
+
+		// Duplicate content to boost term frequencies
+		indexRecord("12", "Advanced Java",
+				"java programming advanced topics concurrency multithreading object oriented design patterns factory singleton observer", "java",
+				new float[] { 0.88f, 0.12f, 0.0f, 0.0f });
+
+		// Secondary index: more Java-related docs (different IDs) for cross-index MLT
+		indexRecord(MLT_TEST_SECONDARY, "100", "Kotlin and Java",
+				"kotlin java jvm interoperability programming object oriented design patterns null safety", "kotlin",
+				new float[] { 0.7f, 0.2f, 0.1f, 0.0f });
+		indexRecord(MLT_TEST_SECONDARY, "101", "Scala on JVM",
+				"scala functional programming jvm object oriented type system pattern matching", "scala", new float[] { 0.5f, 0.3f, 0.2f, 0.0f });
+		indexRecord(MLT_TEST_SECONDARY, "102", "Pure Python", "python scripting language list comprehension generator decorator", "python",
+				new float[] { 0.0f, 0.95f, 0.05f, 0.0f });
+	}
+
+	private void indexRecord(String id, String title, String content, String category, float[] embedding) throws Exception {
+		indexRecord(MLT_TEST, id, title, content, category, embedding);
+	}
+
+	private void indexRecord(String indexName, String id, String title, String content, String category, float[] embedding) throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		Document mongoDocument = new Document();
+		mongoDocument.put("id", id);
+		mongoDocument.put("title", title);
+		mongoDocument.put("content", content);
+		mongoDocument.put("category", category);
+		mongoDocument.put("embedding", embedding != null ? Floats.asList(embedding) : null);
+
+		Store s = new Store(id, indexName);
+		ResultDocBuilder resultDocumentBuilder = ResultDocBuilder.newBuilder().setDocument(mongoDocument);
+		s.setResultDocument(resultDocumentBuilder);
+		zuliaWorkPool.store(s);
+	}
+
+	private static Set<String> resultCategories(SearchResult searchResult) {
+		return resultCategories(searchResult, Long.MAX_VALUE);
+	}
+
+	private static Set<String> resultCategories(SearchResult searchResult, long topN) {
+		return searchResult.getCompleteResults().stream().limit(topN).map(r -> r.getDocument().getString("category")).collect(Collectors.toSet());
+	}
+
+	private static Set<String> resultIndexes(SearchResult searchResult) {
+		return searchResult.getCompleteResults().stream().map(CompleteResult::getIndexName).collect(Collectors.toSet());
+	}
+
+	@Test
+	@Order(3)
+	public void lexicalMLTFromText() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// MLT from raw text about Java, so it should find Java-related docs
+		Search search = new Search(MLT_TEST).setRealtime(true);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("content"), "java programming object oriented development design patterns").setMinDocFreq(1)
+				.setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "MLT from text should return results");
+
+		// Top 4 must be Java docs. Docs 3 and 11 share only two terms with the like text, so their rank vs. the JavaScript doc is not deterministic
+		Assertions.assertEquals(Set.of("java"), resultCategories(searchResult, 4),
+				"Top MLT results from Java text should be Java docs, got: " + searchResult.getUniqueIds());
+	}
+
+	@Test
+	@Order(4)
+	public void lexicalMLTFromDocId() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// MLT from doc1 content field (Java Programming), server fetches text and should return similar Java documents
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forDocuments(List.of("content"), "1").setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "MLT from doc ID should return results");
+
+		// Should return other Java documents with doc1 itself is excluded by default
+		Set<String> resultIds = Set.copyOf(searchResult.getUniqueIds());
+		Assertions.assertFalse(resultIds.contains("1"), "Source doc should be excluded by default, got: " + resultIds);
+		Assertions.assertTrue(resultCategories(searchResult).contains("java"), "MLT from Java doc should find other Java docs, got: " + resultIds);
+	}
+
+	@Test
+	@Order(5)
+	public void lexicalMLTMultipleDocIds() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// MLT from doc1 (Java) + doc5 (Python) (combines terms from both)
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forDocuments(List.of("content"), "1", "5").setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "MLT from multiple doc IDs should return results");
+
+		// Should find both Java and Python docs since we're combining terms
+		Set<String> categories = resultCategories(searchResult);
+		Assertions.assertTrue(categories.containsAll(Set.of("java", "python")),
+				"MLT from Java+Python docs should find related docs in both categories, got: " + categories);
+	}
+
+	@Test
+	@Order(6)
+	public void vectorOnlyMLTFromDocIds() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Pure vector MLT: find docs with similar embeddings to doc1 (Java, vector [0.9, 0.1, 0, 0])
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery().addDocumentId("1").setVectorField("embedding").setVectorTopN(5));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "Vector-only MLT should return results");
+
+		// Doc1 itself is excluded by default.  The closest remaining vectors are all Java documents (doc12 [0.88,0.12,0,0], doc2 [0.85,0.15,0,0])
+		Assertions.assertFalse(searchResult.getUniqueIds().contains("1"), "Source doc should be excluded by default");
+		Assertions.assertEquals(Set.of("java"), resultCategories(searchResult, 1),
+				"Top vector MLT result should be a Java doc, got: " + searchResult.getUniqueIds().getFirst());
+	}
+
+	@Test
+	@Order(7)
+	public void vectorOnlyMLTFromMultipleDocIds() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Average vectors from doc1 [0.9,0.1,0,0] and doc3 [0.8,0.1,0.1,0]
+		// Centroid ≈ [0.85, 0.1, 0.05, 0] normalized to unit
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery().addDocumentId("1").addDocumentId("3").setVectorField("embedding").setVectorTopN(5));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "Vector MLT from multiple docs should return results");
+
+		// All top results should be Java-related (high first component)
+		Assertions.assertEquals(Set.of("java"), resultCategories(searchResult, 3),
+				"Top vector results should be Java docs, got: " + searchResult.getUniqueIds());
+	}
+
+	@Test
+	@Order(8)
+	public void hybridMLTFromDocId() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Hybrid: lexical + vector from doc1 (Java Programming)
+		Search search = new Search(MLT_TEST);
+		search.addQuery(
+				new MoreLikeThisQuery("content").addDocumentId("1").setVectorField("embedding").setVectorTopN(5).setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "Hybrid MLT should return results");
+
+		// Docs matching both text AND vector should rank highest (other Java documents)
+		Assertions.assertEquals(Set.of("java"), resultCategories(searchResult, 4),
+				"Top hybrid results should be Java docs, got: " + searchResult.getUniqueIds());
+	}
+
+	@Test
+	@Order(9)
+	public void userSuppliedTextAndVector() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// User supplies both text and vector (no fetch needed)
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery("content").addLikeText("java programming object oriented design patterns")
+				.addLikeVector(new float[] { 0.9f, 0.1f, 0.0f, 0.0f }).setVectorField("embedding").setVectorTopN(5).setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "User-supplied text+vector MLT should return results");
+
+		// Should find Java documents
+		Assertions.assertEquals(Set.of("java"), resultCategories(searchResult, 4),
+				"Top results from Java text+vector should be Java docs, got: " + searchResult.getUniqueIds());
+	}
+
+	@Test
+	@Order(10)
+	public void userSuppliedVectorOnly() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Pure vector from user-supplied vector (no fetch)
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery().addLikeVector(new float[] { 0.0f, 0.2f, 0.8f, 0.0f }).setVectorField("embedding").setVectorTopN(5));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "User-supplied vector MLT should return results");
+
+		// Vector [0, 0.2, 0.8, 0] is closest to ML docs (doc8 [0,0.2,0.8,0], doc9 [0,0.1,0.9,0])
+		Assertions.assertEquals(Set.of("ml"), resultCategories(searchResult, 1),
+				"Top result from ML-like vector should be an ML doc, got: " + searchResult.getUniqueIds().getFirst());
+	}
+
+	@Test
+	@Order(11)
+	public void mixedInputs() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Mix: doc ID + user text + user vector
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery("content").addDocumentId("1") // fetches Java text + vector
+				.addLikeText("machine learning artificial intelligence neural networks") // adds ML terms
+				.addLikeVector(new float[] { 0.0f, 0.0f, 1.0f, 0.0f }) // adds ML vector
+				.setVectorField("embedding").setVectorTopN(10).setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "Mixed input MLT should return results");
+
+		// Should find both Java documents (from doc ID text) and ML docs (from user text + vector). Source doc 1 is excluded
+		Set<String> resultIds = Set.copyOf(searchResult.getUniqueIds());
+		Assertions.assertFalse(resultIds.contains("1"), "Source doc should be excluded by default, got: " + resultIds);
+		Set<String> categories = resultCategories(searchResult);
+		Assertions.assertTrue(categories.contains("java"), "Mixed MLT should find Java docs from the source doc text, got: " + categories);
+		Assertions.assertTrue(categories.contains("ml"), "Mixed MLT should find ML docs from the user text and vector, got: " + categories);
+	}
+
+	@Test
+	@Order(12)
+	public void mltWithPostFilter() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// MLT + post-filter: find Java-like docs but only in "java" category
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("content"), "programming language dynamic typing scripting").setMinDocFreq(1).setMinTermFreq(1));
+		search.addQuery(new FilterQuery("category:java"));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		// All results should be Java category
+		for (var result : searchResult.getCompleteResults()) {
+			Document doc = result.getDocument();
+			Assertions.assertEquals("java", doc.getString("category"), "All filtered results should be java category");
+		}
+	}
+
+	@Test
+	@Order(13)
+	public void mltMultipleFields() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// MLT across multiple text fields (title + content)
+		Search search = new Search(MLT_TEST);
+		search.addQuery(
+				MoreLikeThisQuery.forText(List.of("title", "content"), "java programming design").setMinDocFreq(1).setMinTermFreq(1).setMaxQueryTerms(30));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "Multi-field MLT should return results");
+	}
+
+	@Test
+	@Order(14)
+	public void mltParameterTuning() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Test with high maxQueryTerms — should produce more diverse results
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("content"), "java programming object oriented development design patterns language").setMinDocFreq(1)
+				.setMinTermFreq(1).setMaxQueryTerms(50));
+		search.setAmount(12);
+		SearchResult highTermResult = zuliaWorkPool.search(search);
+
+		// Test with very low maxQueryTerms — should produce fewer, more focused results
+		search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("content"), "java programming object oriented development design patterns language").setMinDocFreq(1)
+				.setMinTermFreq(1).setMaxQueryTerms(2));
+		search.setAmount(12);
+		SearchResult lowTermResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(highTermResult.getTotalHits() > 0, "High maxQueryTerms MLT should return results");
+		Assertions.assertTrue(lowTermResult.getTotalHits() > 0, "Low maxQueryTerms MLT should return results");
+		// More query terms generally means more results (or at least equal)
+		Assertions.assertTrue(highTermResult.getTotalHits() >= lowTermResult.getTotalHits(),
+				"More query terms should find at least as many docs: high=" + highTermResult.getTotalHits() + " low=" + lowTermResult.getTotalHits());
+	}
+
+	@Test
+	@Order(15)
+	public void mltMinWordLen() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// With high minWordLen, short words like "java" (4 chars) should be excluded
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("content"), "java programming object oriented design patterns").setMinDocFreq(1).setMinTermFreq(1)
+				.setMinWordLen(8) // only words 8+ chars
+		);
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		// Should still work but with fewer matching terms (only "programming", "oriented", "patterns")
+		// May return fewer results since key terms are excluded
+		Assertions.assertNotNull(searchResult, "MLT with minWordLen should not throw");
+	}
+
+	@Test
+	@Order(16)
+	public void mltEmptyResultHandling() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// MLT with text that has no overlap with indexed content
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("content"), "xylophone zephyr quixotic").setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		// Should return 0 results gracefully (no errors)
+		Assertions.assertEquals(0, searchResult.getTotalHits(), "MLT with no term overlap should return 0 results");
+	}
+
+	@Test
+	@Order(17)
+	public void mltForDocumentsConvenienceFactory() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Test the convenience factory methods
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forDocuments(List.of("content"), "1", "2").setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "forDocuments factory should return results");
+
+		// Both source docs are excluded; the combined Java terms should rank the remaining Java docs on top
+		Set<String> resultIds = Set.copyOf(searchResult.getUniqueIds());
+		Assertions.assertFalse(resultIds.contains("1") || resultIds.contains("2"), "Source docs should be excluded by default, got: " + resultIds);
+		Assertions.assertEquals(Set.of("java"), resultCategories(searchResult, 2),
+				"Top results from two Java source docs should be Java docs, got: " + searchResult.getUniqueIds());
+	}
+
+	@Test
+	@Order(18)
+	public void mltScoresDescending() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Verify results are returned in descending score order
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("content"), "java programming object oriented design patterns development").setMinDocFreq(1)
+				.setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		double previousScore = Double.MAX_VALUE;
+		for (var result : searchResult.getCompleteResults()) {
+			Assertions.assertTrue(result.getScore() <= previousScore,
+					"Results should be in descending score order: " + result.getScore() + " > " + previousScore);
+			previousScore = result.getScore();
+		}
+	}
+
+	@Test
+	@Order(19)
+	public void mltNoDuplicates() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Verify no duplicate IDs in results
+		Search search = new Search(MLT_TEST);
+		search.addQuery(
+				new MoreLikeThisQuery("content").addDocumentId("1").setVectorField("embedding").setVectorTopN(10).setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Set<String> uniqueIds = Set.copyOf(searchResult.getUniqueIds());
+		Assertions.assertEquals(searchResult.getUniqueIds().size(), uniqueIds.size(), "Results should have no duplicate IDs");
+	}
+
+	@Test
+	@Order(20)
+	public void multiIndexLexicalMLTFromDocId() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Source doc lives in MLT_TEST and querying both indexes so should pull text from doc1 and find Java-similar docs in both
+		Search search = new Search(MLT_TEST, MLT_TEST_SECONDARY).setRealtime(true);
+		search.addQuery(MoreLikeThisQuery.forDocuments(List.of("content"), "1").setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(20);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "Multi-index MLT from doc ID should return results");
+
+		Set<String> indexes = resultIndexes(searchResult);
+		Assertions.assertTrue(indexes.containsAll(Set.of(MLT_TEST, MLT_TEST_SECONDARY)),
+				"Multi-index MLT should return docs from both indexes, got: " + indexes);
+		Assertions.assertTrue(resultCategories(searchResult).contains("java"),
+				"Multi-index MLT should return Java-related docs, got: " + searchResult.getUniqueIds());
+	}
+
+	@Test
+	@Order(21)
+	public void multiIndexMissingDocIdFails() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		Search search = new Search(MLT_TEST, MLT_TEST_SECONDARY);
+		search.addQuery(MoreLikeThisQuery.forDocuments(List.of("content"), "doesNotExist").setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(5);
+
+		Exception ex = Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(search));
+		Assertions.assertTrue(ex.getMessage() != null && ex.getMessage().contains("doesNotExist"),
+				"Error should name the missing docId, got: " + ex.getMessage());
+	}
+
+	@Test
+	@Order(22)
+	public void hybridMLTWithWeights() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Source doc 6 (Python Data Science) has opposing affinities: its vector is closest to doc 5 (python),
+		// but its text shares the rarest terms (machine, learning, data, analysis) with the ML docs
+
+		// With the vector clause dominant, the nearest vector wins
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery("content").addDocumentId("6").setVectorField("embedding").setVectorTopN(5).setMinDocFreq(1).setMinTermFreq(1)
+				.setTextWeight(0.01f).setVectorWeight(10.0f));
+		search.setAmount(5);
+		SearchResult vectorHeavy = zuliaWorkPool.search(search);
+		Assertions.assertTrue(vectorHeavy.getTotalHits() > 0, "Vector-weighted hybrid MLT should return results");
+		Assertions.assertEquals(Set.of("python"), resultCategories(vectorHeavy, 1),
+				"Vector-heavy weights should rank the nearest vector (doc 5, python) first, got: " + vectorHeavy.getUniqueIds().getFirst());
+
+		// Same query with text dominant, the lexically closest ML docs win
+		search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery("content").addDocumentId("6").setVectorField("embedding").setVectorTopN(5).setMinDocFreq(1).setMinTermFreq(1)
+				.setTextWeight(10.0f).setVectorWeight(0.01f));
+		search.setAmount(5);
+		SearchResult textHeavy = zuliaWorkPool.search(search);
+		Assertions.assertTrue(textHeavy.getTotalHits() > 0, "Text-weighted hybrid MLT should return results");
+		Assertions.assertEquals(Set.of("ml"), resultCategories(textHeavy, 1),
+				"Text-heavy weights should rank the lexically closest ML doc first, got: " + textHeavy.getUniqueIds().getFirst());
+	}
+
+	@Test
+	@Order(23)
+	public void mltUnknownTextFieldFails() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("nonExistentField"), "java programming"));
+		search.setAmount(5);
+
+		Exception ex = Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(search));
+		Assertions.assertTrue(ex.getMessage() != null && ex.getMessage().contains("nonExistentField"),
+				"Error should name the missing field, got: " + ex.getMessage());
+	}
+
+	@Test
+	@Order(24)
+	public void mltVectorFieldOnNonVectorFieldFails() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// "content" is a STRING field, not a vector field
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery().addLikeVector(new float[] { 0.1f, 0.2f, 0.3f, 0.4f }).setVectorField("content").setVectorTopN(5));
+		search.setAmount(5);
+
+		Exception ex = Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(search));
+		Assertions.assertTrue(ex.getMessage() != null && ex.getMessage().contains("content"),
+				"Error should name the bad vector field, got: " + ex.getMessage());
+	}
+
+	@Test
+	@Order(25)
+	public void mltSourceDocLimitEnforced() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		MoreLikeThisQuery mlt = new MoreLikeThisQuery("content");
+		for (int i = 0; i < 101; i++) {
+			mlt.addDocumentId(String.valueOf(i));
+		}
+		Search search = new Search(MLT_TEST);
+		search.addQuery(mlt);
+		search.setAmount(5);
+
+		Exception ex = Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(search));
+		Assertions.assertTrue(ex.getMessage() != null && ex.getMessage().contains("source document limit"),
+				"Error should mention the source document limit, got: " + ex.getMessage());
+	}
+
+	@Test
+	@Order(26)
+	public void wildcardIndexMLTFromDocId() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Wildcard index pattern matching both indexes with source doc living in MLT_TEST
+		Search search = new Search(MLT_TEST + "*").setRealtime(true);
+		search.addQuery(MoreLikeThisQuery.forDocuments(List.of("content"), "1").setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(20);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "Wildcard index MLT should return results");
+
+		Set<String> indexes = resultIndexes(searchResult);
+		Assertions.assertTrue(indexes.containsAll(Set.of(MLT_TEST, MLT_TEST_SECONDARY)),
+				"Wildcard index MLT should return docs from both indexes, got: " + indexes);
+		Assertions.assertTrue(resultCategories(searchResult).contains("java"),
+				"Wildcard index MLT should return Java-related docs, got: " + searchResult.getUniqueIds());
+	}
+
+	@Test
+	@Order(27)
+	public void mltLikeTextWithoutTextFieldsFails() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// likeText can never be used without text fields to analyze
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery().addLikeText("java programming").setVectorField("embedding")
+				.addLikeVector(new float[] { 0.9f, 0.1f, 0.0f, 0.0f }));
+		search.setAmount(5);
+
+		Exception ex = Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(search));
+		Assertions.assertTrue(ex.getMessage() != null && ex.getMessage().contains("no text fields"),
+				"Error should say text fields are missing, got: " + ex.getMessage());
+	}
+
+	@Test
+	@Order(28)
+	public void mltLikeVectorWithoutVectorFieldFails() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// likeVector can never be used without a vector field
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery("content").addLikeText("java programming").addLikeVector(new float[] { 0.9f, 0.1f, 0.0f, 0.0f })
+				.setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(5);
+
+		Exception ex = Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(search));
+		Assertions.assertTrue(ex.getMessage() != null && ex.getMessage().contains("no vector field"),
+				"Error should say the vector field is missing, got: " + ex.getMessage());
+	}
+
+	@Test
+	@Order(29)
+	public void mltIncludeSourceDocs() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// With includeSourceDocs, doc1 should come back and rank first on its own vector
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery().addDocumentId("1").setVectorField("embedding").setVectorTopN(5).setIncludeSourceDocs(true));
+		search.setAmount(12);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(searchResult.getTotalHits() > 0, "Vector MLT including source docs should return results");
+		Assertions.assertEquals("1", searchResult.getUniqueIds().getFirst(),
+				"Source doc should rank first on its own vector when included");
+	}
+
+	@Test
+	@Order(30)
+	public void mltMinShouldMatch() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Without mm, any single shared term matches (e.g. "programming" matches Python/JS docs)
+		Search search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("content"), "java programming object oriented design patterns").setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(12);
+		SearchResult noMmResult = zuliaWorkPool.search(search);
+
+		// With mm 4, a doc must match at least 4 of the selected terms so only the Java documents qualify
+		search = new Search(MLT_TEST);
+		search.addQuery(MoreLikeThisQuery.forText(List.of("content"), "java programming object oriented design patterns").setMinDocFreq(1).setMinTermFreq(1)
+				.setMinShouldMatch(4));
+		search.setAmount(12);
+		SearchResult mmResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(mmResult.getTotalHits() > 0, "MLT with minShouldMatch should return results");
+		Assertions.assertTrue(mmResult.getTotalHits() < noMmResult.getTotalHits(),
+				"minShouldMatch should reduce matches: mm=" + mmResult.getTotalHits() + " noMm=" + noMmResult.getTotalHits());
+
+		for (var result : mmResult.getCompleteResults()) {
+			Assertions.assertEquals("java", result.getDocument().getString("category"),
+					"Docs matching 4+ terms should all be Java docs, got: " + result.getUniqueId());
+		}
+	}
+
+	@Test
+	@Order(31)
+	public void multiShardMLT() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// 3 shards across 3 nodes that exercises per-shard lazy rewrite and cross-shard score merging
+		String multiShardIndex = "mltTestMultiShard";
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("content");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("title").indexAs(DefaultAnalyzers.STANDARD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("content").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("category").indexAs(DefaultAnalyzers.LC_KEYWORD).facet().sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createUnitVector("embedding").index());
+		indexConfig.setIndexName(multiShardIndex);
+		indexConfig.setNumberOfShards(3);
+		indexConfig.setShardCommitInterval(20);
+		zuliaWorkPool.createIndex(indexConfig);
+
+		indexRecord(multiShardIndex, "1", "Java Programming", "java programming language object oriented design patterns inheritance polymorphism", "java",
+				new float[] { 0.9f, 0.1f, 0.0f, 0.0f });
+		indexRecord(multiShardIndex, "2", "Java Development",
+				"java development software engineering object oriented design best practices enterprise application development programming", "java",
+				new float[] { 0.85f, 0.15f, 0.0f, 0.0f });
+		indexRecord(multiShardIndex, "5", "Python Scripting",
+				"python scripting language dynamic typing interpreted programming easy to learn beginner friendly", "python",
+				new float[] { 0.1f, 0.9f, 0.0f, 0.0f });
+		indexRecord(multiShardIndex, "8", "Machine Learning Fundamentals",
+				"machine learning artificial intelligence neural networks deep learning training data models prediction classification", "ml",
+				new float[] { 0.0f, 0.2f, 0.8f, 0.0f });
+		indexRecord(multiShardIndex, "12", "Advanced Java",
+				"java programming advanced topics concurrency multithreading object oriented design patterns factory singleton observer", "java",
+				new float[] { 0.88f, 0.12f, 0.0f, 0.0f });
+
+		// Lexical MLT from doc 1 across shards
+		Search search = new Search(multiShardIndex).setRealtime(true);
+		search.addQuery(MoreLikeThisQuery.forDocuments(List.of("content"), "1").setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(10);
+		SearchResult lexicalResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(lexicalResult.getTotalHits() > 0, "Multi-shard lexical MLT should return results");
+		Set<String> lexicalIds = Set.copyOf(lexicalResult.getUniqueIds());
+		Assertions.assertFalse(lexicalIds.contains("1"), "Source doc should be excluded, got: " + lexicalIds);
+		Assertions.assertTrue(resultCategories(lexicalResult).contains("java"),
+				"Multi-shard MLT from Java doc should find other Java docs, got: " + lexicalIds);
+
+		// Hybrid MLT from doc 1 across shards
+		search = new Search(multiShardIndex).setRealtime(true);
+		search.addQuery(new MoreLikeThisQuery("content").addDocumentId("1").setVectorField("embedding").setVectorTopN(5).setMinDocFreq(1).setMinTermFreq(1));
+		search.setAmount(10);
+		SearchResult hybridResult = zuliaWorkPool.search(search);
+
+		Assertions.assertTrue(hybridResult.getTotalHits() > 0, "Multi-shard hybrid MLT should return results");
+		Assertions.assertEquals(Set.of("java"), resultCategories(hybridResult, 1),
+				"Top multi-shard hybrid result should be a Java doc, got: " + hybridResult.getUniqueIds().getFirst());
+	}
+
+	@Test
+	@Order(32)
+	public void mltNoSourcesFails() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Text fields alone are not enough: a source (document ids, like text, or like vectors) is required
+		Search search = new Search(MLT_TEST);
+		search.addQuery(new MoreLikeThisQuery("content"));
+		search.setAmount(5);
+
+		Exception ex = Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(search));
+		Assertions.assertTrue(ex.getMessage() != null && ex.getMessage().contains("at least one source"),
+				"Error should say a source is required, got: " + ex.getMessage());
+	}
+
+	@Test
+	@Order(33)
+	public void mltSourceDocsWithNoContentFails() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// Source doc with neither text in the analyzed field nor a vector resolves to no content
+		indexRecord("13", "Empty Doc", null, "misc", null);
+
+		Search search = new Search(MLT_TEST).setRealtime(true);
+		search.addQuery(new MoreLikeThisQuery("content").setVectorField("embedding").addDocumentId("13"));
+		search.setAmount(5);
+
+		Exception ex = Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.search(search));
+		Assertions.assertTrue(ex.getMessage() != null && ex.getMessage().contains("contained no text in fields [content] and no vectors in field <embedding>"),
+				"Error should say the source docs yielded no content, got: " + ex.getMessage());
+	}
+
+	@Test
+	@Order(50)
+	public void restart() throws Exception {
+		nodeExtension.restartNodes();
+	}
+
+	@Test
+	@Order(51)
+	public void confirmAfterRestart() throws Exception {
+		// Re-run key tests after restart to verify persistence
+		lexicalMLTFromText();
+		lexicalMLTFromDocId();
+		vectorOnlyMLTFromDocIds();
+		hybridMLTFromDocId();
+	}
+}


### PR DESCRIPTION
Add more-like-this (MLT) query support
Adds a MORE_LIKE_THIS query type supporting lexical (Lucene MoreLikeThis),
vector (KNN on averaged source vectors), and hybrid similarity search.

- Sources are document IDs (fetched server-side), raw text, and/or raw vectors
- MoreLikeThisLazyQuery defers MLT construction to per-shard rewrite so each
  shard uses its own IndexReader for IDF stats
- Document IDs are resolved once on the federating node via batch fetch, and then
  resolved text and centroid vector are passed to shards in the query
- When a doc ID exists in multiple queried indexes, the first index in
  request order wins
- Centroid is normalized for UNIT_VECTOR fields
- Validates fields, types, and cross-index consistency and caps source docs
  at 100 for stability
- Requires at least one source (document IDs, like text, or like vectors) up
  front, and fails once on the federating node with a diagnostic message when
  source docs resolve to no text or vectors
- Queries (all types) now fail fast with "Query requires at least one index"
  instead of silently returning zero hits when the index list is empty. The
  shared validator is unchanged, so warming searches, which imply their index,
  are unaffected
- Wildcard index patterns and aliases are resolved via the same logic as
  regular queries
- Source documents are excluded from results by default (includeSourceDocs
  to opt in)
- minimum_should_match (mm) is honored on the per-field term disjunction
- Realtime searches propagate the realtime flag to the source doc fetch so
  just-stored documents resolve
- Client builder MoreLikeThisQuery with forText/forDocuments factories
- REST access via existing queryJson parameter (protobuf Query JSON)