### PR TITLE
Add vector quantization (BBQ + scalar int8/int7/int4) with oversample and full-precision rescore

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 grpc = "1.82.1"
-lucene = "10.4.0"
+lucene = "10.5.0"
 eclipse-collections = "13.0.0"
 graalvm = "25.0.3"
 micronaut = "5.0.2" # micronaut platform BOM version, applied via micronaut { version(...) }

--- a/zulia-client/src/main/java/io/zulia/client/command/builder/VectorTopNQuery.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/builder/VectorTopNQuery.java
@@ -59,6 +59,16 @@ public class VectorTopNQuery implements QueryBuilder {
 		return this;
 	}
 
+	/**
+	 * Oversampling for quantized vector fields: fetch {@code ceil(topN * oversample)} candidates from the quantized
+	 * graph, then rerank with full-precision vectors. 0 (unset) uses the encoding's default (BBQ rescores by default,
+	 * INT8/FLOAT32 do not), 1.0 forces rescoring off, higher values are capped server-side at 32x
+	 */
+	public VectorTopNQuery oversample(float oversample) {
+		builder.setVectorOversample(oversample);
+		return this;
+	}
+
 	public float getBoost() {
 		return builder.getBoost();
 	}

--- a/zulia-client/src/main/java/io/zulia/fields/FieldConfigBuilder.java
+++ b/zulia-client/src/main/java/io/zulia/fields/FieldConfigBuilder.java
@@ -8,6 +8,8 @@ import static io.zulia.message.ZuliaIndex.FieldConfig;
 import static io.zulia.message.ZuliaIndex.GeoPointConfig;
 import static io.zulia.message.ZuliaIndex.IndexAs;
 import static io.zulia.message.ZuliaIndex.SortAs;
