### PR TITLE
Add per-field doc-values skip index

### DIFF
--- a/zulia-common/src/main/proto/zulia_index.proto
+++ b/zulia-common/src/main/proto/zulia_index.proto
@@ -77,6 +77,11 @@ message IndexSettings {
     uint32 nrtTaxoMaxMergeSizeMB = 30; // default 5
     uint32 nrtTaxoMaxCachedMB = 31; // default 15
     bool nrtCachingDisabled = 32; // when true, no new segments are cached in RAM (directory stays wrapped so it can be toggled live)
+
+    // server populated: the index-creation version, stamped once at create time and never changed (see ZuliaIndexVersion).
+    // Lets new indexes adopt evolving built-in defaults (e.g. id-sort doc-values skip index, default vector quantization)
+    // that cannot be expressed per field and must not change for an index that already exists. 0 means legacy (pre-versioning).
+    uint32 createdIndexVersion = 33;
 }
 
 
@@ -201,6 +206,9 @@ message FieldConfig {
     string displayName = 7;
     string description = 8;
     GeoPointConfig geoPointConfig = 9;
+    // Build a Lucene doc-values skip index on this field's sort doc-values (enables block-skipping range queries and dynamic-pruning sorts).
+    // optional so we can tell "unset" (default on for new fields) apart from an explicit opt-out. Frozen once a field exists
+    optional bool docValueSkipIndex = 10;
 }
 
 message GeoPointConfig {

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardDocumentIndexer.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardDocumentIndexer.java
@@ -76,7 +76,10 @@ public class ShardDocumentIndexer {
 			DirectoryTaxonomyWriter taxoWriter) throws Exception {
 		Document luceneDocument = new Document();
 		luceneDocument.add(new StringField(ZuliaFieldConstants.ID_FIELD, uniqueId, Field.Store.NO));
-		luceneDocument.add(new SortedSetDocValuesField(idSortField, new BytesRef(uniqueId)));
+		// The built-in id sort field is not a FieldConfig, so its skip index is gated on the index-creation version: new indexes
+		// get it, indexes created before the feature (version 0) keep the plain field so their immutable schema is unchanged.
+		boolean idSortDocValueSkipIndex = indexConfig.getIndexSettings().getCreatedIndexVersion() >= ZuliaIndexVersion.ID_SORT_DOC_VALUE_SKIP;
+		luceneDocument.add(sortedSetSortField(idSortField, new BytesRef(uniqueId), idSortDocValueSkipIndex));
 		luceneDocument.add(new LongPoint(ZuliaFieldConstants.TIMESTAMP_FIELD, timestamp));
 
 		boolean compressionEnabled = indexConfig.isCompressionEnabled();
@@ -290,9 +293,20 @@ public class ShardDocumentIndexer {
 		}
 	}
 
+	private static SortedNumericDocValuesField numericSortField(String name, long value, boolean docValueSkipIndex) {
+		return docValueSkipIndex ? SortedNumericDocValuesField.indexedField(name, value) : new SortedNumericDocValuesField(name, value);
+	}
+
+	private static SortedSetDocValuesField sortedSetSortField(String name, BytesRef value, boolean docValueSkipIndex) {
+		return docValueSkipIndex ? SortedSetDocValuesField.indexedField(name, value) : new SortedSetDocValuesField(name, value);
+	}
+
 	private void addSortForStoredField(Document d, String storedFieldName, FieldConfig fc, Object o) {
 
 		FieldConfig.FieldType fieldType = fc.getFieldType();
+
+		// When enabled, sort doc-values are written with a Lucene skip index so range queries block-skip and sorts can dynamically prune.
+		boolean docValueSkipIndex = fc.getDocValueSkipIndex();
 
 		if (FieldTypeUtil.isGeoPointFieldType(fieldType)) {
 			if (fc.getSortAsCount() > 0) {
@@ -370,7 +384,7 @@ public class ShardDocumentIndexer {
 								"Field " + sortAs.getSortFieldName() + " is too large to sort.  Must be less <= 32766 characters and is " + text.length());
 					}
 
-					SortedSetDocValuesField docValue = new SortedSetDocValuesField(sortFieldName, new BytesRef(text));
+					SortedSetDocValuesField docValue = sortedSetSortField(sortFieldName, new BytesRef(text), docValueSkipIndex);
 					d.add(docValue);
 				});
 			}
