### PR TITLE
# Fix zulia-ui-rest authentication and authorization security issues

### DIFF
--- a/zulia-ui-rest/src/main/java/io/zulia/ui/rest/beans/UserEntity.java
+++ b/zulia-ui-rest/src/main/java/io/zulia/ui/rest/beans/UserEntity.java
@@ -1,6 +1,7 @@
 package io.zulia.ui.rest.beans;
 
 import io.micronaut.core.annotation.NonNull;
+import io.micronaut.core.annotation.Nullable;
 import io.micronaut.data.annotation.DateCreated;
 import io.micronaut.data.annotation.Id;
 import io.micronaut.data.annotation.MappedEntity;
@@ -8,6 +9,7 @@ import io.micronaut.serde.annotation.Serdeable;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.Instant;
+import java.util.List;
 
 @Serdeable
 @MappedEntity(value = "users")
@@ -29,6 +31,9 @@ public class UserEntity {
 	@NonNull
 	@NotNull
 	private Instant dateCreated;
+
+	@Nullable
+	private List<String> roles;
 
 	public UserEntity() {
 	}
@@ -63,5 +68,14 @@ public class UserEntity {
 
 	public void setDateCreated(Instant dateCreated) {
 		this.dateCreated = dateCreated;
+	}
+
+	@Nullable
+	public List<String> getRoles() {
+		return roles;
+	}
+
+	public void setRoles(@Nullable List<String> roles) {
+		this.roles = roles;
 	}
 }

--- a/zulia-ui-rest/src/main/java/io/zulia/ui/rest/controllers/UserController.java
+++ b/zulia-ui-rest/src/main/java/io/zulia/ui/rest/controllers/UserController.java
@@ -7,11 +7,12 @@ import io.micronaut.http.annotation.Controller;
 import io.micronaut.http.annotation.Post;
 import io.micronaut.http.annotation.Produces;
 import io.micronaut.security.annotation.Secured;
-import io.micronaut.security.rules.SecurityRule;
 import io.zulia.ui.rest.beans.UserEntity;
 import io.zulia.ui.rest.persistence.MongoUserPersistence;
 
-@Secured(SecurityRule.IS_ANONYMOUS)
+// User provisioning requires an authenticated ADMIN. The first user must be bootstrapped
+// offline via UserCreator; an anonymous create endpoint would let anyone self-provision admin.
+@Secured("ADMIN")
 @Controller
 @Requires(beans = MongoUserPersistence.class)
 public class UserController {

--- a/zulia-ui-rest/src/main/java/io/zulia/ui/rest/persistence/MongoRefreshTokenPersistence.java
+++ b/zulia-ui-rest/src/main/java/io/zulia/ui/rest/persistence/MongoRefreshTokenPersistence.java
@@ -10,7 +10,6 @@ import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
 
-import java.util.List;
 import java.util.Optional;
 
 import static io.micronaut.security.errors.IssuingAnAccessTokenErrorCode.INVALID_GRANT;
@@ -19,9 +18,11 @@ import static io.micronaut.security.errors.IssuingAnAccessTokenErrorCode.INVALID
 public class MongoRefreshTokenPersistence implements RefreshTokenPersistence {
 
 	private final RefreshTokenRepository refreshTokenRepository;
+	private final MongoUserPersistence userPersistence;
 
-	public MongoRefreshTokenPersistence(RefreshTokenRepository refreshTokenRepository) {
+	public MongoRefreshTokenPersistence(RefreshTokenRepository refreshTokenRepository, MongoUserPersistence userPersistence) {
 		this.refreshTokenRepository = refreshTokenRepository;
+		this.userPersistence = userPersistence;
 	}
 
 	@Override
@@ -42,7 +43,8 @@ public class MongoRefreshTokenPersistence implements RefreshTokenPersistence {
 					emitter.error(new OauthErrorResponseException(INVALID_GRANT, "refresh token revoked", null));
 				}
 				else {
-					emitter.next(Authentication.build(token.getUsername(), List.of("ADMIN")));
+					// Rebuild with the user's current stored roles, not a hardcoded ADMIN grant.
+					emitter.next(Authentication.build(token.getUsername(), userPersistence.getRoles(token.getUsername())));
 					emitter.complete();
 				}
 			}

--- a/zulia-ui-rest/src/main/java/io/zulia/ui/rest/persistence/MongoUserPersistence.java
+++ b/zulia-ui-rest/src/main/java/io/zulia/ui/rest/persistence/MongoUserPersistence.java
@@ -3,16 +3,19 @@ package io.zulia.ui.rest.persistence;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.ReplaceOptions;
 import com.password4j.BcryptFunction;
 import com.password4j.Password;
 import com.password4j.types.Bcrypt;
 import io.zulia.ui.rest.beans.UserEntity;
 import jakarta.inject.Singleton;
 
+import java.util.List;
+
 @Singleton
 public class MongoUserPersistence implements UserService {
 
+	// New users default to the least-privilege role. Admins are granted explicitly (see UserCreator).
+	private static final List<String> DEFAULT_ROLES = List.of("USER");
 	private static final BcryptFunction BCRYPT_FUNCTION = BcryptFunction.getInstance(Bcrypt.B, 12);
 	private final MongoUserConfiguration mongoConf;
 	private final MongoClient mongoClient;
@@ -34,12 +37,31 @@ public class MongoUserPersistence implements UserService {
 	}
 
 	@Override
+	public List<String> getRoles(String username) {
+		return effectiveRoles(getUser(username));
+	}
+
+	@Override
 	public void createUser(UserEntity user) {
 		String rawPassword = user.getPassword();
 		String hashedPassword = Password.hash(rawPassword).withBcrypt().getResult();
 		user.setHashedPassword(hashedPassword);
 		user.setPassword(null);
-		getCollection().replaceOne(Filters.eq(user.getUsername()), user, new ReplaceOptions().upsert(true));
+		if (user.getRoles() == null || user.getRoles().isEmpty()) {
+			user.setRoles(DEFAULT_ROLES);
+		}
+		// insertOne relies on the unique _id (username) constraint, so an existing user is never
+		// silently overwritten. A duplicate username fails fast with a write error instead of
+		// clobbering the existing account's credentials.
+		getCollection().insertOne(user);
+	}
+
+	// Fail closed to least privilege for unknown users or legacy records that predate the roles field.
+	private static List<String> effectiveRoles(UserEntity user) {
+		if (user == null || user.getRoles() == null || user.getRoles().isEmpty()) {
+			return DEFAULT_ROLES;
+		}
+		return user.getRoles();
 	}
 
 	private MongoCollection<UserEntity> getCollection() {

--- a/zulia-ui-rest/src/main/java/io/zulia/ui/rest/persistence/UserService.java
+++ b/zulia-ui-rest/src/main/java/io/zulia/ui/rest/persistence/UserService.java
@@ -2,11 +2,15 @@ package io.zulia.ui.rest.persistence;
 
 import io.zulia.ui.rest.beans.UserEntity;
 
+import java.util.List;
+
 public interface UserService {
 
 	UserEntity getUser(String username);
 
 	boolean verifyUser(String username, String password);
+
+	List<String> getRoles(String username);
 
 	void createUser(UserEntity user);
 

--- a/zulia-ui-rest/src/main/java/io/zulia/ui/rest/providers/AuthenticationProviderUserPass.java
+++ b/zulia-ui-rest/src/main/java/io/zulia/ui/rest/providers/AuthenticationProviderUserPass.java
@@ -11,8 +11,6 @@ import io.zulia.ui.rest.persistence.MongoUserPersistence;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 
-import java.util.List;
-
 @Singleton
 public class AuthenticationProviderUserPass<B> implements HttpRequestAuthenticationProvider<B> {
 
@@ -22,9 +20,10 @@ public class AuthenticationProviderUserPass<B> implements HttpRequestAuthenticat
 	@Override
 	public @NonNull AuthenticationResponse authenticate(@Nullable HttpRequest<B> requestContext, @NonNull AuthenticationRequest<String, String> authRequest) {
 
-		boolean userVerified = mongoUserPersistence.verifyUser(authRequest.getIdentity(), authRequest.getSecret());
+		String username = authRequest.getIdentity();
+		boolean userVerified = mongoUserPersistence.verifyUser(username, authRequest.getSecret());
 		return userVerified ?
-				AuthenticationResponse.success(authRequest.getIdentity(), List.of("ADMIN")) :
+				AuthenticationResponse.success(username, mongoUserPersistence.getRoles(username)) :
 				AuthenticationResponse.failure(AuthenticationFailureReason.CREDENTIALS_DO_NOT_MATCH);
 	}
 }

--- a/zulia-ui-rest/src/main/java/io/zulia/ui/rest/util/UserCreator.java
+++ b/zulia-ui-rest/src/main/java/io/zulia/ui/rest/util/UserCreator.java
@@ -1,27 +1,39 @@
 package io.zulia.ui.rest.util;
 
 import io.micronaut.context.ApplicationContext;
-import io.micronaut.http.HttpRequest;
-import io.micronaut.http.HttpResponse;
-import io.micronaut.http.client.HttpClient;
-import io.micronaut.runtime.server.EmbeddedServer;
-import io.micronaut.security.token.render.BearerAccessRefreshToken;
 import io.zulia.ui.rest.beans.UserEntity;
+import io.zulia.ui.rest.persistence.MongoUserPersistence;
 
-import java.util.Collections;
+import java.util.Arrays;
+import java.util.List;
 
+/**
+ * Offline bootstrap for the first user. The /create-user HTTP endpoint now requires the ADMIN
+ * role, so the initial account is provisioned directly through the persistence layer instead of
+ * an anonymous HTTP call. Pass the username and password as arguments rather than hardcoding them.
+ * The bootstrap account defaults to the ADMIN role so it can administer the service; pass explicit
+ * roles to override.
+ */
 public class UserCreator {
 
-	private static final EmbeddedServer embeddedServer = ApplicationContext.run(EmbeddedServer.class, Collections.emptyMap());
-	private static final HttpClient client = embeddedServer.getApplicationContext().createBean(HttpClient.class, embeddedServer.getURL());
+	static void main(String[] args) {
+		if (args.length < 2) {
+			System.err.println("Usage: UserCreator <username> <password> [role...]  (default role: ADMIN)");
+			System.exit(1);
+			return;
+		}
 
-	public static void main(String[] args) {
-		UserEntity user = new UserEntity();
-		user.setUsername("zulia");
-		user.setPassword("password");
-		HttpRequest<?> request = HttpRequest.POST("/zuliauirest/create-user", user); // <4>
-		HttpResponse<BearerAccessRefreshToken> rsp = client.toBlocking().exchange(request, BearerAccessRefreshToken.class); // <5>
-		embeddedServer.stop();
+		List<String> roles = args.length > 2 ? List.of(Arrays.copyOfRange(args, 2, args.length)) : List.of("ADMIN");
+
+		try (ApplicationContext context = ApplicationContext.run()) {
+			MongoUserPersistence userPersistence = context.getBean(MongoUserPersistence.class);
+			UserEntity user = new UserEntity();
+			user.setUsername(args[0]);
+			user.setPassword(args[1]);
+			user.setRoles(roles);
+			userPersistence.createUser(user);
+			System.out.println("Created user '" + args[0] + "' with roles " + roles);
+		}
 	}
 
 }

--- a/zulia-ui-rest/src/main/resources/application-test.yml
+++ b/zulia-ui-rest/src/main/resources/application-test.yml
@@ -20,10 +20,11 @@ micronaut:
         signatures:
           secret:
             generator:
-              secret: '"${JWT_GENERATOR_SIGNATURE_SECRET:ZuliaUISecretGeneratorPassword}"'
+              # Test-only default so the suite runs offline. Production (application.yml) has no default.
+              secret: '"${JWT_GENERATOR_SIGNATURE_SECRET:test-only-secret-do-not-use-in-production}"'
         generator:
           refresh-token:
-            secret: '"${JWT_GENERATOR_SIGNATURE_SECRET:ZuliaUISecretGeneratorPassword}"'
+            secret: '"${JWT_GENERATOR_SIGNATURE_SECRET:test-only-secret-do-not-use-in-production}"'
             enabled: true
       generator:
         access-token:

--- a/zulia-ui-rest/src/main/resources/application.yml
+++ b/zulia-ui-rest/src/main/resources/application.yml
@@ -20,10 +20,12 @@ micronaut:
         signatures:
           secret:
             generator:
-              secret: '"${JWT_GENERATOR_SIGNATURE_SECRET:ZuliaUISecretGeneratorPassword}"'
+              # No default: the app must fail fast if JWT_GENERATOR_SIGNATURE_SECRET is unset.
+              # A committed fallback secret would let anyone forge admin tokens.
+              secret: '"${JWT_GENERATOR_SIGNATURE_SECRET}"'
         generator:
           refresh-token:
-            secret: '"${JWT_GENERATOR_SIGNATURE_SECRET:ZuliaUISecretGeneratorPassword}"'
+            secret: '"${JWT_GENERATOR_SIGNATURE_SECRET}"'
             enabled: true
       generator:
         access-token:


### PR DESCRIPTION
Zulia UI Rest is a work in progress, so this does not affect production usage

*  Anonymous user creation allowed admin self-provisioning

* Hardcoded default JWT signing secret enabled token forgery

* Every authenticated user was granted ADMIN unconditionally

## Notes
- Initial provisioning workflow changed. Set `JWT_GENERATOR_SIGNATURE_SECRET`, then run `UserCreator <username> <password> [role...]` to seed the first admin before starting the service. With no roles given, the bootstrap account is ADMIN.