+import static io.zulia.message.ZuliaIndex.VectorDescription;
+import static io.zulia.message.ZuliaIndex.VectorIndexingConfig;
 
 public class FieldConfigBuilder {
 	private final FieldConfig.FieldType fieldType;
@@ -16,6 +18,8 @@ public class FieldConfigBuilder {
 	private final List<FacetAs> facetAsList;
 	private final List<SortAs> sortAsList;
 	private GeoPointConfig geoPointConfig;
+	private VectorDescription.Builder vectorDescription;
+	private VectorIndexingConfigBuilder vectorIndexingConfig;
 	private String description;
 	private String displayName;
 	private Boolean docValueSkipIndex;
@@ -60,10 +64,15 @@ public class FieldConfigBuilder {
 		return create(storedFieldName, FieldConfig.FieldType.NUMERIC_DOUBLE);
 	}
 
+	/**
+	 * Creates a VECTOR (cosine) field with no explicit encoding. The server picks one by index-creation version:
+	 * INT8 scalar quantization for new indexes, raw float32 for legacy. Pin one with {@link #quantization(VectorIndexingConfig.Encoding)}.
+	 */
 	public static FieldConfigBuilder createVector(String storedFieldName) {
 		return create(storedFieldName, FieldConfig.FieldType.VECTOR);
 	}
 
+	/** Creates a UNIT_VECTOR (dot-product) field. The encoding resolves as in {@link #createVector}. */
 	public static FieldConfigBuilder createUnitVector(String storedFieldName) {
 		return create(storedFieldName, FieldConfig.FieldType.UNIT_VECTOR);
 	}
@@ -86,6 +95,85 @@ public class FieldConfigBuilder {
 	 */
 	public static FieldConfigBuilder createGeoPointTopLevel(String latitudeKey, String longitudeKey) {
 		return createGeoPoint("", latitudeKey, longitudeKey);
+	}
+
+	private VectorDescription.Builder vectorDescriptionBuilder() {
+		if (vectorDescription == null) {
+			vectorDescription = VectorDescription.newBuilder();
+		}
+		return vectorDescription;
+	}
+
+	private VectorIndexingConfigBuilder vectorIndexingConfigBuilder() {
+		if (vectorIndexingConfig == null) {
+			vectorIndexingConfig = VectorIndexingConfigBuilder.create();
+		}
+		return vectorIndexingConfig;
+	}
+
+	/** Vector encoding for every indexed representation of this field that does not set its own via {@link #indexAs(String, VectorIndexingConfig.Encoding)}. */
+	public FieldConfigBuilder quantization(VectorIndexingConfig.Encoding encoding) {
+		vectorIndexingConfigBuilder().quantization(encoding);
+		return this;
+	}
+
+	/** HNSW graph tuning (m = max connections, efConstruction = build beam width) for representations without their own config. */
+	public FieldConfigBuilder hnsw(int m, int efConstruction) {
+		vectorIndexingConfigBuilder().hnsw(m, efConstruction);
+		return this;
+	}
+
+	/** Overrides the similarity (otherwise derived from field type: VECTOR=cosine, UNIT_VECTOR=dot-product). */
+	public FieldConfigBuilder similarity(VectorDescription.Similarity similarity) {
+		vectorDescriptionBuilder().setSimilarity(similarity);
+		return this;
+	}
+
+	/** Expected vector dimensions, validated on store when set. */
+	public FieldConfigBuilder dimensions(int dimensions) {
+		vectorDescriptionBuilder().setDimensions(dimensions);
+		return this;
+	}
+
+	/** Exact brute-force (flat) index instead of the default HNSW graph, for representations without their own config. */
+	public FieldConfigBuilder flat() {
+		vectorIndexingConfigBuilder().flat();
+		return this;
+	}
+
+	/** Records the embedding model that produces this field's vectors (provenance only). */
+	public FieldConfigBuilder model(String modelName) {
+		vectorDescriptionBuilder().setModelName(modelName);
+		return this;
+	}
+
+	public FieldConfigBuilder model(String modelName, String modelDescription) {
+		vectorDescriptionBuilder().setModelName(modelName).setModelDescription(modelDescription);
+		return this;
+	}
+
+	/** Replaces the vector description (dimensions, similarity, model provenance). */
+	public FieldConfigBuilder vectorDescription(VectorDescription vectorDescription) {
+		this.vectorDescription = vectorDescription.toBuilder();
+		return this;
+	}
+
+	/**
+	 * Indexes this vector field under an additional name with its own encoding, e.g.
+	 * {@code createVector("v").dimensions(384).indexAs("vBBQ", Encoding.BBQ).indexAs("vExact", Encoding.FLOAT32)}.
+	 */
+	public FieldConfigBuilder indexAs(String indexedFieldName, VectorIndexingConfig.Encoding encoding) {
+		return indexAs(indexedFieldName, VectorIndexingConfig.newBuilder().setEncoding(encoding).build());
+	}
+
+	/** Indexes this vector field under an additional name with its own config, e.g. {@code indexAs("v8", VectorIndexingConfigBuilder.create().quantization(INT8).hnsw(24, 200))}. */
+	public FieldConfigBuilder indexAs(String indexedFieldName, VectorIndexingConfigBuilder vectorIndexingConfigBuilder) {
+		return indexAs(indexedFieldName, vectorIndexingConfigBuilder.build());
+	}
+
+	/** Indexes this vector field under an additional name with its own {@link VectorIndexingConfig}. */
+	public FieldConfigBuilder indexAs(String indexedFieldName, VectorIndexingConfig vectorIndexingConfig) {
+		return indexAs(IndexAs.newBuilder().setIndexFieldName(indexedFieldName).setVectorIndexingConfig(vectorIndexingConfig).build());
 	}
 
 	public FieldConfigBuilder index() {
@@ -238,7 +326,19 @@ public class FieldConfigBuilder {
 		FieldConfig.Builder fcBuilder = FieldConfig.newBuilder();
 		fcBuilder.setStoredFieldName(storedFieldName);
 		fcBuilder.setFieldType(fieldType);
-		fcBuilder.addAllIndexAs(indexAsList);
+		if (vectorIndexingConfig != null) {
+			// the field-wide indexing config is the default for representations that did not set their own
+			VectorIndexingConfig defaultIndexingConfig = vectorIndexingConfig.build();
+			for (IndexAs indexAs : indexAsList) {
+				fcBuilder.addIndexAs(indexAs.hasVectorIndexingConfig() ? indexAs : indexAs.toBuilder().setVectorIndexingConfig(defaultIndexingConfig).build());
+			}
+		}
+		else {
+			fcBuilder.addAllIndexAs(indexAsList);
+		}
+		if (vectorDescription != null) {
+			fcBuilder.setVectorDescription(vectorDescription);
+		}
 		fcBuilder.addAllFacetAs(facetAsList);
 		fcBuilder.addAllSortAs(sortAsList);
 		if (geoPointConfig != null) {

--- a/zulia-client/src/main/java/io/zulia/fields/VectorIndexingConfigBuilder.java
+++ b/zulia-client/src/main/java/io/zulia/fields/VectorIndexingConfigBuilder.java
@@ -1,0 +1,64 @@
+package io.zulia.fields;
+
+import static io.zulia.message.ZuliaIndex.VectorIndexingConfig;
+
+/**
+ * Builds a {@link VectorIndexingConfig} for one indexed representation of a vector field, e.g.
+ * {@code FieldConfigBuilder.createVector("v").indexAs("vBBQ", VectorIndexingConfigBuilder.create().quantization(Encoding.BBQ).hnsw(24, 200))}.
+ */
+public class VectorIndexingConfigBuilder {
+
+	private VectorIndexingConfig.Encoding encoding;
+	private VectorIndexingConfig.IndexType indexType;
+	private Integer hnswM;
+	private Integer hnswEfConstruction;
+
+	public static VectorIndexingConfigBuilder create() {
+		return new VectorIndexingConfigBuilder();
+	}
+
+	private VectorIndexingConfigBuilder() {
+	}
+
+	/** Vector encoding for this representation. Left unset, the server picks the index-creation-version default. */
+	public VectorIndexingConfigBuilder quantization(VectorIndexingConfig.Encoding encoding) {
+		this.encoding = encoding;
+		return this;
+	}
+
+	/** HNSW graph tuning (m = max connections, efConstruction = build beam width). */
+	public VectorIndexingConfigBuilder hnsw(int m, int efConstruction) {
+		this.hnswM = m;
+		this.hnswEfConstruction = efConstruction;
+		return this;
+	}
+
+	/** Exact brute-force (flat) index instead of the default HNSW graph. */
+	public VectorIndexingConfigBuilder flat() {
+		this.indexType = VectorIndexingConfig.IndexType.FLAT;
+		return this;
+	}
+
+	/** Use HNSW graph (the default, but can be used to toggle back from flat()) **/
+	public VectorIndexingConfigBuilder hnsw() {
+		this.indexType = VectorIndexingConfig.IndexType.HNSW;
+		return this;
+	}
+
+	public VectorIndexingConfig build() {
+		VectorIndexingConfig.Builder builder = VectorIndexingConfig.newBuilder();
+		if (encoding != null) {
+			builder.setEncoding(encoding);
+		}
+		if (indexType != null) {
+			builder.setIndexType(indexType);
+		}
+		if (hnswM != null) {
+			builder.setHnswM(hnswM);
+		}
+		if (hnswEfConstruction != null) {
+			builder.setHnswEfConstruction(hnswEfConstruction);
+		}
+		return builder.build();
+	}
+}

--- a/zulia-common/src/main/java/io/zulia/util/ZuliaUtil.java
+++ b/zulia-common/src/main/java/io/zulia/util/ZuliaUtil.java
@@ -221,32 +221,52 @@ public class ZuliaUtil {
 		return document.toJson();
 	}
 
+	/** Converts a collection of numbers to a {@code float[]}, accepting any {@link Number} subtype. */
+	public static float[] toFloatArray(Collection<? extends Number> collection) {
+		float[] result = new float[collection.size()];
+		int i = 0;
+		for (Number element : collection) {
+			result[i++] = element.floatValue();
+		}
+		return result;
+	}
+
+	/** {@link #toFloatArray(Collection)} for an erased collection. Elements must be {@link Number} or iteration throws ClassCastException. */
+	@SuppressWarnings("unchecked")
+	public static float[] toFloatArrayUnchecked(Collection<?> collection) {
+		return toFloatArray((Collection<? extends Number>) collection);
+	}
+
+	/** Converts a collection of numbers to a {@code double[]}, accepting any {@link Number} subtype. */
+	public static double[] toDoubleArray(Collection<? extends Number> collection) {
+		double[] result = new double[collection.size()];
+		int i = 0;
+		for (Number element : collection) {
+			result[i++] = element.doubleValue();
+		}
+		return result;
+	}
+
+	/** {@link #toDoubleArray(Collection)} for an erased collection. Elements must be {@link Number} or iteration throws ClassCastException. */
+	@SuppressWarnings("unchecked")
+	public static double[] toDoubleArrayUnchecked(Collection<?> collection) {
+		return toDoubleArray((Collection<? extends Number>) collection);
+	}
+
 	public static float[] getFloatArray(Document document, String fieldName, float[] defaultValue) {
-		List<Double> vector = document.getList(fieldName, Double.class);
+		List<Number> vector = document.getList(fieldName, Number.class);
 		if (vector == null) {
 			return defaultValue;
 		}
-
-		float[] vectorFloat = new float[vector.size()];
-		for (int i = 0; i < vector.size(); i++) {
-			vectorFloat[i] = vector.get(i).floatValue();
-		}
-		return vectorFloat;
-
+		return toFloatArray(vector);
 	}
 
 	public static double[] getDoubleArray(Document document, String fieldName, double[] defaultValue) {
-		List<Double> vector = document.getList(fieldName, Double.class);
+		List<Number> vector = document.getList(fieldName, Number.class);
 		if (vector == null) {
 			return defaultValue;
 		}
-
-		double[] vectorFloat = new double[vector.size()];
-		for (int i = 0; i < vector.size(); i++) {
-			vectorFloat[i] = vector.get(i);
-		}
-		return vectorFloat;
-
+		return toDoubleArray(vector);
 	}
 
 	public static void filterDocument(org.bson.Document mongoDocument, Collection<String> returnFields) {

--- a/zulia-common/src/main/proto/zulia_index.proto
+++ b/zulia-common/src/main/proto/zulia_index.proto
@@ -209,11 +209,56 @@ message FieldConfig {
     // Build a Lucene doc-values skip index on this field's sort doc-values (enables block-skipping range queries and dynamic-pruning sorts).
     // optional so we can tell "unset" (default on for new fields) apart from an explicit opt-out. Frozen once a field exists
     optional bool docValueSkipIndex = 10;
+    VectorDescription vectorDescription = 11; // for VECTOR / UNIT_VECTOR fields: dimensions, similarity, model provenance
 }
 
 message GeoPointConfig {
     string latitudeKey = 1;   // default "latitude"
     string longitudeKey = 2;  // default "longitude"
+}
+
+// Properties of the vector data itself, shared by every indexed representation of the field.
+// Per-representation indexing choices (quantization, HNSW) live in VectorIndexingConfig on each IndexAs.
+message VectorDescription {
+    enum Similarity {
+        DEFAULT = 0;            // derive from field type (VECTOR=COSINE, UNIT_VECTOR=DOT_PRODUCT)
+        COSINE = 1;
+        DOT_PRODUCT = 2;
+        EUCLIDEAN = 3;
+        MAX_INNER_PRODUCT = 4;
+    }
+
+    Similarity similarity = 1;
+    uint32 dimensions = 2;          // 0 = infer at index time. When set, vector length is validated on store
+
+    // Provenance only. Records which embedding model produced these vectors. The server does not run inference
+    string modelName = 3;           // e.g. "BAAI/bge-large-en-v1.5"
+    string modelDescription = 4;    // optional free-text notes about the model/vectors
+}
+
+// How one indexed representation of a dense-vector field is encoded on disk. Lives on IndexAs, so one stored field
+// indexed under multiple names can carry a different encoding per name. With no config the encoding resolves by
+// createdIndexVersion (INT8 for new indexes, FLOAT32 for legacy).
+message VectorIndexingConfig {
+    enum Encoding {
+        ENCODING_UNSPECIFIED = 0; // no explicit choice, the server applies the index-creation-version default
+        FLOAT32 = 1;   // raw float32 HNSW (Lucene99HnswVectorsFormat). Explicit opt-out of quantization
+        INT8 = 2;      // 8-bit scalar quant (UNSIGNED_BYTE)
+        INT7 = 3;      // 7-bit scalar quant (SEVEN_BIT)
+        INT4 = 4;      // 4-bit scalar quant (PACKED_NIBBLE)
+        BBQ = 5;       // 1-bit Better Binary Quantization (SINGLE_BIT_QUERY_NIBBLE)
+        BBQ_2BIT = 6;  // 2-bit binary quant (DIBIT_QUERY_NIBBLE)
+    }
+
+    enum IndexType {
+        HNSW = 0;   // approximate nearest neighbor graph
+        FLAT = 1;   // exact brute force (quantized flat)
+    }
+
+    Encoding encoding = 1;          // an explicit value (incl FLOAT32) is authoritative
+    IndexType indexType = 2;
+    uint32 hnswM = 3;               // 0 means 16
+    uint32 hnswEfConstruction = 4;  // 0 means 100
 }
 
 
@@ -265,6 +310,7 @@ message AnalyzerSettings {
 message IndexAs {
     string indexFieldName = 1;
     string analyzerName = 2;
+    VectorIndexingConfig vectorIndexingConfig = 3; // for VECTOR / UNIT_VECTOR fields: quantization and HNSW graph for this representation
 }
 
 message Superbit {

--- a/zulia-common/src/main/proto/zulia_query.proto
+++ b/zulia-common/src/main/proto/zulia_query.proto
@@ -75,6 +75,10 @@ message Query {
 
     float boost = 16; // score multiplier applied to this clause; 0 = unset (treated as 1.0); ignored for non-scoring clause types
     MoreLikeThisParams moreLikeThisParams = 17;
+
+    // Oversampling for quantized vector fields: fetch ceil(vectorTopN * vectorOversample) candidates, rescore with
+    // full-precision vectors, keep vectorTopN. 0 = encoding default (BBQ rescores, INT8/FLOAT32 do not), 1.0 = off, capped server-side at 32x
+    float vectorOversample = 18;
 }
 
 message NumericSet {

--- a/zulia-server/src/main/java/io/zulia/server/index/ReadOnlyPerFieldKnnVectorsFormat.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ReadOnlyPerFieldKnnVectorsFormat.java
@@ -1,0 +1,24 @@
+package io.zulia.server.index;
+
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+
+/**
+ * Read path only. {@link PerFieldKnnVectorsFormat}'s reader resolves each field's stored format name via SPI and
+ * never calls {@link #getKnnVectorsFormatForField(String)}, so an SPI-loaded codec can read any segment. Writing
+ * through it fails fast instead of silently using default formats.
+ */
+final class ReadOnlyPerFieldKnnVectorsFormat extends PerFieldKnnVectorsFormat {
+
+	private final String codecName;
+
+	ReadOnlyPerFieldKnnVectorsFormat(String codecName) {
+		this.codecName = codecName;
+	}
+
+	@Override
+	public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+		throw new IllegalStateException("Codec <" + codecName
+				+ "> was loaded via SPI and is read-only. New segments must be written with ZuliaCodec.currentWriteCodec, requested field <" + field + ">");
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardDocumentIndexer.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardDocumentIndexer.java
@@ -1,7 +1,6 @@
 package io.zulia.server.index;
 
 import com.google.common.base.Splitter;
-import com.google.common.primitives.Floats;
 import org.eclipse.collections.impl.map.mutable.primitive.IntObjectHashMap;
 import org.eclipse.collections.impl.set.mutable.primitive.IntHashSet;
 import io.zulia.ZuliaFieldConstants;
@@ -248,9 +247,17 @@ public class ShardDocumentIndexer {
 				StringFieldIndexer.INSTANCE.index(luceneDocument, storedFieldName, o, indexedFieldName);
 			}
 			else if (FieldTypeUtil.isVectorFieldType(fieldType)) {
-				if (o instanceof Collection collection) {
-					luceneDocument.add(new KnnFloatVectorField(indexedFieldName, Floats.toArray(collection),
-							FieldConfig.FieldType.UNIT_VECTOR.equals(fieldType) ? VectorSimilarityFunction.DOT_PRODUCT : VectorSimilarityFunction.COSINE));
+				if (o instanceof Collection<?> collection) {
+					float[] vector = ZuliaUtil.toFloatArrayUnchecked(collection);
+					ZuliaIndex.VectorDescription vectorDescription = fc.getVectorDescription();
+					if (vectorDescription.getDimensions() > 0 && vector.length != vectorDescription.getDimensions()) {
+						throw new IllegalArgumentException(
+								"Vector field <" + storedFieldName + "> is configured for " + vectorDescription.getDimensions() + " dimensions but document <"
+										+ indexedFieldName + "> has " + vector.length);
+					}
+					// Quantization is purely a codec concern. The indexed field stays a plain KnnFloatVectorField.
+					VectorSimilarityFunction similarity = VectorFieldResolver.resolveSimilarity(vectorDescription, fieldType);
+					luceneDocument.add(new KnnFloatVectorField(indexedFieldName, vector, similarity));
 				}
 			}
 			else if (FieldTypeUtil.isGeoPointFieldType(fieldType)) {

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardWriteManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardWriteManager.java
@@ -109,6 +109,8 @@ public class ShardWriteManager {
 		tieredMergePolicy.setDeletesPctAllowed(0.15);
 		config.setMergePolicy(tieredMergePolicy);
 		config.setIndexDeletionPolicy(snapshotDeletionPolicy);
+		// per-field vector codec, encodes each vector field representation per its VectorIndexingConfig
+		config.setCodec(ZuliaCodec.currentWriteCodec(indexConfig));
 		config.setMaxBufferedDocs(Integer.MAX_VALUE);
 		config.setRAMBufferSizeMB(ServerIndexConfig.DEFAULT_RAM_BUFFER_MB); // overwritten by updateIndexSettings() in the constructor
 		config.setUseCompoundFile(false);

--- a/zulia-server/src/main/java/io/zulia/server/index/VectorFieldResolver.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/VectorFieldResolver.java
@@ -1,0 +1,147 @@
+package io.zulia.server.index;
+
+import io.zulia.message.ZuliaIndex.FieldConfig.FieldType;
+import io.zulia.message.ZuliaIndex.IndexAs;
+import io.zulia.message.ZuliaIndex.VectorDescription;
+import io.zulia.message.ZuliaIndex.VectorIndexingConfig;
+import io.zulia.server.config.IndexFieldInfo;
+import io.zulia.server.config.ServerIndexConfig;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.util.quantization.QuantizedByteVectorValues.ScalarEncoding;
+
+/**
+ * Resolves the effective {@link VectorIndexingConfig} per internal indexed-field name and maps it to Lucene vector
+ * formats and similarities, so the codec, indexer, and query path always agree. An explicit encoding is
+ * authoritative. {@code ENCODING_UNSPECIFIED} resolves by index-creation version: INT8 at or after
+ * {@link ZuliaIndexVersion#VECTOR_DEFAULT_INT8}, raw float32 for older/legacy indexes (no silent re-quantization).
+ */
+public final class VectorFieldResolver {
+
+	public static final int DEFAULT_HNSW_M = 16;
+	public static final int DEFAULT_HNSW_EF_CONSTRUCTION = 100;
+
+	/**
+	 * Hard ceiling on the oversampling factor. Bounds the per-shard candidate fetch (ceil(topN * oversample)).
+	 */
+	public static final float MAX_OVERSAMPLE = 32.0f;
+
+	private VectorFieldResolver() {
+	}
+
+	/**
+	 * Effective indexing config for an internal indexed field name, never null, with the encoding finalized to a
+	 * concrete value so callers never special-case a missing config.
+	 */
+	public static VectorIndexingConfig resolve(ServerIndexConfig indexConfig, String internalFieldName) {
+		VectorIndexingConfig raw = getVectorIndexingConfigForField(indexConfig, internalFieldName);
+		VectorIndexingConfig.Encoding effective = effectiveEncoding(indexConfig, raw);
+		if (raw == null) {
+			return VectorIndexingConfig.newBuilder().setEncoding(effective).build();
+		}
+		if (raw.getEncoding() == effective) {
+			return raw;
+		}
+		return raw.toBuilder().setEncoding(effective).build();
+	}
+
+	private static VectorIndexingConfig getVectorIndexingConfigForField(ServerIndexConfig indexConfig, String internalFieldName) {
+		IndexFieldInfo indexFieldInfo = indexConfig.getIndexFieldInfo(internalFieldName);
+		if (indexFieldInfo != null) {
+			IndexAs indexAs = indexFieldInfo.getIndexAs();
+			if (indexAs != null && indexAs.hasVectorIndexingConfig()) {
+				return indexAs.getVectorIndexingConfig();
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * An explicit encoding wins. Null or unspecified resolves to the index-creation-version default.
+	 */
+	public static VectorIndexingConfig.Encoding effectiveEncoding(ServerIndexConfig indexConfig, VectorIndexingConfig rawConfig) {
+		VectorIndexingConfig.Encoding encoding = rawConfig != null ? rawConfig.getEncoding() : VectorIndexingConfig.Encoding.ENCODING_UNSPECIFIED;
+		if (encoding == VectorIndexingConfig.Encoding.ENCODING_UNSPECIFIED || encoding == VectorIndexingConfig.Encoding.UNRECOGNIZED) {
+			if (indexConfig.getIndexSettings().getCreatedIndexVersion() >= ZuliaIndexVersion.VECTOR_DEFAULT_INT8) {
+				return VectorIndexingConfig.Encoding.INT8;
+			}
+			return VectorIndexingConfig.Encoding.FLOAT32;
+		}
+		return encoding;
+	}
+
+	/**
+	 * True when the representation's effective encoding is quantized (anything other than FLOAT32).
+	 */
+	public static boolean isQuantized(VectorIndexingConfig vectorIndexingConfig) {
+		return switch (vectorIndexingConfig.getEncoding()) {
+			case INT8, INT7, INT4, BBQ, BBQ_2BIT -> true;
+			case FLOAT32, ENCODING_UNSPECIFIED, UNRECOGNIZED -> false;
+		};
+	}
+
+	/**
+	 * Default oversample when the query does not set one. Aggressive BBQ loses too much in the quantized graph to be
+	 * usable without full-precision rescoring, so it oversamples by default. 1.0 means no rescore.
+	 */
+	public static float defaultOversample(VectorIndexingConfig vectorIndexingConfig) {
+		return switch (vectorIndexingConfig.getEncoding()) {
+			case BBQ -> 3.0f;
+			case BBQ_2BIT -> 2.0f;
+			case INT4 -> 1.5f;
+			case INT8, INT7, FLOAT32, ENCODING_UNSPECIFIED, UNRECOGNIZED -> 1.0f;
+		};
+	}
+
+	/**
+	 * Null (the codec read path) or explicit FLOAT32 maps to the raw float32 HNSW format used before quantization existed.
+	 */
+	public static KnnVectorsFormat buildFormat(VectorIndexingConfig vectorIndexingConfig) {
+		if (vectorIndexingConfig == null) {
+			return new Lucene99HnswVectorsFormat(DEFAULT_HNSW_M, DEFAULT_HNSW_EF_CONSTRUCTION);
+		}
+		if (!isQuantized(vectorIndexingConfig)) {
+			return new Lucene99HnswVectorsFormat(hnswM(vectorIndexingConfig), hnswEfConstruction(vectorIndexingConfig));
+		}
+		ScalarEncoding scalarEncoding = toScalarEncoding(vectorIndexingConfig.getEncoding());
+		if (vectorIndexingConfig.getIndexType() == VectorIndexingConfig.IndexType.FLAT) {
+			return new Lucene104ScalarQuantizedVectorsFormat(scalarEncoding);
+		}
+		return new Lucene104HnswScalarQuantizedVectorsFormat(scalarEncoding, hnswM(vectorIndexingConfig), hnswEfConstruction(vectorIndexingConfig));
+	}
+
+	/**
+	 * DEFAULT derives from the field type (UNIT_VECTOR=dot-product, VECTOR=cosine), matching pre-quantization behavior.
+	 */
+	public static VectorSimilarityFunction resolveSimilarity(VectorDescription vectorDescription, FieldType fieldType) {
+		return switch (vectorDescription.getSimilarity()) {
+			case COSINE -> VectorSimilarityFunction.COSINE;
+			case DOT_PRODUCT -> VectorSimilarityFunction.DOT_PRODUCT;
+			case EUCLIDEAN -> VectorSimilarityFunction.EUCLIDEAN;
+			case MAX_INNER_PRODUCT -> VectorSimilarityFunction.MAXIMUM_INNER_PRODUCT;
+			case DEFAULT, UNRECOGNIZED -> fieldType == FieldType.UNIT_VECTOR ? VectorSimilarityFunction.DOT_PRODUCT : VectorSimilarityFunction.COSINE;
+		};
+	}
+
+	private static int hnswM(VectorIndexingConfig vectorIndexingConfig) {
+		return vectorIndexingConfig.getHnswM() > 0 ? vectorIndexingConfig.getHnswM() : DEFAULT_HNSW_M;
+	}
+
+	private static int hnswEfConstruction(VectorIndexingConfig vectorIndexingConfig) {
+		return vectorIndexingConfig.getHnswEfConstruction() > 0 ? vectorIndexingConfig.getHnswEfConstruction() : DEFAULT_HNSW_EF_CONSTRUCTION;
+	}
+
+	private static ScalarEncoding toScalarEncoding(VectorIndexingConfig.Encoding encoding) {
+		return switch (encoding) {
+			case INT8 -> ScalarEncoding.UNSIGNED_BYTE;
+			case INT7 -> ScalarEncoding.SEVEN_BIT;
+			case INT4 -> ScalarEncoding.PACKED_NIBBLE;
+			case BBQ -> ScalarEncoding.SINGLE_BIT_QUERY_NIBBLE;
+			case BBQ_2BIT -> ScalarEncoding.DIBIT_QUERY_NIBBLE;
+			case FLOAT32, ENCODING_UNSPECIFIED, UNRECOGNIZED -> throw new IllegalArgumentException("No scalar encoding for vector encoding <" + encoding + ">");
+		};
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/VectorFieldResolver.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/VectorFieldResolver.java
@@ -97,12 +97,9 @@ public final class VectorFieldResolver {
 	}
 
 	/**
-	 * Null (the codec read path) or explicit FLOAT32 maps to the raw float32 HNSW format used before quantization existed.
+	 * FLOAT32 maps to the raw float32 HNSW format used before quantization existed.
 	 */
 	public static KnnVectorsFormat buildFormat(VectorIndexingConfig vectorIndexingConfig) {
-		if (vectorIndexingConfig == null) {
-			return new Lucene99HnswVectorsFormat(DEFAULT_HNSW_M, DEFAULT_HNSW_EF_CONSTRUCTION);
-		}
 		if (!isQuantized(vectorIndexingConfig)) {
 			return new Lucene99HnswVectorsFormat(hnswM(vectorIndexingConfig), hnswEfConstruction(vectorIndexingConfig));
 		}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaCodec.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaCodec.java
@@ -1,0 +1,36 @@
+package io.zulia.server.index;
+
+import io.zulia.server.config.ServerIndexConfig;
+import org.apache.lucene.codecs.Codec;
+import org.apache.lucene.codecs.FilterCodec;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+
+/**
+ * Base for Zulia's per-Lucene-version codecs. Each subclass pins one persisted codec name to one Lucene delegate
+ * ({@link ZuliaLucene104Codec} = "Zulia104" = Lucene104 formats) and overrides only per-field KNN vector formats.
+ *
+ * <p>Segments persist their codec name and Lucene resolves it back via SPI, so the name to delegate binding is
+ * permanent. Never repoint or rename a released subclass. For a newer Lucene default codec, add a new subclass,
+ * register it in {@code META-INF/services}, point {@link #currentWriteCodec} at it, and keep the old ones registered
+ * so existing segments stay readable. Every node needs the write codec on its classpath before any node writes
+ * vector segments (replication and restarts open segments by persisted codec name).
+ */
+public abstract class ZuliaCodec extends FilterCodec {
+
+	private final KnnVectorsFormat knnVectorsFormat;
+
+	protected ZuliaCodec(String codecName, Codec delegate, ServerIndexConfig indexConfig) {
+		super(codecName, delegate);
+		this.knnVectorsFormat = new ZuliaPerFieldKnnVectorsFormat(indexConfig);
+	}
+
+	/** The codec new segments are written with. The single place to update on a Lucene default-codec upgrade. */
+	public static ZuliaCodec currentWriteCodec(ServerIndexConfig indexConfig) {
+		return new ZuliaLucene104Codec(indexConfig);
+	}
+
+	@Override
+	public KnnVectorsFormat knnVectorsFormat() {
+		return knnVectorsFormat;
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaCodec.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaCodec.java
@@ -6,27 +6,29 @@ import org.apache.lucene.codecs.FilterCodec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 
 /**
- * Base for Zulia's per-Lucene-version codecs. Each subclass pins one persisted codec name to one Lucene delegate
- * ({@link ZuliaLucene104Codec} = "Zulia104" = Lucene104 formats) and overrides only per-field KNN vector formats.
+ * Base for Zulia's per-Lucene-version codecs. Each version is a read/write pair: the read class pins one persisted
+ * codec name to one Lucene delegate ({@link ZuliaLucene104Codec} = "Zulia104" = Lucene104 formats) and is what SPI
+ * resolves when opening segments, and its write subclass ({@link ZuliaLucene104WriteCodec}) adds the index config
+ * for choosing per-field KNN vector formats on new segments.
  *
  * <p>Segments persist their codec name and Lucene resolves it back via SPI, so the name to delegate binding is
- * permanent. Never repoint or rename a released subclass. For a newer Lucene default codec, add a new subclass,
- * register it in {@code META-INF/services}, point {@link #currentWriteCodec} at it, and keep the old ones registered
- * so existing segments stay readable. Every node needs the write codec on its classpath before any node writes
- * vector segments (replication and restarts open segments by persisted codec name).
+ * permanent. Never repoint or rename a released version class. For a newer Lucene default codec, add a new read/write
+ * pair, register the read class in {@code META-INF/services}, and point {@link #currentWriteCodec} at the new write
+ * class. Keep the old read classes registered so existing segments stay readable. Every node needs the read codec on
+ * its classpath before any node writes vector segments (replication and restarts open segments by persisted codec name).
  */
 public abstract class ZuliaCodec extends FilterCodec {
 
 	private final KnnVectorsFormat knnVectorsFormat;
 
-	protected ZuliaCodec(String codecName, Codec delegate, ServerIndexConfig indexConfig) {
+	protected ZuliaCodec(String codecName, Codec delegate, KnnVectorsFormat knnVectorsFormat) {
 		super(codecName, delegate);
-		this.knnVectorsFormat = new ZuliaPerFieldKnnVectorsFormat(indexConfig);
+		this.knnVectorsFormat = knnVectorsFormat;
 	}
 
 	/** The codec new segments are written with. The single place to update on a Lucene default-codec upgrade. */
 	public static ZuliaCodec currentWriteCodec(ServerIndexConfig indexConfig) {
-		return new ZuliaLucene104Codec(indexConfig);
+		return new ZuliaLucene104WriteCodec(indexConfig);
 	}
 
 	@Override

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
@@ -14,6 +14,7 @@ import io.zulia.message.ZuliaIndex.FieldConfig;
 import io.zulia.message.ZuliaIndex.IndexSettings;
 import io.zulia.message.ZuliaIndex.IndexShardMapping;
 import io.zulia.message.ZuliaIndex.ShardMapping;
+import io.zulia.message.ZuliaIndex.VectorIndexingConfig;
 import io.zulia.message.ZuliaQuery;
 import io.zulia.message.ZuliaQuery.Facet;
 import io.zulia.message.ZuliaQuery.FacetRequest;
@@ -69,6 +70,7 @@ import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.KnnFloatVectorQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.RescoreTopNQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
@@ -518,18 +520,44 @@ public class ZuliaIndex {
 		if (query.getQfList().isEmpty()) {
 			throw new IllegalArgumentException("Cosine sim query must give at least one query field (qf)");
 		}
-		else if (query.getQfList().size() == 1) {
-			return new KnnFloatVectorQuery(query.getQfList().getFirst(), vector, query.getVectorTopN(), getPreFilter(query.getVectorPreQueryList()));
+
+		int topN = query.getVectorTopN();
+		float requestedOversample = query.getVectorOversample();
+		// A NaN or negative oversample is a client error. 0 means "let the field's encoding pick a default".
+		if (Float.isNaN(requestedOversample) || requestedOversample < 0f) {
+			throw new IllegalArgumentException("vectorOversample must be >= 0 (0 selects the field's default), got " + requestedOversample);
 		}
-		else {
-			BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
-			BooleanQuery preFilter = getPreFilter(query.getVectorPreQueryList());
-			for (String field : query.getQfList()) {
-				KnnFloatVectorQuery knnVectorQuery = new KnnFloatVectorQuery(field, vector, query.getVectorTopN(), preFilter);
-				booleanQueryBuilder.add(knnVectorQuery, BooleanClause.Occur.SHOULD);
+		BooleanQuery preFilter = getPreFilter(query.getVectorPreQueryList());
+
+		if (query.getQfList().size() == 1) {
+			return buildKnnQuery(query.getQfList().getFirst(), vector, topN, requestedOversample, preFilter);
+		}
+
+		BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
+		for (String field : query.getQfList()) {
+			booleanQueryBuilder.add(buildKnnQuery(field, vector, topN, requestedOversample, preFilter), BooleanClause.Occur.SHOULD);
+		}
+		return booleanQueryBuilder.build();
+	}
+
+	private Query buildKnnQuery(String field, float[] vector, int topN, float requestedOversample, BooleanQuery preFilter) {
+		// oversampling pulls extra candidates from the quantized graph and reranks them with full-precision vectors.
+		// The rescore runs per shard, so the cross-shard merge keeps comparing exact-similarity scores
+		VectorIndexingConfig vectorIndexingConfig = VectorFieldResolver.resolve(indexConfig, field);
+		if (VectorFieldResolver.isQuantized(vectorIndexingConfig)) {
+			float oversample;
+			if (requestedOversample > 0f)
+				oversample = requestedOversample;
+			else
+				oversample = VectorFieldResolver.defaultOversample(vectorIndexingConfig);
+			oversample = Math.min(oversample, VectorFieldResolver.MAX_OVERSAMPLE);
+			if (oversample > 1.0f) {
+				int candidates = (int) Math.ceil(topN * (double) oversample);
+				KnnFloatVectorQuery knnVectorQuery = new KnnFloatVectorQuery(field, vector, candidates, preFilter);
+				return RescoreTopNQuery.createFullPrecisionRescorerQuery(knnVectorQuery, vector, field, topN);
 			}
-			return booleanQueryBuilder.build();
 		}
+		return new KnnFloatVectorQuery(field, vector, topN, preFilter);
 	}
 
 	public Query handleMoreLikeThisQuery(ZuliaQuery.Query query) {

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexVersion.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexVersion.java
@@ -5,18 +5,21 @@ package io.zulia.server.index;
  * <p>
  * The version is stamped once when an index is created and never changes afterward. It lets new indexes adopt evolving
  * built-in defaults that cannot be expressed per field and must not change for an index that already exists (for example,
- * the doc-values skip index on the built-in id sort field). Indexes
- * created before versioning existed report 0 (legacy) and keep their original behavior.
+ * the doc-values skip index on the built-in id sort field). Indexes created before versioning existed report 0 (legacy)
+ * and keep their original behavior.
  * <p>
- * Gate a behavior on {@code createdIndexVersion >=} the fixed version in which it was introduced, never on {@link #CURRENT}
- * (which moves) - otherwise bumping CURRENT would silently change behavior for older versioned indexes.
+ * Gate a behavior on {@code createdIndexVersion >=} the fixed version in which it was introduced, never on
+ * {@link #CURRENT} (which moves). Otherwise, bumping CURRENT would silently change the behavior for older versioned indexes.
  */
 public interface ZuliaIndexVersion {
 
 
 	/** Stamped on every newly created index. Bump when a new creation-time default is introduced. */
-	int CURRENT = 1;
+	int CURRENT = 2;
 
 	/** Indexes at or above this version build a doc-values skip index on the built-in id sort field. */
 	int ID_SORT_DOC_VALUE_SKIP = 1;
+
+	/** Indexes at or above this version default dense-vector fields (with no explicit encoding) to INT8 scalar quantization. */
+	int VECTOR_DEFAULT_INT8 = 2;
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaLucene104Codec.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaLucene104Codec.java
@@ -1,22 +1,23 @@
 package io.zulia.server.index;
 
-import io.zulia.server.config.ServerIndexConfig;
+import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene104.Lucene104Codec;
 
 /**
- * Zulia codec bound permanently to {@link Lucene104Codec} formats (there is no 10.5 codec) under the persisted name
- * {@code "Zulia104"}. For a newer Lucene default codec, add a sibling class rather than changing this one (see {@link ZuliaCodec}).
+ * Zulia read codec bound permanently to {@link Lucene104Codec} formats (there is no 10.5 codec) under the persisted
+ * name {@code "Zulia104"}. The no-arg constructor is the SPI entry point used when opening existing segments. Stored
+ * per-field format names are resolved by SPI on read, so no index config is needed and this instance can read any
+ * Zulia104 segment. New segments are written with {@link ZuliaLucene104WriteCodec} (see {@link ZuliaCodec}).
  */
-public final class ZuliaLucene104Codec extends ZuliaCodec {
+public sealed class ZuliaLucene104Codec extends ZuliaCodec permits ZuliaLucene104WriteCodec {
 
 	public static final String CODEC_NAME = "Zulia104";
 
-	/** SPI read-path constructor. Per-field formats are resolved by their stored name, so no config is needed. */
 	public ZuliaLucene104Codec() {
-		this(null);
+		this(new ReadOnlyPerFieldKnnVectorsFormat(CODEC_NAME));
 	}
 
-	public ZuliaLucene104Codec(ServerIndexConfig indexConfig) {
-		super(CODEC_NAME, new Lucene104Codec(), indexConfig);
+	protected ZuliaLucene104Codec(KnnVectorsFormat knnVectorsFormat) {
+		super(CODEC_NAME, new Lucene104Codec(), knnVectorsFormat);
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaLucene104Codec.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaLucene104Codec.java
@@ -1,0 +1,22 @@
+package io.zulia.server.index;
+
+import io.zulia.server.config.ServerIndexConfig;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+
+/**
+ * Zulia codec bound permanently to {@link Lucene104Codec} formats (there is no 10.5 codec) under the persisted name
+ * {@code "Zulia104"}. For a newer Lucene default codec, add a sibling class rather than changing this one (see {@link ZuliaCodec}).
+ */
+public final class ZuliaLucene104Codec extends ZuliaCodec {
+
+	public static final String CODEC_NAME = "Zulia104";
+
+	/** SPI read-path constructor. Per-field formats are resolved by their stored name, so no config is needed. */
+	public ZuliaLucene104Codec() {
+		this(null);
+	}
+
+	public ZuliaLucene104Codec(ServerIndexConfig indexConfig) {
+		super(CODEC_NAME, new Lucene104Codec(), indexConfig);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaLucene104WriteCodec.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaLucene104WriteCodec.java
@@ -1,0 +1,14 @@
+package io.zulia.server.index;
+
+import io.zulia.server.config.ServerIndexConfig;
+
+/**
+ * Write codec for {@code "Zulia104"} segments. Extends the read codec so new segments persist that name and read
+ * back through SPI without this class or the index config. Only reachable via {@link ZuliaCodec#currentWriteCodec}.
+ */
+public final class ZuliaLucene104WriteCodec extends ZuliaLucene104Codec {
+
+	public ZuliaLucene104WriteCodec(ServerIndexConfig indexConfig) {
+		super(new ZuliaPerFieldKnnVectorsFormat(indexConfig));
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaPerFieldKnnVectorsFormat.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaPerFieldKnnVectorsFormat.java
@@ -1,31 +1,25 @@
 package io.zulia.server.index;
 
-import io.zulia.message.ZuliaIndex.VectorIndexingConfig;
 import io.zulia.server.config.ServerIndexConfig;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
 
+import java.util.Objects;
+
 /**
- * Selects the Lucene KNN vectors format per field from each representation's resolved {@link VectorIndexingConfig}.
- * The read path resolves stored format names via SPI and never calls {@link #getKnnVectorsFormatForField(String)},
- * so the config-less SPI instance can read any segment.
+ * Write path only. Selects the Lucene KNN vectors format per field from each representation's resolved
+ * {@link io.zulia.message.ZuliaIndex.VectorIndexingConfig}, so the codec, indexer, and query path always agree.
  */
-public class ZuliaPerFieldKnnVectorsFormat extends PerFieldKnnVectorsFormat {
+final class ZuliaPerFieldKnnVectorsFormat extends PerFieldKnnVectorsFormat {
 
 	private final ServerIndexConfig indexConfig;
 
-	/** SPI read path only. */
-	public ZuliaPerFieldKnnVectorsFormat() {
-		this(null);
-	}
-
-	public ZuliaPerFieldKnnVectorsFormat(ServerIndexConfig indexConfig) {
-		this.indexConfig = indexConfig;
+	ZuliaPerFieldKnnVectorsFormat(ServerIndexConfig indexConfig) {
+		this.indexConfig = Objects.requireNonNull(indexConfig, "indexConfig is required for the write codec");
 	}
 
 	@Override
 	public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
-		VectorIndexingConfig vectorIndexingConfig = indexConfig != null ? VectorFieldResolver.resolve(indexConfig, field) : null;
-		return VectorFieldResolver.buildFormat(vectorIndexingConfig);
+		return VectorFieldResolver.buildFormat(VectorFieldResolver.resolve(indexConfig, field));
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaPerFieldKnnVectorsFormat.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaPerFieldKnnVectorsFormat.java
@@ -1,0 +1,31 @@
+package io.zulia.server.index;
+
+import io.zulia.message.ZuliaIndex.VectorIndexingConfig;
+import io.zulia.server.config.ServerIndexConfig;
+import org.apache.lucene.codecs.KnnVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+
+/**
+ * Selects the Lucene KNN vectors format per field from each representation's resolved {@link VectorIndexingConfig}.
+ * The read path resolves stored format names via SPI and never calls {@link #getKnnVectorsFormatForField(String)},
+ * so the config-less SPI instance can read any segment.
+ */
+public class ZuliaPerFieldKnnVectorsFormat extends PerFieldKnnVectorsFormat {
+
+	private final ServerIndexConfig indexConfig;
+
+	/** SPI read path only. */
+	public ZuliaPerFieldKnnVectorsFormat() {
+		this(null);
+	}
+
+	public ZuliaPerFieldKnnVectorsFormat(ServerIndexConfig indexConfig) {
+		this.indexConfig = indexConfig;
+	}
+
+	@Override
+	public KnnVectorsFormat getKnnVectorsFormatForField(String field) {
+		VectorIndexingConfig vectorIndexingConfig = indexConfig != null ? VectorFieldResolver.resolve(indexConfig, field) : null;
+		return VectorFieldResolver.buildFormat(vectorIndexingConfig);
+	}
+}

--- a/zulia-server/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
+++ b/zulia-server/src/main/resources/META-INF/services/org.apache.lucene.codecs.Codec
@@ -1,0 +1,1 @@
+io.zulia.server.index.ZuliaLucene104Codec

--- a/zulia-server/src/test/java/io/zulia/server/test/node/QuantizedVectorTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/QuantizedVectorTest.java
@@ -1,0 +1,332 @@
+package io.zulia.server.test.node;
+
+import com.google.common.primitives.Floats;
+import io.zulia.DefaultAnalyzers;
+import io.zulia.ai.embedding.KnownEmbeddingModel;
+import io.zulia.ai.embedding.TextEmbeddingModel;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.command.builder.VectorTopNQuery;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.CompleteResult;
+import io.zulia.client.result.GetIndexConfigResult;
+import io.zulia.client.result.SearchResult;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.fields.VectorIndexingConfigBuilder;
+import io.zulia.message.ZuliaIndex.FieldConfig;
+import io.zulia.message.ZuliaIndex.IndexAs;
+import io.zulia.message.ZuliaIndex.VectorDescription;
+import io.zulia.message.ZuliaIndex.VectorIndexingConfig;
+import io.zulia.server.test.node.shared.NodeExtension;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.SequencedMap;
+import java.util.stream.Collectors;
+
+/**
+ * End-to-end coverage of the quantized vector path: every encoding round-trips, oversample rescore recovers exact
+ * ordering, dual-representation fields and VectorDescription read-back work, and everything survives a node restart
+ * (SPI codec resolution).
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class QuantizedVectorTest {
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(1);
+
+	private static final String INDEX_NAME = "quantizedVectorTest";
+
+	private static TextEmbeddingModel embeddingModel;
+
+	private static final String[] TITLES = { "Phase III trial of pembrolizumab in non-small cell lung cancer",
+			"Immunotherapy response rates in advanced melanoma patients", "CRISPR-Cas9 gene editing for sickle cell disease treatment",
+			"Cardiovascular outcomes with SGLT2 inhibitors in type 2 diabetes", "Deep learning for early detection of diabetic retinopathy",
+			"Renaissance art and its influence on modern architecture", "Soil microbiome diversity in tropical rainforests",
+			"Quantum computing approaches to protein folding simulation" };
+
+	// One indexed vector field per encoding. All populated from the same embedding so results are directly comparable.
+	private static final SequencedMap<String, VectorIndexingConfig.Encoding> ENCODING_FIELDS = new LinkedHashMap<>();
+
+	static {
+		ENCODING_FIELDS.put("vFloat", VectorIndexingConfig.Encoding.FLOAT32);
+		ENCODING_FIELDS.put("vInt8", VectorIndexingConfig.Encoding.INT8);
+		ENCODING_FIELDS.put("vInt7", VectorIndexingConfig.Encoding.INT7);
+		ENCODING_FIELDS.put("vInt4", VectorIndexingConfig.Encoding.INT4);
+		ENCODING_FIELDS.put("vBBQ", VectorIndexingConfig.Encoding.BBQ);
+		ENCODING_FIELDS.put("vBBQ2", VectorIndexingConfig.Encoding.BBQ_2BIT);
+	}
+
+	private static final String FLAT_FIELD = "vFlat";       // INT8, exact brute-force
+	private static final String EUCLID_FIELD = "vEuclid";   // FLOAT32, EUCLIDEAN similarity
+	private static final String MIP_FIELD = "vMip";         // INT8, MAX_INNER_PRODUCT similarity
+	private static final String RAW_FIELD = "vRaw";         // no vector config at all, inherits the index-version default (INT8 for this new index)
+	private static final String DIMS_FIELD = "vDims";       // INT8 with declared dimensions (length validated on store)
+
+	// one stored field indexed under two names with different encodings, the vector is supplied once per document
+	private static final String DUAL_FIELD = "vDual";
+	private static final String DUAL_EXACT = "vDualExact";  // FLOAT32 representation
+	private static final String DUAL_BBQ = "vDualBBQ";      // BBQ representation
+	private static final String DUAL_MODEL_NAME = "intfloat/e5-small-v2";
+
+	@Test
+	@Order(1)
+	public void loadModel() throws Exception {
+		embeddingModel = TextEmbeddingModel.load(KnownEmbeddingModel.E5_SMALL_V2);
+	}
+
+	@Test
+	@Order(2)
+	public void createIndex() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("title");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("title").indexAs(DefaultAnalyzers.STANDARD));
+
+		for (Map.Entry<String, VectorIndexingConfig.Encoding> entry : ENCODING_FIELDS.entrySet()) {
+			indexConfig.addFieldConfig(FieldConfigBuilder.createVector(entry.getKey()).quantization(entry.getValue()).index());
+		}
+
+		indexConfig.addFieldConfig(FieldConfigBuilder.createVector(FLAT_FIELD).quantization(VectorIndexingConfig.Encoding.INT8).flat().index());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createVector(EUCLID_FIELD).quantization(VectorIndexingConfig.Encoding.FLOAT32)
+				.similarity(VectorDescription.Similarity.EUCLIDEAN).index());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createVector(MIP_FIELD).quantization(VectorIndexingConfig.Encoding.INT8)
+				.similarity(VectorDescription.Similarity.MAX_INNER_PRODUCT).index());
+		indexConfig.addFieldConfig(
+				FieldConfigBuilder.createVector(DIMS_FIELD).quantization(VectorIndexingConfig.Encoding.INT8).dimensions(embeddingModel.getDimensions()).index());
+
+		indexConfig.addFieldConfig(FieldConfigBuilder.createVector(DUAL_FIELD).dimensions(embeddingModel.getDimensions())
+				.model(DUAL_MODEL_NAME, "test embedding model").indexAs(DUAL_EXACT, VectorIndexingConfig.Encoding.FLOAT32)
+				.indexAs(DUAL_BBQ, VectorIndexingConfigBuilder.create().quantization(VectorIndexingConfig.Encoding.BBQ).hnsw(24, 200)));
+
+		// no vector config at all, so it inherits the index-creation-version default (INT8 for this new index)
+		indexConfig.addFieldConfig(FieldConfig.newBuilder().setStoredFieldName(RAW_FIELD).setFieldType(FieldConfig.FieldType.VECTOR)
+				.addIndexAs(IndexAs.newBuilder().setIndexFieldName(RAW_FIELD).build()).build());
+
+		indexConfig.setIndexName(INDEX_NAME);
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setShardCommitInterval(20);
+
+		zuliaWorkPool.createIndex(indexConfig);
+	}
+
+	@Test
+	@Order(3)
+	public void indexDocuments() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		for (int i = 0; i < TITLES.length; i++) {
+			List<Float> embedding = Floats.asList(embeddingModel.embedPassage(TITLES[i]));
+
+			Document mongoDocument = new Document();
+			mongoDocument.put("title", TITLES[i]);
+			for (String field : ENCODING_FIELDS.keySet()) {
+				mongoDocument.put(field, embedding);
+			}
+			mongoDocument.put(FLAT_FIELD, embedding);
+			mongoDocument.put(EUCLID_FIELD, embedding);
+			mongoDocument.put(MIP_FIELD, embedding);
+			mongoDocument.put(DIMS_FIELD, embedding);
+			mongoDocument.put(RAW_FIELD, embedding);
+			mongoDocument.put(DUAL_FIELD, embedding);
+
+			Store store = new Store(String.valueOf(i), INDEX_NAME);
+			store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(mongoDocument));
+			zuliaWorkPool.store(store);
+		}
+	}
+
+	@Test
+	@Order(4)
+	public void everyEncodingIsSearchable() throws Exception {
+		// without oversampling 1-bit/2-bit BBQ can shift the rank-1 hit, so lossy encodings only need to return hits.
+		// Recall recovery is proven by oversampleRescoreMatchesExact()
+		for (Map.Entry<String, VectorIndexingConfig.Encoding> entry : ENCODING_FIELDS.entrySet()) {
+			if (isLossyBinary(entry.getValue())) {
+				Assertions.assertEquals(3, topIds(entry.getKey(), lungCancerQuery(), 3, 0f).size(), "field " + entry.getKey() + " should return hits");
+			}
+			else {
+				assertTopHitIsLungCancer(entry.getKey());
+			}
+		}
+		assertTopHitIsLungCancer(FLAT_FIELD);
+		assertTopHitIsLungCancer(EUCLID_FIELD);
+		assertTopHitIsLungCancer(MIP_FIELD);
+		assertTopHitIsLungCancer(RAW_FIELD);
+		assertTopHitIsLungCancer(DIMS_FIELD);
+	}
+
+	private static boolean isLossyBinary(VectorIndexingConfig.Encoding encoding) {
+		return encoding == VectorIndexingConfig.Encoding.BBQ || encoding == VectorIndexingConfig.Encoding.BBQ_2BIT;
+	}
+
+	private float[] lungCancerQuery() throws Exception {
+		return embeddingModel.embedQuery("lung cancer immunotherapy treatment");
+	}
+
+	@Test
+	@Order(5)
+	public void oversampleRescoreMatchesExact() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// with 8 docs and 4x oversample the rescore reranks the whole corpus with exact vectors, so every quantized
+		// field must match the FLOAT32 ordering
+		String[] queries = { "lung cancer immunotherapy treatment", "gene editing therapy", "diabetes outcomes" };
+		for (String queryText : queries) {
+			float[] queryVec = embeddingModel.embedQuery(queryText);
+			List<String> exactOrder = topIds("vFloat", queryVec, 5, 0f);
+			for (VectorIndexingConfig.Encoding encoding : ENCODING_FIELDS.values()) {
+				if (encoding == VectorIndexingConfig.Encoding.FLOAT32) {
+					continue;
+				}
+				String field = fieldFor(encoding);
+				List<String> rescored = topIds(field, queryVec, 5, 4.0f);
+				Assertions.assertEquals(exactOrder, rescored,
+						"Oversample rescore on " + field + " should match exact float32 ordering for query: " + queryText);
+			}
+		}
+	}
+
+	@Test
+	@Order(6)
+	public void bbqDefaultsToRescore() throws Exception {
+		// with no oversample set, BBQ rescores by its encoding default, so its top hit matches the exact ordering
+		float[] queryVec = lungCancerQuery();
+		String exactTop = topIds("vFloat", queryVec, 3, 0f).getFirst();
+		for (VectorIndexingConfig.Encoding encoding : List.of(VectorIndexingConfig.Encoding.BBQ, VectorIndexingConfig.Encoding.BBQ_2BIT)) {
+			String defaultedTop = topIds(fieldFor(encoding), queryVec, 3, 0f).getFirst();
+			Assertions.assertEquals(exactTop, defaultedTop,
+					encoding + " with no explicit oversample should rescore by default and recover the exact top hit");
+		}
+	}
+
+	@Test
+	@Order(7)
+	public void dualRepresentationsSearchable() throws Exception {
+		// each representation searches through its own graph: the FLOAT32 twin exactly, the BBQ twin via rescore
+		float[] queryVec = lungCancerQuery();
+		List<String> exactOrder = topIds("vFloat", queryVec, 5, 0f);
+		Assertions.assertEquals(exactOrder, topIds(DUAL_EXACT, queryVec, 5, 0f), "FLOAT32 representation should match the exact float32 ordering");
+		Assertions.assertEquals(exactOrder, topIds(DUAL_BBQ, queryVec, 5, 4.0f), "BBQ representation with oversample should match the exact ordering");
+		Assertions.assertEquals(exactOrder.getFirst(), topIds(DUAL_BBQ, queryVec, 3, 0f).getFirst(),
+				"BBQ representation should recover the exact top hit through its default rescore");
+	}
+
+	@Test
+	@Order(8)
+	public void vectorDescriptionReadBack() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		GetIndexConfigResult indexConfigResult = zuliaWorkPool.getIndexConfig(INDEX_NAME);
+		ClientIndexConfig readBack = indexConfigResult.getIndexConfig();
+
+		FieldConfig dualFieldConfig = readBack.getFieldConfig(DUAL_FIELD);
+		Assertions.assertTrue(dualFieldConfig.hasVectorDescription(), "Field " + DUAL_FIELD + " should read back a VectorDescription");
+		VectorDescription dualDescription = dualFieldConfig.getVectorDescription();
+		Assertions.assertEquals(embeddingModel.getDimensions(), dualDescription.getDimensions());
+		Assertions.assertEquals(DUAL_MODEL_NAME, dualDescription.getModelName());
+		Assertions.assertEquals("test embedding model", dualDescription.getModelDescription());
+		Assertions.assertEquals(VectorDescription.Similarity.DEFAULT, dualDescription.getSimilarity(), "no explicit similarity was set");
+
+		Map<String, VectorIndexingConfig.Encoding> encodingByRepresentation = dualFieldConfig.getIndexAsList().stream()
+				.collect(Collectors.toMap(IndexAs::getIndexFieldName, ia -> ia.getVectorIndexingConfig().getEncoding()));
+		Assertions.assertEquals(Map.of(DUAL_EXACT, VectorIndexingConfig.Encoding.FLOAT32, DUAL_BBQ, VectorIndexingConfig.Encoding.BBQ),
+				encodingByRepresentation, "each representation should read back its own encoding");
+
+		VectorIndexingConfig bbqIndexingConfig = dualFieldConfig.getIndexAsList().stream().filter(ia -> DUAL_BBQ.equals(ia.getIndexFieldName())).findFirst()
+				.orElseThrow().getVectorIndexingConfig();
+		Assertions.assertEquals(24, bbqIndexingConfig.getHnswM(), "hnsw m from VectorIndexingConfigBuilder should round-trip");
+		Assertions.assertEquals(200, bbqIndexingConfig.getHnswEfConstruction(), "hnsw efConstruction from VectorIndexingConfigBuilder should round-trip");
+
+		VectorDescription euclidDescription = readBack.getFieldConfig(EUCLID_FIELD).getVectorDescription();
+		Assertions.assertEquals(VectorDescription.Similarity.EUCLIDEAN, euclidDescription.getSimilarity(), "explicit similarity should round-trip");
+	}
+
+	@Test
+	@Order(9)
+	public void invalidOversampleIsRejected() throws Exception {
+		// a NaN or negative oversample is a client error and must be rejected, not silently treated as off
+		float[] queryVec = lungCancerQuery();
+		for (float bad : new float[] { -1.0f, Float.NaN }) {
+			Search search = new Search(INDEX_NAME).setRealtime(true);
+			VectorTopNQuery vectorQuery = new VectorTopNQuery(queryVec, 3, "vBBQ");
+			vectorQuery.oversample(bad);
+			search.addQuery(vectorQuery);
+			search.setAmount(3);
+			Assertions.assertThrows(Exception.class, () -> nodeExtension.getClient().search(search), "Oversample " + bad + " should be rejected");
+		}
+	}
+
+	@Test
+	@Order(10)
+	public void dimensionMismatchIsRejected() {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		Document badDocument = new Document();
+		badDocument.put("title", "bad vector");
+		badDocument.put(DIMS_FIELD, Floats.asList(0.1f, 0.2f, 0.3f)); // wrong length for a declared-dimension field
+
+		Store store = new Store("bad", INDEX_NAME);
+		store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(badDocument));
+
+		Assertions.assertThrows(Exception.class, () -> zuliaWorkPool.store(store),
+				"Storing a vector whose length disagrees with the declared dimensions should fail");
+	}
+
+	@Test
+	@Order(11)
+	public void restart() throws Exception {
+		nodeExtension.restartNodes();
+	}
+
+	@Test
+	@Order(12)
+	public void confirmAfterRestart() throws Exception {
+		// reopening the index from disk resolves the "Zulia104" codec by its persisted name via SPI
+		everyEncodingIsSearchable();
+		oversampleRescoreMatchesExact();
+		dualRepresentationsSearchable();
+	}
+
+	@Test
+	@Order(13)
+	public void closeModel() {
+		if (embeddingModel != null) {
+			embeddingModel.close();
+		}
+	}
+
+	private static String fieldFor(VectorIndexingConfig.Encoding encoding) {
+		return ENCODING_FIELDS.entrySet().stream().filter(e -> e.getValue() == encoding).map(Map.Entry::getKey).findFirst().orElseThrow();
+	}
+
+	private void assertTopHitIsLungCancer(String field) throws Exception {
+		List<String> ids = topIds(field, lungCancerQuery(), 3, 0f);
+		Assertions.assertEquals(3, ids.size(), "Expected 3 hits on field " + field);
+		String topTitle = TITLES[Integer.parseInt(ids.getFirst())];
+		Assertions.assertTrue(topTitle.contains("lung cancer"), "Top hit on field " + field + " should be the lung cancer paper, got: " + topTitle);
+	}
+
+	private List<String> topIds(String field, float[] queryVec, int topN, float oversample) throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		Search search = new Search(INDEX_NAME).setRealtime(true);
+		VectorTopNQuery vectorQuery = new VectorTopNQuery(queryVec, topN, field);
+		if (oversample > 0f) {
+			vectorQuery.oversample(oversample);
+		}
+		search.addQuery(vectorQuery);
+		search.setAmount(topN);
+		SearchResult searchResult = zuliaWorkPool.search(search);
+		return searchResult.getUniqueIds();
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/ZuliaCodecTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/ZuliaCodecTest.java
@@ -1,0 +1,186 @@
+package io.zulia.server.test.node;
+
+import io.zulia.message.ZuliaIndex.FieldConfig;
+import io.zulia.message.ZuliaIndex.IndexAs;
+import io.zulia.message.ZuliaIndex.IndexSettings;
+import io.zulia.message.ZuliaIndex.VectorIndexingConfig;
+import io.zulia.server.config.ServerIndexConfig;
+import io.zulia.server.index.ZuliaIndexVersion;
+import io.zulia.server.index.ZuliaLucene104Codec;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.codecs.lucene104.Lucene104Codec;
+import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene104.Lucene104ScalarQuantizedVectorsFormat;
+import org.apache.lucene.codecs.lucene99.Lucene99HnswVectorsFormat;
+import org.apache.lucene.codecs.perfield.PerFieldKnnVectorsFormat;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.FieldInfo;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.VectorSimilarityFunction;
+import org.apache.lucene.store.ByteBuffersDirectory;
+import org.apache.lucene.store.Directory;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+/**
+ * Proves quantization is applied at the codec level rather than silently falling back to float32, using the per-field KNN format
+ * name in FieldInfos, and the on-disk size which grows with quantization bit width (the raw vectors are retained for rescoring).
+ */
+public class ZuliaCodecTest {
+
+	private static final String FIELD = "v";
+	private static final int DIMS = 256;
+	private static final int DOCS = 500;
+
+	private static final String HNSW_FLOAT_NAME = new Lucene99HnswVectorsFormat().getName();
+	private static final String HNSW_QUANTIZED_NAME = new Lucene104HnswScalarQuantizedVectorsFormat().getName();
+	private static final String FLAT_QUANTIZED_NAME = new Lucene104ScalarQuantizedVectorsFormat().getName();
+
+	@Test
+	public void formatNamePerEncoding() throws Exception {
+		// a config-less field and an explicit FLOAT32 field both stay raw float32 HNSW
+		Assertions.assertEquals(HNSW_FLOAT_NAME, generateIndexAndGetFormatName(buildConfig(null, false, 0), FIELD), "config-less vector field must stay float32");
+		Assertions.assertEquals(HNSW_FLOAT_NAME, generateIndexAndGetFormatName(buildConfig(VectorIndexingConfig.Encoding.FLOAT32, false, 0), FIELD));
+
+		for (VectorIndexingConfig.Encoding encoding : new VectorIndexingConfig.Encoding[] { VectorIndexingConfig.Encoding.INT8, VectorIndexingConfig.Encoding.INT7,
+				VectorIndexingConfig.Encoding.INT4, VectorIndexingConfig.Encoding.BBQ, VectorIndexingConfig.Encoding.BBQ_2BIT }) {
+			String name = generateIndexAndGetFormatName(buildConfig(encoding, false, 0), FIELD);
+			Assertions.assertEquals(HNSW_QUANTIZED_NAME, name, encoding + " must use the quantized HNSW format, not " + name);
+		}
+
+		Assertions.assertEquals(FLAT_QUANTIZED_NAME, generateIndexAndGetFormatName(buildConfig(VectorIndexingConfig.Encoding.INT8, true, 0), FIELD));
+	}
+
+	@Test
+	public void quantizedPayloadIsBitWidthProportional() throws Exception {
+		long float32 = generateIndexAndGetSize(buildConfig(VectorIndexingConfig.Encoding.FLOAT32, false, 0));
+		long bbq = generateIndexAndGetSize(buildConfig(VectorIndexingConfig.Encoding.BBQ, false, 0));
+		long int4 = generateIndexAndGetSize(buildConfig(VectorIndexingConfig.Encoding.INT4, false, 0));
+		long int8 = generateIndexAndGetSize(buildConfig(VectorIndexingConfig.Encoding.INT8, false, 0));
+
+		// the quantized formats retain the raw float vectors for rescoring and add the quantized data on top, so
+		// size grows with bit width, direct evidence each field wrote its configured encoding
+		Assertions.assertTrue(bbq > float32, "BBQ (" + bbq + ") should add quantized data over FLOAT32 (" + float32 + ")");
+		Assertions.assertTrue(int4 > bbq, "INT4 (" + int4 + ") should be larger than BBQ (" + bbq + ")");
+		Assertions.assertTrue(int8 > int4, "INT8 (" + int8 + ") should be larger than INT4 (" + int4 + ")");
+	}
+
+	@Test
+	public void versionedCodecBindingIsPinned() {
+		// the persisted name and Lucene delegate are the on-disk contract for existing segments. These fail loudly
+		// if the Zulia104 to Lucene104 binding ever changes, keeping upgrades a deliberate add-a-new-codec decision
+		ZuliaLucene104Codec codec = new ZuliaLucene104Codec();
+		Assertions.assertEquals("Zulia104", codec.getName(), "Renaming the codec would make existing Zulia104 indexes unreadable");
+		Lucene104Codec delegate = new Lucene104Codec();
+		Assertions.assertEquals(delegate.segmentInfoFormat().getClass(), codec.segmentInfoFormat().getClass(),
+				"Zulia104 must keep delegating to Lucene104 formats; add a new ZuliaLuceneNNNCodec for a newer Lucene default");
+		Assertions.assertEquals(delegate.storedFieldsFormat().getClass(), codec.storedFieldsFormat().getClass(),
+				"Zulia104 must keep delegating to Lucene104 formats; add a new ZuliaLuceneNNNCodec for a newer Lucene default");
+	}
+
+	@Test
+	public void configlessFieldFollowsIndexVersion() throws Exception {
+		// a config-less field inherits the index-creation-version default: float32 below VECTOR_DEFAULT_INT8, INT8 at/after
+		Assertions.assertEquals(HNSW_FLOAT_NAME, generateIndexAndGetFormatName(buildConfig(null, false, ZuliaIndexVersion.VECTOR_DEFAULT_INT8 - 1), FIELD),
+				"config-less field on a pre-vector-default index must stay float32");
+		Assertions.assertEquals(HNSW_QUANTIZED_NAME, generateIndexAndGetFormatName(buildConfig(null, false, ZuliaIndexVersion.VECTOR_DEFAULT_INT8), FIELD),
+				"config-less field on a current index must default to INT8 (quantized HNSW format)");
+	}
+
+	@Test
+	public void perRepresentationFormats() throws Exception {
+		// one stored field indexed under two names, each IndexAs carrying its own encoding
+		FieldConfig fieldConfig = FieldConfig.newBuilder().setStoredFieldName(FIELD).setFieldType(FieldConfig.FieldType.VECTOR)
+				.addIndexAs(IndexAs.newBuilder().setIndexFieldName("vExact")
+						.setVectorIndexingConfig(VectorIndexingConfig.newBuilder().setEncoding(VectorIndexingConfig.Encoding.FLOAT32)))
+				.addIndexAs(IndexAs.newBuilder().setIndexFieldName("vBBQ")
+						.setVectorIndexingConfig(VectorIndexingConfig.newBuilder().setEncoding(VectorIndexingConfig.Encoding.BBQ))).build();
+		IndexSettings indexSettings = IndexSettings.newBuilder().setIndexName("codecTest").setCreatedIndexVersion(ZuliaIndexVersion.CURRENT)
+				.addFieldConfig(fieldConfig).build();
+		ServerIndexConfig config = new ServerIndexConfig(indexSettings);
+
+		try (Directory directory = new ByteBuffersDirectory()) {
+			writeVectors(directory, config, "vExact", "vBBQ");
+			try (DirectoryReader reader = DirectoryReader.open(directory)) {
+				LeafReaderContext leaf = reader.leaves().getFirst();
+				Assertions.assertEquals(HNSW_FLOAT_NAME, leaf.reader().getFieldInfos().fieldInfo("vExact").getAttribute(PerFieldKnnVectorsFormat.PER_FIELD_FORMAT_KEY),
+						"the FLOAT32 representation must persist the raw float32 format");
+				Assertions.assertEquals(HNSW_QUANTIZED_NAME, leaf.reader().getFieldInfos().fieldInfo("vBBQ").getAttribute(PerFieldKnnVectorsFormat.PER_FIELD_FORMAT_KEY),
+						"the BBQ representation must persist the quantized format");
+			}
+		}
+	}
+
+
+	private static ServerIndexConfig buildConfig(VectorIndexingConfig.Encoding encoding, boolean flat, int createdIndexVersion) {
+		IndexAs.Builder indexAs = IndexAs.newBuilder().setIndexFieldName(FIELD);
+		if (encoding != null) {
+			VectorIndexingConfig.Builder vectorIndexingConfig = VectorIndexingConfig.newBuilder().setEncoding(encoding);
+			if (flat) {
+				vectorIndexingConfig.setIndexType(VectorIndexingConfig.IndexType.FLAT);
+			}
+			indexAs.setVectorIndexingConfig(vectorIndexingConfig);
+		}
+		FieldConfig fieldConfig = FieldConfig.newBuilder().setStoredFieldName(FIELD).setFieldType(FieldConfig.FieldType.VECTOR).addIndexAs(indexAs).build();
+		IndexSettings indexSettings = IndexSettings.newBuilder().setIndexName("codecTest").setCreatedIndexVersion(createdIndexVersion).addFieldConfig(fieldConfig).build();
+		return new ServerIndexConfig(indexSettings);
+	}
+
+	private static String generateIndexAndGetFormatName(ServerIndexConfig config, String field) throws Exception {
+		try (Directory directory = new ByteBuffersDirectory()) {
+			writeVectors(directory, config);
+			try (DirectoryReader reader = DirectoryReader.open(directory)) {
+				LeafReaderContext leaf = reader.leaves().getFirst();
+				FieldInfo fieldInfo = leaf.reader().getFieldInfos().fieldInfo(field);
+				return fieldInfo.getAttribute(PerFieldKnnVectorsFormat.PER_FIELD_FORMAT_KEY);
+			}
+		}
+	}
+
+	private static long generateIndexAndGetSize(ServerIndexConfig config) throws Exception {
+		try (Directory directory = new ByteBuffersDirectory()) {
+			writeVectors(directory, config);
+			long total = 0;
+			for (String file : directory.listAll()) {
+				total += directory.fileLength(file);
+			}
+			return total;
+		}
+	}
+
+	private static void writeVectors(Directory directory, ServerIndexConfig config, String... fields) throws Exception {
+		if (fields.length == 0) {
+			fields = new String[] { FIELD };
+		}
+		IndexWriterConfig writerConfig = new IndexWriterConfig(new StandardAnalyzer());
+		writerConfig.setCodec(new ZuliaLucene104Codec(config));
+		try (IndexWriter writer = new IndexWriter(directory, writerConfig)) {
+			Random random = new Random(42); // deterministic so comparable across runs
+			for (int i = 0; i < DOCS; i++) {
+				float[] vector = generateNonZeroVector(random);
+				Document document = new Document();
+				for (String field : fields) {
+					document.add(new KnnFloatVectorField(field, vector, VectorSimilarityFunction.COSINE));
+				}
+				writer.addDocument(document);
+			}
+			writer.forceMerge(1); // single segment means one leaf, stable format attributes
+		}
+	}
+
+	private static float @NonNull [] generateNonZeroVector(Random random) {
+		float[] vector = new float[DIMS];
+		for (int d = 0; d < DIMS; d++) {
+			vector[d] = random.nextFloat() * 2f - 1f;
+		}
+		vector[0] += 1f; // guarantee a non-zero vector for COSINE
+		return vector;
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/ZuliaCodecTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/ZuliaCodecTest.java
@@ -7,6 +7,7 @@ import io.zulia.message.ZuliaIndex.VectorIndexingConfig;
 import io.zulia.server.config.ServerIndexConfig;
 import io.zulia.server.index.ZuliaIndexVersion;
 import io.zulia.server.index.ZuliaLucene104Codec;
+import io.zulia.server.index.ZuliaLucene104WriteCodec;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.codecs.lucene104.Lucene104Codec;
 import org.apache.lucene.codecs.lucene104.Lucene104HnswScalarQuantizedVectorsFormat;
@@ -86,6 +87,15 @@ public class ZuliaCodecTest {
 	}
 
 	@Test
+	public void spiCodecIsReadOnly() {
+		// the SPI instance has no index config, so writing through it must fail fast rather than pick default formats
+		ZuliaLucene104Codec codec = new ZuliaLucene104Codec();
+		PerFieldKnnVectorsFormat perFieldFormat = (PerFieldKnnVectorsFormat) codec.knnVectorsFormat();
+		IllegalStateException exception = Assertions.assertThrows(IllegalStateException.class, () -> perFieldFormat.getKnnVectorsFormatForField(FIELD));
+		Assertions.assertTrue(exception.getMessage().contains("read-only"), "unexpected message: " + exception.getMessage());
+	}
+
+	@Test
 	public void configlessFieldFollowsIndexVersion() throws Exception {
 		// a config-less field inherits the index-creation-version default: float32 below VECTOR_DEFAULT_INT8, INT8 at/after
 		Assertions.assertEquals(HNSW_FLOAT_NAME, generateIndexAndGetFormatName(buildConfig(null, false, ZuliaIndexVersion.VECTOR_DEFAULT_INT8 - 1), FIELD),
@@ -160,7 +170,7 @@ public class ZuliaCodecTest {
 			fields = new String[] { FIELD };
 		}
 		IndexWriterConfig writerConfig = new IndexWriterConfig(new StandardAnalyzer());
-		writerConfig.setCodec(new ZuliaLucene104Codec(config));
+		writerConfig.setCodec(new ZuliaLucene104WriteCodec(config));
 		try (IndexWriter writer = new IndexWriter(directory, writerConfig)) {
 			Random random = new Random(42); // deterministic so comparable across runs
 			for (int i = 0; i < DOCS; i++) {

--- a/zulia-util/src/main/java/io/zulia/util/VectorUtil.java
+++ b/zulia-util/src/main/java/io/zulia/util/VectorUtil.java
@@ -12,7 +12,12 @@ public class VectorUtil {
 			normA += a[i] * a[i];
 			normB += b[i] * b[i];
 		}
-		return (float) (dot / (Math.sqrt(normA) * Math.sqrt(normB)));
+		double denom = Math.sqrt(normA) * Math.sqrt(normB);
+		// A zero-magnitude vector has no direction, so cosine is undefined, but returning 0 is numerically safer
+		if (denom == 0.0) {
+			return 0f;
+		}
+		return (float) (dot / denom);
 	}
 
 }


### PR DESCRIPTION

Vector fields can now be stored quantized through a per-field Lucene codec, cutting graph-search RAM roughly 4x
at INT8 and more at BBQ. 

Bumped Lucene 10.4.0 to 10.5.0.

- Proto: new `VectorDescription` on `FieldConfig` for the data itself (similarity, dimensions, model provenance)
  and `VectorIndexingConfig` on `IndexAs` for how each representation is encoded (FLOAT32/INT8/INT7/INT4/BBQ/
  BBQ_2BIT, HNSW or flat, hnswM/efConstruction). One stored field indexed under multiple names can carry a
  different encoding per name, i.e., a BBQ representation next to a FLOAT32 twin. `Query.vectorOversample` added.
- Codec: `ZuliaCodec` + `ZuliaLucene104Codec` ("Zulia104", SPI registered) select the KNN format per field via
  `ZuliaPerFieldKnnVectorsFormat` and `VectorFieldResolver`. The name-to-delegate binding is permanent. A future
  Lucene upgrade adds a new codec class instead of re-pointing this one.
- Version-gated default: indexes created at or after `ZuliaIndexVersion.VECTOR_DEFAULT_INT8` default config-less
  vector fields to INT8. Existing and legacy indexes stay raw float32. An explicit encoding always wins.
- Query: quantized fields fetch `ceil(topN * oversample)` candidates and rerank with full-precision vectors via
  `RescoreTopNQuery`, per shard, so the cross-shard merge compares exact scores. Encoding defaults apply when
  unset (BBQ 3x, BBQ_2BIT 2x, INT4 1.5x, others none). NaN/negative rejected, capped at 32x.
- Client: `FieldConfigBuilder` gains `quantization`, `hnsw`, `flat`, `similarity`, `dimensions`, `model`, and
  `indexAs(name, encoding)` for multi-representation fields. New `VectorIndexingConfigBuilder` for custom
  per-representation configs. `VectorTopNQuery.oversample(float)` added.
- Rolling upgrade note: deploy this build to every node before creating or writing vector indexes, since
  replication and restarts open segments by their persisted codec name.
- Tests: `ZuliaCodecTest` tests the persisted per-field formats, bit-width-proportional storage, the pinned
  codec binding, and the version gate. `QuantizedVectorTest` round-trips every encoding through a node restart
  and verifies oversample rescore matches exact float32 ordering, dual-representation search, dimension
  validation, and `VectorDescription` read-back through `getIndexConfig`.