@@ -380,16 +394,16 @@ public class ShardDocumentIndexer {
 
 						SortedNumericDocValuesField docValue;
 						if (FieldTypeUtil.isNumericIntFieldType(fieldType)) {
-							docValue = new SortedNumericDocValuesField(sortFieldName, number.intValue());
+							docValue = numericSortField(sortFieldName, number.intValue(), docValueSkipIndex);
 						}
 						else if (FieldTypeUtil.isNumericLongFieldType(fieldType)) {
-							docValue = new SortedNumericDocValuesField(sortFieldName, number.longValue());
+							docValue = numericSortField(sortFieldName, number.longValue(), docValueSkipIndex);
 						}
 						else if (FieldTypeUtil.isNumericFloatFieldType(fieldType)) {
-							docValue = new SortedNumericDocValuesField(sortFieldName, NumericUtils.floatToSortableInt(number.floatValue()));
+							docValue = numericSortField(sortFieldName, NumericUtils.floatToSortableInt(number.floatValue()), docValueSkipIndex);
 						}
 						else if (FieldTypeUtil.isNumericDoubleFieldType(fieldType)) {
-							docValue = new SortedNumericDocValuesField(sortFieldName, NumericUtils.doubleToSortableLong(number.doubleValue()));
+							docValue = numericSortField(sortFieldName, NumericUtils.doubleToSortableLong(number.doubleValue()), docValueSkipIndex);
 						}
 						else {
 							throw new RuntimeException(
@@ -402,16 +416,16 @@ public class ShardDocumentIndexer {
 						SortedNumericDocValuesField docValue;
 						try {
 							if (FieldTypeUtil.isNumericIntFieldType(fieldType)) {
-								docValue = new SortedNumericDocValuesField(sortFieldName, Integer.parseInt(value));
+								docValue = numericSortField(sortFieldName, Integer.parseInt(value), docValueSkipIndex);
 							}
 							else if (FieldTypeUtil.isNumericLongFieldType(fieldType)) {
-								docValue = new SortedNumericDocValuesField(sortFieldName, Long.parseLong(value));
+								docValue = numericSortField(sortFieldName, Long.parseLong(value), docValueSkipIndex);
 							}
 							else if (FieldTypeUtil.isNumericFloatFieldType(fieldType)) {
-								docValue = new SortedNumericDocValuesField(sortFieldName, NumericUtils.floatToSortableInt(Float.parseFloat(value)));
+								docValue = numericSortField(sortFieldName, NumericUtils.floatToSortableInt(Float.parseFloat(value)), docValueSkipIndex);
 							}
 							else if (FieldTypeUtil.isNumericDoubleFieldType(fieldType)) {
-								docValue = new SortedNumericDocValuesField(sortFieldName, NumericUtils.doubleToSortableLong(Double.parseDouble(value)));
+								docValue = numericSortField(sortFieldName, NumericUtils.doubleToSortableLong(Double.parseDouble(value)), docValueSkipIndex);
 							}
 							else {
 								throw new RuntimeException(
@@ -435,17 +449,17 @@ public class ShardDocumentIndexer {
 			else if (FieldTypeUtil.isBooleanFieldType(fieldType)) {
 				ZuliaUtil.handleListsUniqueValues(o, obj -> {
 					if (obj instanceof Boolean) {
-						SortedNumericDocValuesField docValue = new SortedNumericDocValuesField(sortFieldName, (Boolean) obj ? 1 : 0);
+						SortedNumericDocValuesField docValue = numericSortField(sortFieldName, (Boolean) obj ? 1 : 0, docValueSkipIndex);
 						d.add(docValue);
 					}
 					else if (obj instanceof Number) {
 						Number num = (Number) (obj);
 						if (num.intValue() == 1) {
-							SortedNumericDocValuesField docValue = new SortedNumericDocValuesField(sortFieldName, 1);
+							SortedNumericDocValuesField docValue = numericSortField(sortFieldName, 1, docValueSkipIndex);
 							d.add(docValue);
 						}
 						else if (num.intValue() == 0) {
-							SortedNumericDocValuesField docValue = new SortedNumericDocValuesField(sortFieldName, 0);
+							SortedNumericDocValuesField docValue = numericSortField(sortFieldName, 0, docValueSkipIndex);
 							d.add(docValue);
 						}
 					}
@@ -453,7 +467,7 @@ public class ShardDocumentIndexer {
 						String string = obj.toString();
 						int booleanInt = BooleanUtil.getStringAsBooleanInt(string);
 						if (booleanInt >= 0) {
-							SortedNumericDocValuesField docValue = new SortedNumericDocValuesField(sortFieldName, booleanInt);
+							SortedNumericDocValuesField docValue = numericSortField(sortFieldName, booleanInt, docValueSkipIndex);
 							d.add(docValue);
 						}
 					}
@@ -463,7 +477,7 @@ public class ShardDocumentIndexer {
 				ZuliaUtil.handleListsUniqueValues(o, obj -> {
 					Date date = ZuliaDateUtil.convertToDate(obj, "document field <" + storedFieldName + "> / sort field <" + sortFieldName + ">");
 					if (date != null) {
-						d.add(new SortedNumericDocValuesField(sortFieldName, date.getTime()));
+						d.add(numericSortField(sortFieldName, date.getTime(), docValueSkipIndex));
 					}
 				});
 			}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
@@ -818,6 +818,39 @@ public class ZuliaIndexManager {
 		return allResponses;
 	}
 
+	/**
+	 * Resolves the per-field {@link FieldConfig#getDocValueSkipIndex()} flag before settings are persisted.
+	 * <p>
+	 * Any field that does not explicitly opt out defaults to on, whether it belongs to a brand-new index or is newly added
+	 * to an existing one, so new fields get block-skipping range queries and dynamic-pruning sorts by default. For fields that
+	 * already exist, the flag is frozen to whatever was persisted when it was first created.  Lucene treats
+	 * the doc-values skip index as part of the immutable field schema. The IndexWriter throws if it changes, so we can't
+	 * flip it on an existing field.
+	 * <p>
+	 */
+	static IndexSettings applyDocValueSkipIndexPolicy(IndexSettings requested, IndexSettings existingIndex) {
+		Map<String, Boolean> frozenByField = new HashMap<>();
+		if (existingIndex != null) {
+			for (FieldConfig fc : existingIndex.getFieldConfigList()) {
+				frozenByField.put(fc.getStoredFieldName(), fc.getDocValueSkipIndex());
+			}
+		}
+
+		IndexSettings.Builder builder = requested.toBuilder();
+		for (FieldConfig.Builder fc : builder.getFieldConfigBuilderList()) {
+			Boolean frozen = frozenByField.get(fc.getStoredFieldName());
+			if (frozen != null) {
+				// Existing field so keep the schema already on disk so the IndexWriter does not reject writes
+				fc.setDocValueSkipIndex(frozen);
+			}
+			else if (!fc.hasDocValueSkipIndex()) {
+				// New field (new index or added to an existing one) that did not opt out so default on.
+				fc.setDocValueSkipIndex(true);
+			}
+		}
+		return builder.build();
+	}
+
 	public CreateIndexResponse createIndex(CreateIndexRequest request) throws Exception {
 		//if existing index make sure not to allow changing number of shards
 
@@ -833,6 +866,8 @@ public class ZuliaIndexManager {
 		String indexName = indexSettings.getIndexName();
 		IndexSettings existingIndex = indexService.getIndex(indexName);
 
+		indexSettings = applyDocValueSkipIndexPolicy(indexSettings, existingIndex);
+
 		long currentTimeMillis = System.currentTimeMillis();
 		if (existingIndex == null) {
 
@@ -843,8 +878,8 @@ public class ZuliaIndexManager {
 		}
 		else {
 
-			IndexSettings existingComparable = existingIndex.toBuilder().clearCreateTime().clearUpdateTime().build();
-			IndexSettings requestComparable = indexSettings.toBuilder().clearCreateTime().clearUpdateTime().build();
+			IndexSettings existingComparable = existingIndex.toBuilder().clearCreateTime().clearUpdateTime().clearCreatedIndexVersion().build();
+			IndexSettings requestComparable = indexSettings.toBuilder().clearCreateTime().clearUpdateTime().clearCreatedIndexVersion().build();
 			if (existingComparable.equals(requestComparable)) {
 				LOG.info("No changes to existing index {}", indexName);
 				return CreateIndexResponse.newBuilder().build();
@@ -865,6 +900,11 @@ public class ZuliaIndexManager {
 		IndexSettings.Builder timestampBuilder = indexSettings.toBuilder().setUpdateTime(currentTimeMillis);
 		if (existingIndex != null) {
 			timestampBuilder.setCreateTime(existingIndex.getCreateTime());
+			// createdIndexVersion is stamped once at creation and frozen thereafter (server populated, like createTime).
+			timestampBuilder.setCreatedIndexVersion(existingIndex.getCreatedIndexVersion());
+		}
+		else {
+			timestampBuilder.setCreatedIndexVersion(ZuliaIndexVersion.CURRENT);
 		}
 		indexSettings = timestampBuilder.build();
 
@@ -1096,7 +1136,9 @@ public class ZuliaIndexManager {
 			}
 
 			CreateIndexRequestValidator.validateIndexSettingsAndSetDefaults(existingSettings);
-			indexSettings = existingSettings.build();
+			// Freeze the doc-values skip index flag to the persisted schema for fields that already exist. An update must
+			// never flip it on a live field (the IndexWriter would reject writes). New fields keep whatever was requested.
+			indexSettings = applyDocValueSkipIndexPolicy(existingSettings.build(), originalIndexSettings);
 
 			if (indexSettings.equals(originalIndexSettings)) {
 				LOG.info("No changes to index {} from update", indexName);

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexVersion.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexVersion.java
@@ -1,0 +1,22 @@
+package io.zulia.server.index;
+
+/**
+ * Registry for the index-creation version stamped on {@code IndexSettings.createdIndexVersion}.
+ * <p>
+ * The version is stamped once when an index is created and never changes afterward. It lets new indexes adopt evolving
+ * built-in defaults that cannot be expressed per field and must not change for an index that already exists (for example,
+ * the doc-values skip index on the built-in id sort field). Indexes
+ * created before versioning existed report 0 (legacy) and keep their original behavior.
+ * <p>
+ * Gate a behavior on {@code createdIndexVersion >=} the fixed version in which it was introduced, never on {@link #CURRENT}
+ * (which moves) - otherwise bumping CURRENT would silently change behavior for older versioned indexes.
+ */
+public interface ZuliaIndexVersion {
+
+
+	/** Stamped on every newly created index. Bump when a new creation-time default is introduced. */
+	int CURRENT = 1;
+
+	/** Indexes at or above this version build a doc-values skip index on the built-in id sort field. */
+	int ID_SORT_DOC_VALUE_SKIP = 1;
+}

--- a/zulia-server/src/test/java/io/zulia/server/index/DocValueSkipIndexPolicyTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/index/DocValueSkipIndexPolicyTest.java
@@ -1,0 +1,60 @@
+package io.zulia.server.index;
+
+import io.zulia.message.ZuliaIndex.FieldConfig;
+import io.zulia.message.ZuliaIndex.FieldConfig.FieldType;
+import io.zulia.message.ZuliaIndex.IndexSettings;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ *  Test that any new field defaults on unless it opts out, whether the index is new or the field is added to an existing one, while a field that already exists stays frozen to
+ *  its persisted flag. (Lucene treats the skip index as immutable field schema)
+ */
+public class DocValueSkipIndexPolicyTest {
+
+	private static FieldConfig field(String name) {
+		return FieldConfig.newBuilder().setStoredFieldName(name).setFieldType(FieldType.NUMERIC_INT).build();
+	}
+
+	private static FieldConfig field(String name, boolean skip) {
+		return FieldConfig.newBuilder().setStoredFieldName(name).setFieldType(FieldType.NUMERIC_INT).setDocValueSkipIndex(skip).build();
+	}
+
+	private static IndexSettings settings(FieldConfig... fieldConfigs) {
+		IndexSettings.Builder builder = IndexSettings.newBuilder().setIndexName("x");
+		for (FieldConfig fieldConfig : fieldConfigs) {
+			builder.addFieldConfig(fieldConfig);
+		}
+		return builder.build();
+	}
+
+	private static boolean skipOf(IndexSettings resolved, String name) {
+		return resolved.getFieldConfigList().stream().filter(fc -> fc.getStoredFieldName().equals(name)).findFirst().orElseThrow().getDocValueSkipIndex();
+	}
+
+	@Test
+	public void newIndexDefaultsOnUnlessOptedOut() {
+		IndexSettings resolved = ZuliaIndexManager.applyDocValueSkipIndexPolicy(settings(field("a"), field("b", false)), null);
+
+		Assertions.assertTrue(skipOf(resolved, "a"), "unset field on a new index should default on");
+		Assertions.assertFalse(skipOf(resolved, "b"), "explicit opt-out should be preserved");
+	}
+
+	@Test
+	public void newFieldOnExistingIndexDefaultsOn() {
+		IndexSettings existing = settings(field("a", false));
+		IndexSettings resolved = ZuliaIndexManager.applyDocValueSkipIndexPolicy(settings(field("a"), field("b")), existing);
+
+		Assertions.assertFalse(skipOf(resolved, "a"), "existing field must stay frozen to its persisted value");
+		Assertions.assertTrue(skipOf(resolved, "b"), "field newly added to an existing index should default on");
+	}
+
+	@Test
+	public void existingFieldFlagIsFrozenAgainstTheRequest() {
+		IndexSettings existing = settings(field("a", true));
+		// An older client re-sends settings without the flag, which reads as false; the on-disk schema must still win.
+		IndexSettings resolved = ZuliaIndexManager.applyDocValueSkipIndexPolicy(settings(field("a", false)), existing);
+
+		Assertions.assertTrue(skipOf(resolved, "a"), "existing field's persisted schema must win over the request");
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/index/DocValueSkipIndexTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/index/DocValueSkipIndexTest.java
@@ -1,0 +1,142 @@
+package io.zulia.server.test.index;
+
+import io.zulia.ZuliaFieldConstants;
+import io.zulia.message.ZuliaIndex.FieldConfig;
+import io.zulia.message.ZuliaIndex.FieldConfig.FieldType;
+import io.zulia.message.ZuliaIndex.IndexSettings;
+import io.zulia.message.ZuliaIndex.SortAs;
+import io.zulia.server.config.ServerIndexConfig;
+import io.zulia.server.field.FieldTypeUtil;
+import io.zulia.server.index.DocumentContainer;
+import io.zulia.server.index.ShardDocumentIndexer;
+import io.zulia.server.index.ZuliaIndexVersion;
+import io.zulia.util.ZuliaUtil;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyWriter;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.DocValuesSkipIndexType;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.LeafReader;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the per-field {@code docValueSkipIndex} flag actually controls whether Zulia writes a Lucene doc-values skip
+ * index on the sort field. Drives {@link ShardDocumentIndexer} directly so the assertion is independent of the cluster stack.
+ */
+public class DocValueSkipIndexTest {
+
+	private static final String SKIP_FIELD = "withSkip";
+	private static final String NO_SKIP_FIELD = "noSkip";
+
+	private static ShardDocumentIndexer indexer() {
+		IndexSettings settings = IndexSettings.newBuilder()
+				.setIndexName("dvSkip")
+				.addFieldConfig(FieldConfig.newBuilder()
+						.setStoredFieldName(SKIP_FIELD)
+						.setFieldType(FieldType.NUMERIC_INT)
+						.setDocValueSkipIndex(true)
+						.addSortAs(SortAs.newBuilder().setSortFieldName(SKIP_FIELD)))
+				.addFieldConfig(FieldConfig.newBuilder()
+						.setStoredFieldName(NO_SKIP_FIELD)
+						.setFieldType(FieldType.NUMERIC_INT)
+						.addSortAs(SortAs.newBuilder().setSortFieldName(NO_SKIP_FIELD)))
+				.build();
+		return new ShardDocumentIndexer(new ServerIndexConfig(settings));
+	}
+
+	private static Document indexDocument(ShardDocumentIndexer indexer, DirectoryTaxonomyWriter taxoWriter) throws Exception {
+		org.bson.Document mongoDocument = new org.bson.Document();
+		mongoDocument.put(SKIP_FIELD, 5);
+		mongoDocument.put(NO_SKIP_FIELD, 7);
+
+		DocumentContainer mongoContainer = new DocumentContainer(ZuliaUtil.mongoDocumentToByteArray(mongoDocument));
+		DocumentContainer metadataContainer = new DocumentContainer((byte[]) null);
+
+		return indexer.getIndexDocument("1", 0L, mongoContainer, metadataContainer, taxoWriter);
+	}
+
+	@Test
+	public void flagControlsSortFieldType() throws Exception {
+		try (Directory taxoDir = new ByteBuffersDirectory(); DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir)) {
+			Document luceneDocument = indexDocument(indexer(), taxoWriter);
+
+			IndexableField skipField = luceneDocument.getField(FieldTypeUtil.getSortField(SKIP_FIELD, FieldType.NUMERIC_INT));
+			IndexableField noSkipField = luceneDocument.getField(FieldTypeUtil.getSortField(NO_SKIP_FIELD, FieldType.NUMERIC_INT));
+
+			Assertions.assertNotNull(skipField, "sort doc-values missing for " + SKIP_FIELD);
+			Assertions.assertNotNull(noSkipField, "sort doc-values missing for " + NO_SKIP_FIELD);
+
+			Assertions.assertEquals(DocValuesSkipIndexType.RANGE, skipField.fieldType().docValuesSkipIndexType());
+			Assertions.assertEquals(DocValuesSkipIndexType.NONE, noSkipField.fieldType().docValuesSkipIndexType());
+		}
+	}
+
+	@Test
+	public void skipperPresentInSegmentOnlyWhenEnabled() throws Exception {
+		String skipSortField = FieldTypeUtil.getSortField(SKIP_FIELD, FieldType.NUMERIC_INT);
+		String noSkipSortField = FieldTypeUtil.getSortField(NO_SKIP_FIELD, FieldType.NUMERIC_INT);
+
+		try (Directory dir = new ByteBuffersDirectory(); Directory taxoDir = new ByteBuffersDirectory()) {
+
+			Document luceneDocument;
+			try (DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir)) {
+				luceneDocument = indexDocument(indexer(), taxoWriter);
+				taxoWriter.commit();
+			}
+
+			try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+				writer.addDocument(luceneDocument);
+				writer.commit();
+			}
+
+			try (DirectoryReader reader = DirectoryReader.open(dir)) {
+				LeafReader leaf = reader.leaves().getFirst().reader();
+				Assertions.assertNotNull(leaf.getDocValuesSkipper(skipSortField), "expected a doc-values skipper on " + skipSortField);
+				Assertions.assertNull(leaf.getDocValuesSkipper(noSkipSortField), "did not expect a doc-values skipper on " + noSkipSortField);
+			}
+		}
+	}
+
+	@Test
+	public void idSortFieldSkipperFollowsIndexVersion() throws Exception {
+		String idSortField = FieldTypeUtil.getSortField(ZuliaFieldConstants.ID_SORT_FIELD, FieldType.STRING);
+
+		// Legacy index (version 0): the built-in id sort field stays plain so its immutable schema is unchanged.
+		assertIdSortSkipper(0, idSortField, false);
+
+		// Index created at the feature version: the id sort field gets a doc-values skipper.
+		assertIdSortSkipper(ZuliaIndexVersion.ID_SORT_DOC_VALUE_SKIP, idSortField, true);
+	}
+
+	private static void assertIdSortSkipper(int createdIndexVersion, String idSortField, boolean expectSkipper) throws Exception {
+		IndexSettings settings = IndexSettings.newBuilder().setIndexName("dvSkipId").setCreatedIndexVersion(createdIndexVersion).build();
+		ShardDocumentIndexer indexer = new ShardDocumentIndexer(new ServerIndexConfig(settings));
+
+		try (Directory dir = new ByteBuffersDirectory(); Directory taxoDir = new ByteBuffersDirectory()) {
+			Document luceneDocument;
+			try (DirectoryTaxonomyWriter taxoWriter = new DirectoryTaxonomyWriter(taxoDir)) {
+				luceneDocument = indexer.getIndexDocument("1", 0L, new DocumentContainer((byte[]) null), new DocumentContainer((byte[]) null), taxoWriter);
+			}
+
+			try (IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig())) {
+				writer.addDocument(luceneDocument);
+				writer.commit();
+			}
+
+			try (DirectoryReader reader = DirectoryReader.open(dir)) {
+				LeafReader leaf = reader.leaves().getFirst().reader();
+				if (expectSkipper) {
+					Assertions.assertNotNull(leaf.getDocValuesSkipper(idSortField), "expected id sort skipper at version " + createdIndexVersion);
+				}
+				else {
+					Assertions.assertNull(leaf.getDocValuesSkipper(idSortField), "did not expect id sort skipper at version " + createdIndexVersion);
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
# Turn on doc-values skip index for new fields and the id field in new indexes
* Lucene 10.0 introduced the doc-values skip index (`DocValuesSkipper`), and 10.3/10.4/10.5
built a series of optimizations on top of it: block-skipping `SortedNumeric`/`SortedSet`
range queries, dynamic-pruning numeric and sorted-set sorts, and skipper-backed
`FieldExistsQuery`/`count()`/`rewrite()`. None of these fire unless the doc-values field was
written with a skip index. Zulia stores every value as doc values and drives range queries
and sorts off them, so adding this optimization helps many places.
* write `SortAs` sort doc-values via `SortedNumericDocValuesField.indexedField` / `SortedSetDocValuesField.indexedField` when the field has the flag set, otherwise the plain
constructor
* `zulia_index.proto`: add `optional bool docValueSkipIndex` to `FieldConfig`. `optional` so we
  can distinguish "unset" (default on for a new field) from an explicit opt-out.
* Any new field defaults on unless it explicitly opts out
* A field that already exists is frozen to its persisted flag. Lucene treats the skip index as part of the
  immutable field schema and the IndexWriter throws if it changes, so we never flip it on an existing field.
* The built-in `zuliaId` sort field is not a `FieldConfig`, so it is gated on a new index-level version instead. `ShardDocumentIndexer` builds the id-sort skip
  index when `createdIndexVersion >= ZuliaIndexVersion.ID_SORT_DOC_VALUE_SKIP`, so new indexes get it and existing
  indexes keep the plain field.
* `ZuliaIndexVersion` holds the current version plus per-feature introduction versions. It generalizes to other
  creation-time defaults that can't be expressed per field
* Tests: `DocValueSkipIndexTest` (sort field type, skipper present in segment, id-sort skipper follows index version)
  and `DocValueSkipIndexPolicyTest` (per-field default-on / freeze policy).
* The query side needs no changes
* No index-format break. Existing indexes stay readable and keep working unchanged, but they
  do not get the optimization
* To get the benefit on existing data, that data must be reindexed into a new index