### PR TITLE
# zulia-data robustness fixes

### DIFF
--- a/zulia-data/src/main/java/io/zulia/data/common/SpreadsheetType.java
+++ b/zulia-data/src/main/java/io/zulia/data/common/SpreadsheetType.java
@@ -15,19 +15,21 @@ public enum SpreadsheetType {
 
 	public static SpreadsheetType getSpreadsheetType(DataStreamMeta dataStreamMeta) {
 
-		String contentType = dataStreamMeta.contentType().toLowerCase();
-		switch (contentType) {
-			case CSV_TYPE -> {
-				return SpreadsheetType.CSV;
-			}
-			case TSV_TYPE -> {
-				return SpreadsheetType.TSV;
-			}
-			case XLSX_TYPE -> {
-				return SpreadsheetType.XLSX;
-			}
-			case XLS_TYPE -> {
-				return SpreadsheetType.XLS;
+		String contentType = dataStreamMeta.contentType();
+		if (contentType != null) {
+			switch (contentType.toLowerCase()) {
+				case CSV_TYPE -> {
+					return SpreadsheetType.CSV;
+				}
+				case TSV_TYPE -> {
+					return SpreadsheetType.TSV;
+				}
+				case XLSX_TYPE -> {
+					return SpreadsheetType.XLSX;
+				}
+				case XLS_TYPE -> {
+					return SpreadsheetType.XLS;
+				}
 			}
 		}
 

--- a/zulia-data/src/main/java/io/zulia/data/source/json/JsonArraySource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/json/JsonArraySource.java
@@ -40,10 +40,23 @@ public class JsonArraySource implements DataSource<JsonSourceRecord>, AutoClosea
 		if (parser.nextToken() != JsonToken.START_ARRAY) {
 			throw new IllegalStateException("Expected an array");
 		}
-		if (parser.nextToken() == JsonToken.START_OBJECT) {
+		advanceToNextElement();
+	}
+
+	private void advanceToNextElement() {
+		JsonToken token = parser.nextToken();
+		if (token == JsonToken.START_OBJECT) {
 			next = mapper.readTree(parser).toString();
 		}
-
+		else if (token == JsonToken.END_ARRAY || token == null) {
+			// End of the array (or end of input): iteration is complete.
+			next = null;
+		}
+		else {
+			// A non-object element (scalar, null literal, or nested array). Fail loudly rather than silently
+			// dropping this and every remaining element by mistaking it for the end of the array.
+			throw new IllegalStateException("Expected an object in the JSON array but found " + token);
+		}
 	}
 
 	public void reset() throws IOException {
@@ -77,12 +90,7 @@ public class JsonArraySource implements DataSource<JsonSourceRecord>, AutoClosea
 			@Override
 			public JsonSourceRecord next() {
 				JsonSourceRecord jsonSourceRecord = new JsonSourceRecord(next);
-				if (parser.nextToken() == JsonToken.START_OBJECT) {
-					next = mapper.readTree(parser).toString();
-				}
-				else {
-					next = null;
-				}
+				advanceToNextElement();
 				return jsonSourceRecord;
 			}
 

--- a/zulia-data/src/main/java/io/zulia/data/source/json/JsonLineDataSource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/json/JsonLineDataSource.java
@@ -14,6 +14,7 @@ public class JsonLineDataSource implements DataSource<JsonSourceRecord>, AutoClo
 	private BufferedReader reader;
 
 	private String next;
+	private boolean iterated;
 
 	public static JsonLineDataSource withConfig(JsonLineSourceConfig jsonLineSourceConfig) throws IOException {
 		return new JsonLineDataSource(jsonLineSourceConfig);
@@ -42,7 +43,10 @@ public class JsonLineDataSource implements DataSource<JsonSourceRecord>, AutoClo
 	@Override
 	public Iterator<JsonSourceRecord> iterator() {
 
-		if (next == null) {
+		// open() already primed the first line in the constructor, so the first iterator() call must not
+		// reopen (an empty source legitimately leaves next == null). Reset only to re-iterate, which only
+		// succeeds for resettable inputs because single-use streams cannot be read twice.
+		if (iterated) {
 			try {
 				reset();
 			}
@@ -50,6 +54,7 @@ public class JsonLineDataSource implements DataSource<JsonSourceRecord>, AutoClo
 				throw new RuntimeException(e);
 			}
 		}
+		iterated = true;
 
 		return new Iterator<>() {
 
@@ -60,10 +65,22 @@ public class JsonLineDataSource implements DataSource<JsonSourceRecord>, AutoClo
 
 			@Override
 			public JsonSourceRecord next() {
+				// Advance the cursor before parsing so the current line is consumed exactly once.
+				// Otherwise, a malformed line that a non-throwing handler skips would be re-read forever.
+				String currentLine = next;
 				try {
-					JsonSourceRecord jsonSourceRecord = new JsonSourceRecord(next);
 					next = reader.readLine();
-					return jsonSourceRecord;
+				}
+				catch (IOException e) {
+					// The underlying stream failed. Terminate iteration (so a non-throwing handler does not
+					// retry the same broken position forever), then route the error through the configured
+					// handler: the default throwing handler surfaces it loudly, a logging handler skips quietly.
+					next = null;
+					return jsonLineSourceConfig.getExceptionHandler().handleException(e);
+				}
+
+				try {
+					return new JsonSourceRecord(currentLine);
 				}
 				catch (Exception e) {
 					return jsonLineSourceConfig.getExceptionHandler().handleException(e);

--- a/zulia-data/src/main/java/io/zulia/data/source/json/JsonSourceRecord.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/json/JsonSourceRecord.java
@@ -32,27 +32,22 @@ public class JsonSourceRecord implements DataSourceRecord {
 
 	@Override
 	public Float getFloat(String field) {
-		Double val = document.getDouble(field);
-		if (val != null) {
-			return val.floatValue();
-		}
-		return null;
+		return document.get(field) instanceof Number number ? number.floatValue() : null;
 	}
 
 	@Override
 	public Double getDouble(String field) {
-		return document.getDouble(field);
+		return document.get(field) instanceof Number number ? number.doubleValue() : null;
 	}
 
 	@Override
 	public Integer getInt(String field) {
-		return document.getInteger(field);
-
+		return document.get(field) instanceof Number number ? Math.toIntExact(number.longValue()) : null;
 	}
 
 	@Override
 	public Long getLong(String field) {
-		return document.getLong(field);
+		return document.get(field) instanceof Number number ? number.longValue() : null;
 	}
 
 	@Override

--- a/zulia-data/src/main/java/io/zulia/data/source/json/JsonSourceRecord.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/json/JsonSourceRecord.java
@@ -32,22 +32,22 @@ public class JsonSourceRecord implements DataSourceRecord {
 
 	@Override
 	public Float getFloat(String field) {
-		return document.get(field) instanceof Number number ? number.floatValue() : null;
+		return DocumentHelper.getAsFloat(document, field);
 	}
 
 	@Override
 	public Double getDouble(String field) {
-		return document.get(field) instanceof Number number ? number.doubleValue() : null;
+		return DocumentHelper.getAsDouble(document, field);
 	}
 
 	@Override
 	public Integer getInt(String field) {
-		return document.get(field) instanceof Number number ? Math.toIntExact(number.longValue()) : null;
+		return DocumentHelper.getAsInt(document, field);
 	}
 
 	@Override
 	public Long getLong(String field) {
-		return document.get(field) instanceof Number number ? number.longValue() : null;
+		return DocumentHelper.getAsLong(document, field);
 	}
 
 	@Override

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/csv/CSVSource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/csv/CSVSource.java
@@ -2,6 +2,7 @@ package io.zulia.data.source.spreadsheet.csv;
 
 import de.siegmar.fastcsv.reader.CommentStrategy;
 import de.siegmar.fastcsv.reader.CsvReader;
+import de.siegmar.fastcsv.reader.FieldMismatchStrategy;
 import io.zulia.data.input.DataInputStream;
 import io.zulia.data.source.spreadsheet.delimited.DelimitedSource;
 
@@ -26,8 +27,8 @@ public class CSVSource extends DelimitedSource<CSVRecord, CSVSourceConfig> {
 	@Override
 	protected CsvReader.CsvReaderBuilder createParser(CSVSourceConfig csvSourceConfig) {
 		return CsvReader.builder().fieldSeparator(csvSourceConfig.getDelimiter()).quoteCharacter('"').commentStrategy(CommentStrategy.SKIP)
-				.commentCharacter('#').skipEmptyLines(true).allowExtraFields(false).allowMissingFields(false).allowExtraCharsAfterClosingQuote(false)
-				.detectBomHeader(true).maxBufferSize(16777216);
+				.commentCharacter('#').skipEmptyLines(true).extraFieldStrategy(FieldMismatchStrategy.STRICT).missingFieldStrategy(FieldMismatchStrategy.STRICT)
+				.allowExtraCharsAfterClosingQuote(false).detectBomHeader(true).maxBufferSize(16777216);
 
 	}
 

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/delimited/DelimitedSource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/delimited/DelimitedSource.java
@@ -17,6 +17,7 @@ public abstract class DelimitedSource<T extends DelimitedRecord, S extends Delim
 	private Iterator<CsvRecord> recordIterator;
 	private List<String> nextRow;
 	private HeaderMapping headerMapping;
+	private boolean iterated;
 
 	public DelimitedSource(S delimitedSourceConfig) throws IOException {
 		this.delimitedSourceConfig = delimitedSourceConfig;
@@ -64,8 +65,10 @@ public abstract class DelimitedSource<T extends DelimitedRecord, S extends Delim
 	@Override
 	public Iterator<T> iterator() {
 
-		//handles multiple iterations with the same DataSources
-		if (nextRow == null) {
+		// open() already primed the first row in the constructor, so the first iterator() call must not
+		// reopen (a source with only a header row legitimately leaves nextRow == null). Reset only to
+		// re-iterate, which only succeeds for resettable inputs because single-use streams cannot be read twice.
+		if (iterated) {
 			try {
 				reset();
 			}
@@ -73,6 +76,7 @@ public abstract class DelimitedSource<T extends DelimitedRecord, S extends Delim
 				throw new RuntimeException(e);
 			}
 		}
+		iterated = true;
 
 		return new Iterator<>() {
 

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/DefaultExcelCellHandler.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/DefaultExcelCellHandler.java
@@ -21,6 +21,9 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 			return formatNumericCellAsString(cell);
 
 		}
+		else if (isCellBoolean(cell)) {
+			return String.valueOf(cell.getBooleanCellValue());
+		}
 		else if (isCellFormula(cell)) {
 			CellType cachedFormulaResultType = cell.getCachedFormulaResultType();
 			if (cachedFormulaResultType.equals(CellType.NUMERIC)) {
@@ -28,6 +31,9 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 			}
 			else if (cachedFormulaResultType.equals(CellType.STRING)) {
 				return cell.getRichStringCellValue().getString();
+			}
+			else if (cachedFormulaResultType.equals(CellType.BOOLEAN)) {
+				return String.valueOf(cell.getBooleanCellValue());
 			}
 		}
 
@@ -42,6 +48,11 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 		}
 		else if (isCellString(cell)) {
 			return Boolean.parseBoolean(cell.getStringCellValue());
+		}
+		else if (isCellFormula(cell)) {
+			if (cell.getCachedFormulaResultType().equals(CellType.BOOLEAN)) {
+				return cell.getBooleanCellValue();
+			}
 		}
 
 		return null;
@@ -150,13 +161,12 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 
 	@Override
 	public String formatNumericCellAsString(Cell cell) {
-		Number numericCellValue = cell.getNumericCellValue();
-		if ((numericCellValue.doubleValue() == Math.floor(numericCellValue.doubleValue())) && !Double.isInfinite(numericCellValue.doubleValue())) {
-			return String.valueOf(numericCellValue.longValue());
+		double value = cell.getNumericCellValue();
+		// upper bound is strict because 2^63 is a valid double but overflows long
+		if (value == Math.floor(value) && !Double.isInfinite(value) && value >= -0x1p63 && value < 0x1p63) {
+			return String.valueOf((long) value);
 		}
-		else {
-			return String.valueOf(numericCellValue.doubleValue());
-		}
+		return String.valueOf(value);
 	}
 
 	@Override

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelRecord.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelRecord.java
@@ -45,7 +45,10 @@ public class ExcelRecord implements SpreadsheetRecord {
 	}
 
 	public Cell getCell(int i) {
-		return row.getCell(i);
+		// POI's Sheet.getRow returns null for a blank row (one with no cells), and that null Row is wrapped
+		// in an ExcelRecord. A blank row simply has no cells, so return null here. The cell handlers already
+		// treat a null Cell as empty, which keeps every accessor null-safe instead of throwing on a blank row.
+		return row == null ? null : row.getCell(i);
 	}
 
 	public Cell getCell(String field) {
@@ -102,43 +105,43 @@ public class ExcelRecord implements SpreadsheetRecord {
 
 	@Override
 	public String getString(int index) {
-		return excelCellHandler.cellToString(row.getCell(index));
+		return excelCellHandler.cellToString(getCell(index));
 	}
 
 	@Override
 	public Boolean getBoolean(int index) {
-		return excelCellHandler.cellToBoolean(row.getCell(index));
+		return excelCellHandler.cellToBoolean(getCell(index));
 	}
 
 	@Override
 	public Float getFloat(int index) {
-		return excelCellHandler.cellToFloat(row.getCell(index));
+		return excelCellHandler.cellToFloat(getCell(index));
 	}
 
 	@Override
 	public Double getDouble(int index) {
-		return excelCellHandler.cellToDouble(row.getCell(index));
+		return excelCellHandler.cellToDouble(getCell(index));
 	}
 
 	@Override
 	public Integer getInt(int index) {
-		return excelCellHandler.cellToInt(row.getCell(index));
+		return excelCellHandler.cellToInt(getCell(index));
 	}
 
 	@Override
 	public Long getLong(int index) {
-		return excelCellHandler.cellToLong(row.getCell(index));
+		return excelCellHandler.cellToLong(getCell(index));
 	}
 
 	@Override
 	public Date getDate(int index) {
-		return excelCellHandler.cellToDate(row.getCell(index));
+		return excelCellHandler.cellToDate(getCell(index));
 	}
 
 	public String[] getRow() {
 		String[] values = new String[sheetInfo.numberOfColumns()];
 		for (int i = 0; i < sheetInfo.numberOfColumns(); i++) {
-			Cell cell = row.getCell(i);
+			Cell cell = getCell(i);
 			values[i] = excelCellHandler.cellToString(cell);
 		}
 		return values;

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSource.java
@@ -107,17 +107,17 @@ public class ExcelSource implements SpreadsheetSource<ExcelRecord>, AutoCloseabl
 		numberOfRowsForSheet = (sheet.getPhysicalNumberOfRows() == 0) ? 0 : sheet.getLastRowNum() + 1;
 		Row firstRow = sheet.getRow(0);
 
-		int numberOfColumns = (firstRow == null) ? 0 : firstRow.getLastCellNum();
+		// POI's Row.getLastCellNum() returns -1 for a present-but-empty first row. Clamp to 0 so the column
+		// count never goes negative (a negative count later becomes new String[-1] in ExcelRecord.getRow()).
+		int numberOfColumns = (firstRow == null) ? 0 : Math.max(0, firstRow.getLastCellNum());
 
 		if (excelSourceConfig.hasHeaders()) {
 			ExcelCellHandler excelCellHandler = excelSourceConfig.getExcelCellHandler();
 
 			List<String> headerRow = new ArrayList<>();
-			if (firstRow != null) {
-				for (int i = 0; i < firstRow.getLastCellNum(); i++) {
-					Cell cell = firstRow.getCell(i);
-					headerRow.add(excelCellHandler.cellToString(cell));
-				}
+			for (int i = 0; i < numberOfColumns; i++) {
+				Cell cell = firstRow.getCell(i);
+				headerRow.add(excelCellHandler.cellToString(cell));
 			}
 			sheetInfo = new SheetInfo(numberOfColumns, numberOfRowsForSheet, new HeaderMapping(excelSourceConfig.getHeaderConfig(), headerRow));
 		}

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/tsv/TSVSource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/tsv/TSVSource.java
@@ -2,9 +2,8 @@ package io.zulia.data.source.spreadsheet.tsv;
 
 import de.siegmar.fastcsv.reader.CommentStrategy;
 import de.siegmar.fastcsv.reader.CsvReader;
+import de.siegmar.fastcsv.reader.FieldMismatchStrategy;
 import io.zulia.data.input.DataInputStream;
-import io.zulia.data.source.spreadsheet.csv.CSVSource;
-import io.zulia.data.source.spreadsheet.csv.CSVSourceConfig;
 import io.zulia.data.source.spreadsheet.delimited.DelimitedSource;
 
 import java.io.IOException;
@@ -15,8 +14,8 @@ public class TSVSource extends DelimitedSource<TSVRecord, TSVSourceConfig> {
 		return new TSVSource(tsvSourceConfig);
 	}
 
-	public static CSVSource withDefaults(DataInputStream dataInputStream) throws IOException {
-		return CSVSource.withConfig(CSVSourceConfig.from(dataInputStream));
+	public static TSVSource withDefaults(DataInputStream dataInputStream) throws IOException {
+		return TSVSource.withConfig(TSVSourceConfig.from(dataInputStream));
 	}
 
 	protected TSVSource(TSVSourceConfig tsvSourceConfig) throws IOException {
@@ -26,7 +25,8 @@ public class TSVSource extends DelimitedSource<TSVRecord, TSVSourceConfig> {
 	@Override
 	protected CsvReader.CsvReaderBuilder createParser(TSVSourceConfig tsvSourceConfig) {
 		return CsvReader.builder().fieldSeparator("\t").quoteCharacter('"').commentStrategy(CommentStrategy.SKIP).commentCharacter('#').skipEmptyLines(true)
-				.allowExtraFields(false).allowMissingFields(false).allowExtraCharsAfterClosingQuote(false).detectBomHeader(true).maxBufferSize(16777216);
+				.extraFieldStrategy(FieldMismatchStrategy.STRICT).missingFieldStrategy(FieldMismatchStrategy.STRICT).allowExtraCharsAfterClosingQuote(false)
+				.detectBomHeader(true).maxBufferSize(16777216);
 	}
 
 	@Override

--- a/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/delimited/formatter/NumberCSVWriter.java
+++ b/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/delimited/formatter/NumberCSVWriter.java
@@ -30,11 +30,14 @@ public class NumberCSVWriter<T extends List<String>> implements SpreadsheetTypeH
 	@Override
 	public void writeType(T reference, Number value) {
 		switch (value) {
+			case null -> reference.add(null);
 			case Integer i -> reference.add(String.valueOf(i));
 			case Long l -> reference.add(String.valueOf(l));
 			case Float f -> reference.add(String.format(doubleFormatter, f));
 			case Double d -> reference.add(String.format(doubleFormatter, d));
-			case null, default -> reference.add(null);
+			// Any other Number subtype (Decimal128, BigDecimal, BigInteger, Short, Byte, AtomicInteger, ...).
+			// Write its exact value rather than dropping it as an empty cell or forcing a lossy doubleValue().
+			default -> reference.add(value.toString());
 		}
 	}
 }

--- a/zulia-data/src/test/java/io/zulia/data/test/DataSourceTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/DataSourceTest.java
@@ -1,12 +1,15 @@
 package io.zulia.data.test;
 
 import io.zulia.data.common.DataStreamMeta;
+import io.zulia.data.common.SpreadsheetType;
 import io.zulia.data.input.DataInputStream;
 import io.zulia.data.input.SingleUseDataInputStream;
 import io.zulia.data.output.SingleUseDataOutputStream;
 import io.zulia.data.source.spreadsheet.SpreadsheetRecord;
 import io.zulia.data.source.spreadsheet.SpreadsheetSource;
 import io.zulia.data.source.spreadsheet.SpreadsheetSourceFactory;
+import io.zulia.data.source.spreadsheet.tsv.TSVRecord;
+import io.zulia.data.source.spreadsheet.tsv.TSVSource;
 import io.zulia.data.target.spreadsheet.SpreadsheetTargetFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -76,6 +79,35 @@ public class DataSourceTest {
 	}
 
 	@Test
+	void tsvWithDefaultsParsesTabsNotCommas() throws IOException {
+		// TSVSource.withDefaults was a copy-paste of the CSVSource version and returned a
+		// comma-delimited CSVSource, so tab rows were split on embedded commas instead of tabs.
+		byte[] tsv = "Alice\tPortland, OR\t34\n".getBytes(StandardCharsets.UTF_8);
+
+		int rows = 0;
+		try (TSVSource source = TSVSource.withDefaults(SingleUseDataInputStream.from(tsv, "test.tsv"))) {
+			for (TSVRecord record : source) {
+				Assertions.assertEquals("Alice", record.getString(0));
+				Assertions.assertEquals("Portland, OR", record.getString(1));
+				Assertions.assertEquals(Integer.valueOf(34), record.getInt(2));
+				rows++;
+			}
+		}
+		Assertions.assertEquals(1, rows);
+	}
+
+	@Test
+	void spreadsheetTypeFallsBackToExtensionWhenContentTypeIsNull() throws IOException {
+		// The content type is null for unrecognized extensions or when a caller passes an explicit
+		// null. getSpreadsheetType used to NPE on it before reaching its own extension fallback.
+		SingleUseDataInputStream csvStream = SingleUseDataInputStream.from(new ByteArrayInputStream(new byte[0]), null, "data.csv");
+		Assertions.assertEquals(SpreadsheetType.CSV, SpreadsheetType.getSpreadsheetType(csvStream.getMeta()));
+
+		SingleUseDataInputStream unknownStream = SingleUseDataInputStream.from(new ByteArrayInputStream(new byte[0]), null, "data.dat");
+		Assertions.assertNull(SpreadsheetType.getSpreadsheetType(unknownStream.getMeta()));
+	}
+
+	@Test
 	void trulyEmptyDelimitedSourceWithHeadersThrowsIOException() throws IOException {
 		// a file with no rows at all (not even a header line) should surface a clear IOException rather than letting
 		// FastCSV's NoSuchElementException escape when headers are required
@@ -96,6 +128,18 @@ public class DataSourceTest {
 
 		Assertions.assertTrue(dataInputStream.openCount() >= 2, "re-iteration should have reopened the source");
 		Assertions.assertEquals(0, dataInputStream.unclosedCount(), "every opened underlying stream should be closed");
+	}
+
+	@Test
+	void emptySingleUseDelimitedSourceIteratesWithoutReopening() throws IOException {
+		// A header-only source over a single-use stream must iterate to zero rows. Previously iterator() saw
+		// nextRow == null and called reset(), which reopens the stream and throws on a single-use input.
+		byte[] csv = "header1,header2\n".getBytes(StandardCharsets.UTF_8);
+		SingleUseDataInputStream dataInputStream = SingleUseDataInputStream.from(new ByteArrayInputStream(csv), "test.csv");
+
+		try (SpreadsheetSource<?> dataSource = SpreadsheetSourceFactory.fromStreamWithHeaders(dataInputStream)) {
+			Assertions.assertEquals(0, countRows(dataSource));
+		}
 	}
 
 	private static int countRows(SpreadsheetSource<?> dataSource) {

--- a/zulia-data/src/test/java/io/zulia/data/test/ExcelSourceTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/ExcelSourceTest.java
@@ -3,13 +3,20 @@ package io.zulia.data.test;
 import io.zulia.data.input.SingleUseDataInputStream;
 import io.zulia.data.source.spreadsheet.excel.ExcelRecord;
 import io.zulia.data.source.spreadsheet.excel.ExcelSource;
+import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.function.Consumer;
 
 public class ExcelSourceTest {
@@ -49,6 +56,90 @@ public class ExcelSourceTest {
 
 		try (ExcelSource source = ExcelSource.withDefaults(SingleUseDataInputStream.from(xlsx, "test.xlsx"))) {
 			Assertions.assertThrows(IllegalArgumentException.class, () -> source.switchSheet("missing"));
+		}
+	}
+
+	@Test
+	void blankInteriorRowDoesNotThrow() throws IOException {
+		// Row 1 is intentionally never created, so POI's sheet.getRow(1) returns null on a blank interior row.
+		// Accessing such a row used to NullPointerException. It now reads correctly as an empty row.
+		byte[] xlsx = sheetToWorkbookAsBytes(sheet -> {
+			sheet.createRow(0).createCell(0).setCellValue("first");
+			sheet.createRow(2).createCell(0).setCellValue("third");
+		});
+
+		try (ExcelSource source = ExcelSource.withDefaults(SingleUseDataInputStream.from(xlsx, "test.xlsx"))) {
+			List<String> firstColumn = new ArrayList<>();
+			for (ExcelRecord record : source) {
+				firstColumn.add(record.getString(0));
+				Assertions.assertNotNull(record.getRow(), "getRow() must not throw on a blank row");
+			}
+			Assertions.assertEquals(Arrays.asList("first", null, "third"), firstColumn);
+		}
+	}
+
+	@Test
+	void presentButEmptyFirstRowDoesNotThrow() throws IOException {
+		// Row 0 exists but has no cells, so POI's Row.getLastCellNum() returns -1. Before clamping, that made
+		// numberOfColumns = -1 and ExcelRecord.getRow() did new String[-1] -> NegativeArraySizeException.
+		byte[] xlsx = sheetToWorkbookAsBytes(sheet -> {
+			sheet.createRow(0);
+			sheet.createRow(1).createCell(0).setCellValue("data");
+		});
+
+		// a present-but-empty first row really does report -1 columns.
+		try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(xlsx))) {
+			Row firstRow = workbook.getSheetAt(0).getRow(0);
+			Assertions.assertNotNull(firstRow, "expected a present-but-empty first row, not an absent one");
+			Assertions.assertEquals(-1, firstRow.getLastCellNum());
+		}
+
+		try (ExcelSource source = ExcelSource.withDefaults(SingleUseDataInputStream.from(xlsx, "test.xlsx"))) {
+			for (ExcelRecord record : source) {
+				Assertions.assertNotNull(record.getRow());
+			}
+		}
+	}
+
+	@Test
+	void booleanCellsReadAsStringsAndBooleans() throws IOException {
+		// cellToString had no BOOLEAN branch, so TRUE/FALSE cells (and formulas with a cached
+		// boolean result) read as null strings, silently dropping the column in whole-row exports.
+		byte[] xlsx = sheetToWorkbookAsBytes(sheet -> {
+			Row row = sheet.createRow(0);
+			row.createCell(0).setCellValue(true);
+			row.createCell(1).setCellValue(false);
+			row.createCell(2).setCellFormula("1=1");
+			sheet.getWorkbook().getCreationHelper().createFormulaEvaluator().evaluateAll();
+		});
+
+		try (ExcelSource source = ExcelSource.withDefaults(SingleUseDataInputStream.from(xlsx, "test.xlsx"))) {
+			ExcelRecord record = source.iterator().next();
+			Assertions.assertEquals("true", record.getString(0));
+			Assertions.assertEquals("false", record.getString(1));
+			Assertions.assertEquals("true", record.getString(2));
+			Assertions.assertEquals(Boolean.TRUE, record.getBoolean(0));
+			Assertions.assertEquals(Boolean.TRUE, record.getBoolean(2));
+			Assertions.assertArrayEquals(new String[] { "true", "false", "true" }, record.getRow());
+		}
+	}
+
+	@Test
+	void largeIntegralNumbersAreNotClampedToLongRange() throws IOException {
+		// formatNumericCellAsString rendered any integral double via longValue(), so 1E20 saturated
+		// to Long.MAX_VALUE ("9223372036854775807") and exported a completely unrelated number.
+		byte[] xlsx = sheetToWorkbookAsBytes(sheet -> {
+			Row row = sheet.createRow(0);
+			row.createCell(0).setCellValue(1e20);
+			row.createCell(1).setCellValue(-1e20);
+			row.createCell(2).setCellValue(42);
+		});
+
+		try (ExcelSource source = ExcelSource.withDefaults(SingleUseDataInputStream.from(xlsx, "test.xlsx"))) {
+			ExcelRecord record = source.iterator().next();
+			Assertions.assertEquals("1.0E20", record.getString(0));
+			Assertions.assertEquals("-1.0E20", record.getString(1));
+			Assertions.assertEquals("42", record.getString(2));
 		}
 	}
 

--- a/zulia-data/src/test/java/io/zulia/data/test/JsonArraySourceTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/JsonArraySourceTest.java
@@ -39,6 +39,27 @@ public class JsonArraySourceTest {
 		Assertions.assertTrue(readAll("[]").isEmpty());
 	}
 
+	@Test
+	public void nonObjectElementThrowsInsteadOfTruncating() {
+		// A null (or scalar) element used to be indistinguishable from the end of the array, so every object
+		// after it was silently dropped. It must now fail loudly rather than return a truncated result.
+		String json = """
+				[
+				  {"id": "a"},
+				  null,
+				  {"id": "c"}
+				]
+				""";
+
+		Assertions.assertThrows(IllegalStateException.class, () -> readAll(json));
+	}
+
+	@Test
+	public void scalarFirstElementThrows() {
+		// The same silent truncation applied to the very first element read during open().
+		Assertions.assertThrows(IllegalStateException.class, () -> readAll("[1, 2, 3]"));
+	}
+
 	private static List<JsonSourceRecord> readAll(String json) throws Exception {
 		var dataInputStream = SingleUseDataInputStream.from(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)), "test.json");
 		List<JsonSourceRecord> records = new ArrayList<>();

--- a/zulia-data/src/test/java/io/zulia/data/test/JsonLineSourceTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/JsonLineSourceTest.java
@@ -1,0 +1,178 @@
+package io.zulia.data.test;
+
+import io.zulia.data.input.SingleUseDataInputStream;
+import io.zulia.data.source.json.JsonLineDataSource;
+import io.zulia.data.source.json.JsonLineSourceConfig;
+import io.zulia.data.source.json.JsonSourceRecord;
+import io.zulia.data.source.json.LoggingJsonLineParseExceptionHandler;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class JsonLineSourceTest {
+
+	@Test
+	public void parsesMultipleLines() throws Exception {
+		String jsonl = """
+				{"id": "a", "count": 1, "ratio": 1.5, "active": true}
+				{"id": "b", "count": 2, "ratio": 2.5, "active": false}
+				{"id": "c", "count": 3, "ratio": 3.5, "active": true}
+				""";
+
+		List<JsonSourceRecord> records = readAll(jsonl);
+
+		Assertions.assertEquals(3, records.size());
+		Assertions.assertEquals(List.of("a", "b", "c"), records.stream().map(r -> r.getString("id")).toList());
+		Assertions.assertEquals(1, records.getFirst().getInt("count"));
+		Assertions.assertEquals(Boolean.FALSE, records.get(1).getBoolean("active"));
+	}
+
+	@Test
+	public void numericGettersAcceptAnyJsonNumberType() {
+		// Document.parse maps whole numbers in int range to Integer, larger ones to Long, and
+		// decimals to Double. The getters used to delegate to Document's casting getters, so
+		// getLong("count") threw ClassCastException whenever the value happened to fit in an int.
+		JsonSourceRecord record = new JsonSourceRecord("{\"count\": 42, \"big\": 5000000000, \"ratio\": 2.5}");
+
+		Assertions.assertEquals(42L, record.getLong("count"));
+		Assertions.assertEquals(42.0, record.getDouble("count"));
+		Assertions.assertEquals(42.0f, record.getFloat("count"));
+		Assertions.assertEquals(42, record.getInt("count"));
+
+		Assertions.assertEquals(5_000_000_000L, record.getLong("big"));
+		Assertions.assertEquals(2.5, record.getDouble("ratio"));
+		Assertions.assertEquals(2.5f, record.getFloat("ratio"));
+
+		// an out-of-int-range value surfaces clearly instead of silently wrapping
+		Assertions.assertThrows(ArithmeticException.class, () -> record.getInt("big"));
+
+		Assertions.assertNull(record.getLong("missing"));
+		Assertions.assertNull(record.getInt("missing"));
+	}
+
+	@Test
+	public void skipsMalformedLineWithoutLooping() {
+		// A non-throwing handler (logs and returns null) is the documented way to skip bad lines.
+		// Before the fix, the cursor was not advanced on a parse failure, so the bad line was
+		// re-parsed forever. The preemptive timeout fails the test if that regression returns.
+		String jsonl = """
+				{"id": "a"}
+				{not valid json
+				{"id": "c"}
+				""";
+
+		List<JsonSourceRecord> records = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+			var dataInputStream = SingleUseDataInputStream.from(new ByteArrayInputStream(jsonl.getBytes(StandardCharsets.UTF_8)), "test.jsonl");
+			JsonLineSourceConfig config = JsonLineSourceConfig.from(dataInputStream);
+			config.withExceptionHandler(new LoggingJsonLineParseExceptionHandler(LoggerFactory.getLogger(JsonLineSourceTest.class)));
+
+			List<JsonSourceRecord> collected = new ArrayList<>();
+			try (JsonLineDataSource source = JsonLineDataSource.withConfig(config)) {
+				for (JsonSourceRecord record : source) {
+					collected.add(record);
+				}
+			}
+			return collected;
+		});
+
+		// The bad line yields a null record from the logging handler; the two good lines parse normally.
+		List<JsonSourceRecord> valid = records.stream().filter(Objects::nonNull).toList();
+		Assertions.assertEquals(List.of("a", "c"), valid.stream().map(r -> r.getString("id")).toList());
+	}
+
+	@Test
+	public void surfacesStreamErrorLoudlyByDefault() {
+		// The default handler (ThrowingJsonLineParseExceptionHandler) must surface a failure of the
+		// underlying stream as an exception rather than ending iteration silently.
+		Assertions.assertThrows(RuntimeException.class, () -> {
+			var dataInputStream = SingleUseDataInputStream.from(new FailAfterLineInputStream("{\"id\": \"a\"}\n"), "broken.jsonl");
+			try (JsonLineDataSource source = JsonLineDataSource.withDefaults(dataInputStream)) {
+				for (JsonSourceRecord ignored : source) {
+					// drain until the stream failure surfaces
+				}
+			}
+		});
+	}
+
+	@Test
+	public void streamErrorCanBeSkippedQuietly() {
+		// With a logging (non-throwing) handler the same stream failure ends iteration cleanly and
+		// without looping. The preemptive timeout guards against a regression to the infinite loop.
+		List<JsonSourceRecord> records = Assertions.assertTimeoutPreemptively(Duration.ofSeconds(10), () -> {
+			var dataInputStream = SingleUseDataInputStream.from(new FailAfterLineInputStream("{\"id\": \"a\"}\n"), "broken.jsonl");
+			JsonLineSourceConfig config = JsonLineSourceConfig.from(dataInputStream);
+			config.withExceptionHandler(new LoggingJsonLineParseExceptionHandler(LoggerFactory.getLogger(JsonLineSourceTest.class)));
+
+			List<JsonSourceRecord> collected = new ArrayList<>();
+			try (JsonLineDataSource source = JsonLineDataSource.withConfig(config)) {
+				for (JsonSourceRecord record : source) {
+					collected.add(record);
+				}
+			}
+			return collected;
+		});
+
+		// Read-ahead means the failed read aborts before the in-hand line is returned, so the handler
+		// contributes a null and iteration terminates with no surviving record.
+		Assertions.assertTrue(records.stream().allMatch(Objects::isNull));
+	}
+
+	@Test
+	public void emptySingleUseSourceIteratesEmptyWithoutReopening() throws Exception {
+		// An empty source over a single-use stream must iterate to an empty result once. Previously iterator()
+		// saw next == null and called reset(), which reopens the stream and throws on a single-use input.
+		Assertions.assertEquals(0, readAll("").size());
+	}
+
+	private static List<JsonSourceRecord> readAll(String jsonl) throws Exception {
+		var dataInputStream = SingleUseDataInputStream.from(new ByteArrayInputStream(jsonl.getBytes(StandardCharsets.UTF_8)), "test.jsonl");
+		List<JsonSourceRecord> records = new ArrayList<>();
+		try (JsonLineDataSource source = JsonLineDataSource.withDefaults(dataInputStream)) {
+			for (JsonSourceRecord record : source) {
+				records.add(record);
+			}
+		}
+		return records;
+	}
+
+	/**
+	 * Serves the bytes of a single line and then throws on the next read, simulating an underlying
+	 * stream that fails partway through iteration.
+	 */
+	private static final class FailAfterLineInputStream extends InputStream {
+		private final byte[] data;
+		private int pos = 0;
+
+		private FailAfterLineInputStream(String line) {
+			this.data = line.getBytes(StandardCharsets.UTF_8);
+		}
+
+		@Override
+		public int read() throws IOException {
+			if (pos >= data.length) {
+				throw new IOException("simulated stream failure");
+			}
+			return data[pos++] & 0xFF;
+		}
+
+		@Override
+		public int read(byte[] b, int off, int len) throws IOException {
+			if (pos >= data.length) {
+				throw new IOException("simulated stream failure");
+			}
+			int n = Math.min(len, data.length - pos);
+			System.arraycopy(data, pos, b, off, n);
+			pos += n;
+			return n;
+		}
+	}
+}

--- a/zulia-data/src/test/java/io/zulia/data/test/NumberCSVWriterTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/NumberCSVWriterTest.java
@@ -1,0 +1,52 @@
+package io.zulia.data.test;
+
+import io.zulia.data.target.spreadsheet.delimited.formatter.NumberCSVWriter;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NumberCSVWriterTest {
+
+	@Test
+	void standardNumberTypesAreFormatted() {
+		NumberCSVWriter<List<String>> writer = new NumberCSVWriter<>();
+		List<String> out = new ArrayList<>();
+
+		writer.writeType(out, 42);
+		writer.writeType(out, 42L);
+		writer.writeType(out, 1.5f);
+		writer.writeType(out, 2.5d);
+
+		Assertions.assertEquals(List.of("42", "42", "1.500", "2.500"), out);
+	}
+
+	@Test
+	void otherNumberSubtypesKeepTheirValueInsteadOfWritingNull() {
+		// Integer/Long/Float/Double were the only matched cases; every other Number subtype fell through to a
+		// null cell, silently dropping data (notably Decimal128 from Mongo decimal fields). They must now write.
+		NumberCSVWriter<List<String>> writer = new NumberCSVWriter<>();
+		List<String> out = new ArrayList<>();
+
+		writer.writeType(out, new BigInteger("123456789012345678901234567890"));
+		writer.writeType(out, new BigDecimal("1.25"));
+		writer.writeType(out, (short) 7);
+		writer.writeType(out, (byte) 3);
+
+		Assertions.assertEquals(List.of("123456789012345678901234567890", "1.25", "7", "3"), out);
+	}
+
+	@Test
+	void nullStillWritesAnEmptyCell() {
+		NumberCSVWriter<List<String>> writer = new NumberCSVWriter<>();
+		List<String> out = new ArrayList<>();
+
+		writer.writeType(out, null);
+
+		Assertions.assertEquals(1, out.size());
+		Assertions.assertNull(out.getFirst());
+	}
+}

--- a/zulia-util/src/main/java/io/zulia/util/document/DocumentHelper.java
+++ b/zulia-util/src/main/java/io/zulia/util/document/DocumentHelper.java
@@ -39,6 +39,30 @@ public class DocumentHelper {
 
 	}
 
+	public static Float getAsFloat(Document document, String field) {
+		return document.get(field) instanceof Number number ? number.floatValue() : null;
+	}
+
+	public static Double getAsDouble(Document document, String field) {
+		return document.get(field) instanceof Number number ? number.doubleValue() : null;
+	}
+
+	public static Integer getAsInt(Document document, String field) {
+		if (document.get(field) instanceof Number number) {
+			try {
+				return Math.toIntExact(number.longValue());
+			}
+			catch (ArithmeticException e) {
+				throw new ArithmeticException("Field <" + field + "> has value <" + number + "> that does not fit in an int");
+			}
+		}
+		return null;
+	}
+
+	public static Long getAsLong(Document document, String field) {
+		return document.get(field) instanceof Number number ? number.longValue() : null;
+	}
+
 	private static Object getChild(Object o, String field, boolean retainNullAndEmpty) {
 		if (o instanceof Document d) {
 			o = d.get(field);


### PR DESCRIPTION
# zulia-data robustness fixes
## JsonLineDataSource had infinite loop on a malformed line

next() parsed the current line before advancing the cursor. When a line failed
to parse and a non-throwing handler skipped it, `next` was never advanced, so
hasNext() stayed true, and the same bad line was re-parsed forever. next() now
advances the cursor before parsing so each line is consumed exactly once. A
failure of the underlying stream sets `next` to null to stop iteration and then
routes the IOException through the configured exception handler: the default
throwing handler surfaces it loudly, a logging handler skips it quietly.

## ExcelRecord threw NullPointerException on blank rows

POI's Sheet.getRow returns null for a blank interior row, and that null Row was
wrapped in an ExcelRecord with no guard, so every accessor threw. getCell(int)
now returns null for a null row, and all index accessors and getRow() route
through it. The cell handlers already treat a null Cell as empty, so a blank row
reads as an empty row.

## reset-on-null breaks empty single-use streams

DelimitedSource and JsonLineDataSource called reset() whenever the prefetched
value was null, which conflated "empty input" with "fully consumed" and threw
on a single-use stream that had only a header (or no rows). Both now track an
`iterated` boolean, matching JsonArraySource, so an empty single-use source
iterates to an empty result once and re-iteration is explicit.

##  NumberCSVWriter dropped non-standard Number subtypes

writeType matched only Integer/Long/Float/Double and sent every other Number to
a null cell, silently dropping Decimal128, BigDecimal, BigInteger, Short, and
Byte. The null case is now separate from the default, and other Number subtypes
are written via toString() to preserve their exact value rather than forcing a
lossy doubleValue().

## ExcelSource set numberOfColumns = -1 on an empty first row

POI's Row.getLastCellNum() returns -1 for a present-but-empty first row, which
propagated into new String[-1] (NegativeArraySizeException). The column count is
clamped with Math.max(0, ...) and the header loop uses the clamped value.

## JsonArraySource truncates at the first non-object element

next() treated any non START_OBJECT token as end-of-array, so a null or scalar
element silently ended iteration and dropped every remaining object. A shared
advanceToNextElement() now branches explicitly: END_ARRAY (or end of input) ends
iteration, START_OBJECT reads the next object, and any other token throws a clear
IllegalStateException instead of truncating. open() uses the same helper, so a
non-object first element fails loudly.

## TSVSource.withDefaults returned a comma-delimited CSVSource

The method was copy-pasted from CSVSource and built a CSVSource with
CSVSourceConfig, so files opened through it were split on commas instead of
tabs. Rows with embedded commas parsed into wrong fields and comma-free rows
collapsed into a single field. It now returns a TSVSource built from
TSVSourceConfig, and the return type is corrected to TSVSource.

## SpreadsheetType.getSpreadsheetType threw NPE on a null content type

The content type is null whenever the extension is unrecognized or a caller
passes an explicit null, and the method called toLowerCase() on it before its
own extension fallback could run. The content-type switch is now guarded and
a null content type falls through to the extension-based resolution.

## JsonSourceRecord numeric getters crashed on JSON whole numbers

Document.parse maps whole numbers in int range to Integer and larger ones to
Long, but the getters delegated to Document's casting getters, so
getLong("count") on {"count": 42} threw ClassCastException, as did getDouble
and getFloat. All numeric getters now read the raw value through the Number
interface. getInt uses Math.toIntExact so an out-of-int-range value fails
loudly instead of wrapping, matching the Excel cell handler behavior.

## Excel boolean cells were silently dropped

cellToString had no BOOLEAN branch, so TRUE/FALSE cells read as null strings
and whole-row exports lost the column even though cellToBoolean could read the
cell. Boolean cells and formula cells with a cached boolean result now render
as "true"/"false", and cellToBoolean also handles cached boolean formula
results.

## Excel large integral numbers clamped to Long.MAX_VALUE

Whole numbers were rendered without a trailing ".0" via longValue(), and every
finite double at or above 2^53 is integral, so a cell holding 1E20 exported as
"9223372036854775807" and -1E20 as "-9223372036854775808". The long rendering
now applies only when the value fits in long range. Larger magnitudes keep the
double form.

## FastCSV deprecation cleanup

Replaced the removal-marked allowExtraFields(false)/allowMissingFields(false)
calls in CSVSource and TSVSource with extraFieldStrategy(FieldMismatchStrategy
.STRICT)/missingFieldStrategy(FieldMismatchStrategy.STRICT), which is the exact
behavior the deprecated methods delegated to.