### PR TITLE
Worktree transient index

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/command/UpdateIndex.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/UpdateIndex.java
@@ -53,6 +53,7 @@ public class UpdateIndex extends SimpleCommand<UpdateIndexRequest, UpdateIndexRe
 	private Integer nrtTaxoMaxMergeSizeMB;
 	private Integer nrtTaxoMaxCachedMB;
 	private Boolean nrtCachingDisabled;
+	private Boolean transientIndex;
 
 	private Boolean disableCompression;
 	private Integer defaultConcurrency;
@@ -372,6 +373,19 @@ public class UpdateIndex extends SimpleCommand<UpdateIndexRequest, UpdateIndexRe
 		return this;
 	}
 
+	public Boolean getTransientIndex() {
+		return transientIndex;
+	}
+
+	/**
+	 * When true the index loads lazily and may be unloaded from memory after idle time or under the node's
+	 * transient cache bound, then reloaded on demand. When false the index stays resident once loaded.
+	 */
+	public UpdateIndex setTransientIndex(Boolean transientIndex) {
+		this.transientIndex = transientIndex;
+		return this;
+	}
+
 	public Integer getMaxMergeThreads() {
 		return maxMergeThreads;
 	}
@@ -628,6 +642,11 @@ public class UpdateIndex extends SimpleCommand<UpdateIndexRequest, UpdateIndexRe
 		if (nrtCachingDisabled != null) {
 			updateIndexSettings.setSetNrtCachingDisabled(true);
 			updateIndexSettings.setNrtCachingDisabled(nrtCachingDisabled);
+		}
+
+		if (transientIndex != null) {
+			updateIndexSettings.setSetTransientIndex(true);
+			updateIndexSettings.setTransientIndex(transientIndex);
 		}
 
 		if (maxMergeThreads != null) {

--- a/zulia-client/src/main/java/io/zulia/client/config/ClientIndexConfig.java
+++ b/zulia-client/src/main/java/io/zulia/client/config/ClientIndexConfig.java
@@ -47,6 +47,7 @@ public class ClientIndexConfig {
 	private Integer nrtTaxoMaxMergeSizeMB;
 	private Integer nrtTaxoMaxCachedMB;
 	private Boolean nrtCachingDisabled;
+	private Boolean transientIndex;
 
 	private Boolean disableCompression;
 
@@ -197,6 +198,19 @@ public class ClientIndexConfig {
 
 	public ClientIndexConfig setNrtCachingDisabled(Boolean nrtCachingDisabled) {
 		this.nrtCachingDisabled = nrtCachingDisabled;
+		return this;
+	}
+
+	public Boolean getTransientIndex() {
+		return transientIndex;
+	}
+
+	/**
+	 * When true, the index loads lazily and may be unloaded from memory after idle time or under the node's
+	 * transient cache bound, then reloaded on demand. Default false: the index loads at startup and stays resident.
+	 */
+	public ClientIndexConfig setTransientIndex(Boolean transientIndex) {
+		this.transientIndex = transientIndex;
 		return this;
 	}
 
@@ -484,6 +498,10 @@ public class ClientIndexConfig {
 			isb.setNrtCachingDisabled(nrtCachingDisabled);
 		}
 
+		if (transientIndex != null) {
+			isb.setTransientIndex(transientIndex);
+		}
+
 		if (disableCompression != null) {
 			isb.setDisableCompression(disableCompression);
 		}
@@ -561,6 +579,7 @@ public class ClientIndexConfig {
 		this.nrtTaxoMaxMergeSizeMB = indexSettings.getNrtTaxoMaxMergeSizeMB();
 		this.nrtTaxoMaxCachedMB = indexSettings.getNrtTaxoMaxCachedMB();
 		this.nrtCachingDisabled = indexSettings.getNrtCachingDisabled();
+		this.transientIndex = indexSettings.getTransientIndex();
 		this.disableCompression = indexSettings.getDisableCompression();
 		this.defaultConcurrency = indexSettings.getDefaultConcurrency();
 		this.description = indexSettings.getDescription();

--- a/zulia-client/src/main/java/io/zulia/client/pool/ZuliaPool.java
+++ b/zulia-client/src/main/java/io/zulia/client/pool/ZuliaPool.java
@@ -128,6 +128,9 @@ public class ZuliaPool {
 
 		int tries = 0;
 		while (true) {
+			if (isClosed) {
+				throw new IllegalStateException("Cannot execute " + command.getClass().getSimpleName() + " because the pool is closed");
+			}
 			Node selectedNode = null;
 			try {
 				if (routingEnabled && (indexRouting != null)) {
@@ -210,7 +213,8 @@ public class ZuliaPool {
 
 			}
 			catch (Exception e) {
-				if (tries >= retries) {
+				// a closed pool must not retry: the retry would surface a pool-closed error and hide this one
+				if (tries >= retries || isClosed) {
 					if (connectionListener != null) {
 						connectionListener.exception(selectedNode, command, e);
 					}
@@ -243,15 +247,25 @@ public class ZuliaPool {
 	}
 
 	public void close() {
-		for (ZuliaConnection connection : zuliaConnectionMap.values()) {
-			closeConnection(connection);
-		}
-
-		for (ZuliaRESTClient restClient : zuliaRestPoolMap.values()) {
-			restClient.close();
-		}
-
+		// reject new work before draining so a connection cannot be created after its bucket was drained
 		isClosed = true;
+
+		// drain by remove, repeating while non-empty.  An execute() that raced past the isClosed check may
+		// still insert a connection mid-drain, and it must be closed too rather than leak its channel
+		while (!zuliaConnectionMap.isEmpty() || !zuliaRestPoolMap.isEmpty()) {
+			for (String nodeKey : zuliaConnectionMap.keySet()) {
+				ZuliaConnection connection = zuliaConnectionMap.remove(nodeKey);
+				if (connection != null) {
+					closeConnection(connection);
+				}
+			}
+			for (String nodeKey : zuliaRestPoolMap.keySet()) {
+				ZuliaRESTClient restClient = zuliaRestPoolMap.remove(nodeKey);
+				if (restClient != null) {
+					restClient.close();
+				}
+			}
+		}
 	}
 
 }

--- a/zulia-common/src/main/proto/zulia_base.proto
+++ b/zulia-common/src/main/proto/zulia_base.proto
@@ -95,11 +95,17 @@ message NodeStats {
     double usedDataDirSpaceGB = 8;
     string zuliaVersion = 9;
     repeated IndexStats indexStat = 10;
+    // residency and churn stats for transient indexes on this node
+    uint32 residentIndexCount = 11;
+    uint64 indexLoadCount = 12;
+    uint64 indexEvictionCount = 13;
 }
 
 message IndexStats {
     string indexName = 1;
     repeated ShardCacheStats shardCacheStat = 2;
+    // false for a transient index currently unloaded from memory, and such entries carry no shard cache stats
+    bool resident = 3;
 }
 
 message ShardCacheStats {

--- a/zulia-common/src/main/proto/zulia_index.proto
+++ b/zulia-common/src/main/proto/zulia_index.proto
@@ -82,6 +82,11 @@ message IndexSettings {
     // Lets new indexes adopt evolving built-in defaults (e.g. id-sort doc-values skip index, default vector quantization)
     // that cannot be expressed per field and must not change for an index that already exists. 0 means legacy (pre-versioning).
     uint32 createdIndexVersion = 33;
+
+    // when true the index loads lazily and may be unloaded from memory after idle time or under the node's
+    // transient cache bound, then reloaded on demand. By default false which means the index loads at startup and stays
+    // resident, which is the behavior of all indexes created before this flag existed.
+    bool transientIndex = 34;
 }
 
 
@@ -176,6 +181,9 @@ message UpdateIndexSettings {
 
     bool setNumberOfReplicas = 53;
     uint32 numberOfReplicas = 54;
+
+    bool setTransientIndex = 55;
+    bool transientIndex = 56;
 
 }
 

--- a/zulia-server/build.gradle.kts
+++ b/zulia-server/build.gradle.kts
@@ -1,5 +1,7 @@
 import io.zulia.task.PicoCLITask
 
+import java.time.Duration
+
 plugins {
     application
     alias(libs.plugins.micronaut.application)
@@ -37,6 +39,25 @@ tasks.withType<Test> {
     this.testLogging {
         this.showStandardStreams = true
     }
+}
+
+tasks.test {
+    useJUnitPlatform {
+        excludeTags("soak")
+    }
+}
+
+tasks.register<Test>("soakTest") {
+    description = "Runs hour-scale soak tests tagged 'soak', which the regular test task excludes. Duration via -Dzulia.soak.minutes (default 60)."
+    group = "verification"
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath = sourceSets.test.get().runtimeClasspath
+    useJUnitPlatform {
+        includeTags("soak")
+    }
+    systemProperty("zulia.soak.minutes", providers.systemProperty("zulia.soak.minutes").getOrElse("60"))
+    timeout = Duration.ofHours(2)
+    outputs.upToDateWhen { false }
 }
 
 dependencies {

--- a/zulia-server/src/main/java/io/zulia/server/config/ZuliaConfig.java
+++ b/zulia-server/src/main/java/io/zulia/server/config/ZuliaConfig.java
@@ -50,6 +50,20 @@ public class ZuliaConfig {
 	// bootstrap of a large index from saturating the network and impacting query traffic. Default 60 MiB/s.
 	private long replicationMaxBytesPerSec = 60L * 1024 * 1024;
 
+	// Maximum number of indexes kept loaded in memory on this node. 0 = unlimited (every index stays
+	// resident, the historical behavior). When exceeded, the longest-idle evictable index is unloaded to
+	// disk and reloaded on demand.
+	private int transientIndexCacheSize = 0;
+
+	// Unload an index after it has gone unaccessed for this long, independent of the cache size bound.
+	// 0 = disabled. Setting either this or transientIndexCacheSize enables lazy loading and eviction.
+	private int transientIndexIdleTimeoutSeconds = 0;
+
+	// Whether indexes that have replicas are eligible for eviction. Off by default: evicting a replicated
+	// primary pauses its replication push until reload, and inbound pushes reload evicted replicas, so
+	// write-active replicated indexes would cycle in and out of memory.
+	private boolean transientIndexEvictReplicated = false;
+
 	public ZuliaConfig() {
 	}
 
@@ -213,6 +227,30 @@ public class ZuliaConfig {
 		this.replicationMaxBytesPerSec = replicationMaxBytesPerSec;
 	}
 
+	public int getTransientIndexCacheSize() {
+		return transientIndexCacheSize;
+	}
+
+	public void setTransientIndexCacheSize(int transientIndexCacheSize) {
+		this.transientIndexCacheSize = transientIndexCacheSize;
+	}
+
+	public int getTransientIndexIdleTimeoutSeconds() {
+		return transientIndexIdleTimeoutSeconds;
+	}
+
+	public void setTransientIndexIdleTimeoutSeconds(int transientIndexIdleTimeoutSeconds) {
+		this.transientIndexIdleTimeoutSeconds = transientIndexIdleTimeoutSeconds;
+	}
+
+	public boolean isTransientIndexEvictReplicated() {
+		return transientIndexEvictReplicated;
+	}
+
+	public void setTransientIndexEvictReplicated(boolean transientIndexEvictReplicated) {
+		this.transientIndexEvictReplicated = transientIndexEvictReplicated;
+	}
+
 	@Override
 	public String toString() {
 		return "ZuliaConfig{" + "dataPath='" + dataPath + '\'' + ", cluster=" + cluster + ", clusterName='" + clusterName + '\'' + ", clusterStorageEngine='"
@@ -220,6 +258,8 @@ public class ZuliaConfig {
 				+ mongoAuth + ", serverAddress='" + serverAddress + '\'' + ", servicePort=" + servicePort + ", restPort=" + restPort + ", health=" + health
 				+ ", responseCompression=" + responseCompression + ", rpcWorkers=" + rpcWorkers + ", defaultConcurrency=" + defaultConcurrency + ", debug="
 				+ debug + ", maxFacetsCachedPerDimension=" + maxFacetsCachedPerDimension + ", hitsPerConcurrentRequest=" + hitsPerConcurrentRequest
-				+ ", replicaResponseTimeout=" + replicaResponseTimeout + ", replicationMaxBytesPerSec=" + replicationMaxBytesPerSec + '}';
+				+ ", replicaResponseTimeout=" + replicaResponseTimeout + ", replicationMaxBytesPerSec=" + replicationMaxBytesPerSec
+				+ ", transientIndexCacheSize=" + transientIndexCacheSize + ", transientIndexIdleTimeoutSeconds=" + transientIndexIdleTimeoutSeconds
+				+ ", transientIndexEvictReplicated=" + transientIndexEvictReplicated + '}';
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/config/single/FSIndexService.java
+++ b/zulia-server/src/main/java/io/zulia/server/config/single/FSIndexService.java
@@ -163,9 +163,10 @@ public class FSIndexService implements IndexService {
 			throw new IndexConfigDoesNotExistException(indexSettingsFile.getName());
 		}
 
-		JsonFormat.Parser parser = JsonFormat.parser();
 		ZuliaIndex.IndexSettings.Builder indexSettingsBuilder = ZuliaIndex.IndexSettings.newBuilder();
-		parser.merge(new FileReader(indexSettingsFile), indexSettingsBuilder);
+		try (FileReader fileReader = new FileReader(indexSettingsFile)) {
+			JsonFormat.parser().merge(fileReader, indexSettingsBuilder);
+		}
 		return indexSettingsBuilder.build();
 	}
 
@@ -175,7 +176,9 @@ public class FSIndexService implements IndexService {
 		}
 
 		IndexShardMapping.Builder indexMappingBuilder = IndexShardMapping.newBuilder();
-		JsonFormat.parser().merge(new FileReader(indexMappingFile), indexMappingBuilder);
+		try (FileReader fileReader = new FileReader(indexMappingFile)) {
+			JsonFormat.parser().merge(fileReader, indexMappingBuilder);
+		}
 		return indexMappingBuilder.build();
 	}
 
@@ -185,7 +188,9 @@ public class FSIndexService implements IndexService {
 		}
 
 		IndexAlias.Builder indexAliasBuilder = IndexAlias.newBuilder();
-		JsonFormat.parser().merge(new FileReader(indexAliasFile), indexAliasBuilder);
+		try (FileReader fileReader = new FileReader(indexAliasFile)) {
+			JsonFormat.parser().merge(fileReader, indexAliasBuilder);
+		}
 		return indexAliasBuilder.build();
 	}
 

--- a/zulia-server/src/main/java/io/zulia/server/connection/client/InternalRpcConnection.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/client/InternalRpcConnection.java
@@ -16,9 +16,11 @@ public class InternalRpcConnection {
 	private final String memberAddress;
 	private final int internalServicePort;
 
-	private ManagedChannel channel;
-	private ZuliaServiceBlockingStub blockingStub;
-	private ZuliaServiceStub asyncStub;
+	// final so a concurrent close() can never surface a null stub to an in-flight request. Calls on a
+	// shutdown channel fail with a clean retriable StatusRuntimeException instead of an NPE.
+	private final ManagedChannel channel;
+	private final ZuliaServiceBlockingStub blockingStub;
+	private final ZuliaServiceStub asyncStub;
 
 	public InternalRpcConnection(String memberAddress, int servicePort) {
 		this.memberAddress = memberAddress;
@@ -44,25 +46,22 @@ public class InternalRpcConnection {
 
 	public void close() {
 		try {
-			if (channel != null) {
-				LOG.info("Closing connection to {}:{}", memberAddress, internalServicePort);
-				channel.shutdown();
-				try {
-					channel.awaitTermination(15, TimeUnit.SECONDS);
+			LOG.info("Closing connection to {}:{}", memberAddress, internalServicePort);
+			channel.shutdown();
+			try {
+				if (!channel.awaitTermination(15, TimeUnit.SECONDS)) {
+					LOG.warn("Connection to {}:{} did not terminate within 15s on close, forcing shutdown", memberAddress, internalServicePort);
+					channel.shutdownNow();
 				}
-				catch (InterruptedException ex) {
-					LOG.warn("connection to {}:{} timed out on close", memberAddress, internalServicePort);
-				}
-
+			}
+			catch (InterruptedException ex) {
+				LOG.warn("Interrupted while closing connection to {}:{}, forcing shutdown", memberAddress, internalServicePort);
+				channel.shutdownNow();
+				Thread.currentThread().interrupt();
 			}
 		}
 		catch (Exception e) {
-			LOG.error("Close Failed", e);
+			LOG.error("Close failed: ", e);
 		}
-
-		channel = null;
-		blockingStub = null;
-		asyncStub = null;
-
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/handler/GetSegmentFileInfoServerRequest.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/handler/GetSegmentFileInfoServerRequest.java
@@ -3,7 +3,7 @@ package io.zulia.server.connection.server.handler;
 import io.zulia.message.ZuliaServiceOuterClass.GetSegmentFileInfoRequest;
 import io.zulia.message.ZuliaServiceOuterClass.GetSegmentFileInfoResponse;
 import io.zulia.message.ZuliaServiceOuterClass.SegmentFileInfo;
-import io.zulia.server.index.ZuliaIndex;
+import io.zulia.server.index.resident.IndexLease;
 import io.zulia.server.index.ZuliaIndexManager;
 import io.zulia.server.index.replication.ReplicaFileInfo;
 import org.apache.lucene.util.Version;
@@ -22,8 +22,10 @@ public class GetSegmentFileInfoServerRequest extends ServerRequestHandler<GetSeg
 
 	@Override
 	protected GetSegmentFileInfoResponse handleCall(ZuliaIndexManager indexManager, GetSegmentFileInfoRequest request) throws Exception {
-		ZuliaIndex zuliaIndex = indexManager.getIndexFromName(request.getIndexName());
-		List<ReplicaFileInfo> files = zuliaIndex.listReplicaFileInfo(request.getShardNumber(), request.getTaxonomy());
+		List<ReplicaFileInfo> files;
+		try (IndexLease lease = indexManager.leaseIndexFromName(request.getIndexName())) {
+			files = lease.getIndex().listReplicaFileInfo(request.getShardNumber(), request.getTaxonomy());
+		}
 		GetSegmentFileInfoResponse.Builder responseBuilder = GetSegmentFileInfoResponse.newBuilder().setLuceneVersion(Version.LATEST.toString());
 		for (ReplicaFileInfo info : files) {
 			responseBuilder.addFiles(SegmentFileInfo.newBuilder().setFileName(info.name()).setLength(info.length()).setChecksum(info.checksum()).build());

--- a/zulia-server/src/main/java/io/zulia/server/connection/server/handler/ReplicaStreamObserver.java
+++ b/zulia-server/src/main/java/io/zulia/server/connection/server/handler/ReplicaStreamObserver.java
@@ -7,6 +7,7 @@ import io.zulia.message.ZuliaServiceOuterClass.SendSegmentFilesResponse;
 import io.zulia.server.index.ZuliaIndexManager;
 import io.zulia.server.index.replication.ReplicaDirectoryApplier;
 import io.zulia.server.index.replication.ReplicationLimits;
+import io.zulia.server.index.resident.IndexLease;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,10 +21,11 @@ public class ReplicaStreamObserver implements StreamObserver<SegmentFileData> {
 	private final StreamObserver<SendSegmentFilesResponse> responseObserver;
 	private final Semaphore inboundSemaphore;
 
+	private IndexLease lease;
 	private ReplicaDirectoryApplier applier;
 	private long generation;
 	private boolean terminated;
-	private boolean permitReleased;
+	private boolean streamResourcesReleased;
 
 	public ReplicaStreamObserver(ZuliaIndexManager indexManager, StreamObserver<SendSegmentFilesResponse> responseObserver, Semaphore inboundSemaphore) {
 		this.indexManager = indexManager;
@@ -38,7 +40,9 @@ public class ReplicaStreamObserver implements StreamObserver<SegmentFileData> {
 		}
 		try {
 			if (applier == null) {
-				applier = indexManager.getIndexFromName(data.getIndexName()).newReplicaApplier(data.getShardNumber());
+				// the lease spans the whole inbound stream so the index cannot be unloaded while segment files are applied
+				lease = indexManager.leaseIndexFromName(data.getIndexName());
+				applier = lease.getIndex().newReplicaApplier(data.getShardNumber());
 			}
 
 			generation = data.getGeneration();
@@ -67,13 +71,13 @@ public class ReplicaStreamObserver implements StreamObserver<SegmentFileData> {
 		if (applier != null) {
 			applier.abort();
 		}
-		releasePermit();
+		releaseStreamResources();
 	}
 
 	@Override
 	public void onCompleted() {
 		if (terminated) {
-			releasePermit();
+			releaseStreamResources();
 			return;
 		}
 		try {
@@ -97,7 +101,7 @@ public class ReplicaStreamObserver implements StreamObserver<SegmentFileData> {
 			}
 		}
 		finally {
-			releasePermit();
+			releaseStreamResources();
 		}
 	}
 
@@ -113,14 +117,17 @@ public class ReplicaStreamObserver implements StreamObserver<SegmentFileData> {
 			}
 			catch (IllegalStateException ignored) {
 			}
-			releasePermit();
+			releaseStreamResources();
 		}
 	}
 
-	private void releasePermit() {
-		if (!permitReleased) {
-			permitReleased = true;
+	private void releaseStreamResources() {
+		if (!streamResourcesReleased) {
+			streamResourcesReleased = true;
 			inboundSemaphore.release();
+			if (lease != null) {
+				lease.close();
+			}
 		}
 	}
 }

--- a/zulia-server/src/main/java/io/zulia/server/index/ShardWriteManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ShardWriteManager.java
@@ -2,9 +2,9 @@ package io.zulia.server.index;
 
 import io.zulia.ZuliaFieldConstants;
 import io.zulia.server.analysis.ZuliaPerFieldAnalyzer;
-import io.zulia.server.search.aggregation.AggregationSettings;
 import io.zulia.server.config.ServerIndexConfig;
 import io.zulia.server.index.cache.ZuliaTaxonomyWriterCache;
+import io.zulia.server.search.aggregation.AggregationSettings;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.facet.taxonomy.directory.DirectoryTaxonomyReader;
 import org.apache.lucene.index.DirectoryReader;
@@ -18,6 +18,7 @@ import org.apache.lucene.index.TieredMergePolicy;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.MMapDirectory;
 import org.apache.lucene.store.NRTCachingDirectory;
+import org.apache.lucene.util.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -83,10 +84,26 @@ public class ShardWriteManager {
 		this.pathToTaxoIndex = pathToTaxoIndex;
 		this.snapshotDeletionPolicy = new SnapshotDeletionPolicy(new KeepOnlyLastCommitDeletionPolicy());
 		this.indexWriter = openIndexWriter(pathToIndex);
-		this.taxoWriter = openTaxoWriter(pathToTaxoIndex, aggregationSettings.maxFacetsCachedPerDimension());
-		this.segmentOpenExecutor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name(indexName + ":s" + shardNumber + "-segment-", 0).factory());
+		SnapshotDirectoryTaxonomyWriter openedTaxoWriter = null;
+		try {
+			openedTaxoWriter = openTaxoWriter(pathToTaxoIndex, aggregationSettings.maxFacetsCachedPerDimension());
+			this.taxoWriter = openedTaxoWriter;
+			this.segmentOpenExecutor = Executors.newThreadPerTaskExecutor(Thread.ofVirtual().name(indexName + ":s" + shardNumber + "-segment-", 0).factory());
 
-		updateIndexSettings();
+			updateIndexSettings();
+		}
+		catch (Exception e) {
+			// a failure after the IndexWriter opens must not leak it because a leaked writer holds the shard's
+			// write.lock in-process, blocking every reload of this shard until a JVM restart
+			try {
+				IOUtils.close(indexWriter::rollback, indexWriter.getDirectory(), openedTaxoWriter,
+						openedTaxoWriter == null ? null : openedTaxoWriter.getDirectory());
+			}
+			catch (Exception cleanup) {
+				e.addSuppressed(cleanup);
+			}
+			throw e;
+		}
 
 	}
 
@@ -147,17 +164,9 @@ public class ShardWriteManager {
 
 	public void close() throws IOException {
 		segmentOpenExecutor.close();
-		{
-			Directory directory = indexWriter.getDirectory();
-			indexWriter.rollback();
-			directory.close();
-		}
-		{
-			Directory directory = taxoWriter.getDirectory();
-			taxoWriter.close();
-			directory.close();
-
-		}
+		// close everything even when an earlier step fails: a leaked writer or directory holds mmap handles
+		// and lock files that block reopening this shard
+		IOUtils.close(indexWriter::rollback, indexWriter.getDirectory(), taxoWriter, taxoWriter.getDirectory());
 	}
 
 	public ShardReader createShardReader() throws IOException {

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
@@ -5,8 +5,8 @@ import com.google.protobuf.ProtocolStringList;
 import io.zulia.ZuliaFieldConstants;
 import io.zulia.message.ZuliaBase;
 import io.zulia.message.ZuliaBase.AssociatedDocument;
-import io.zulia.message.ZuliaBase.PrimaryReplicaSettings;
 import io.zulia.message.ZuliaBase.Node;
+import io.zulia.message.ZuliaBase.PrimaryReplicaSettings;
 import io.zulia.message.ZuliaBase.ResultDocument;
 import io.zulia.message.ZuliaBase.ShardCountResponse;
 import io.zulia.message.ZuliaBase.Similarity;
@@ -36,19 +36,19 @@ import io.zulia.server.config.ZuliaConfig;
 import io.zulia.server.connection.client.InternalClient;
 import io.zulia.server.exceptions.IndexDoesNotExistException;
 import io.zulia.server.exceptions.ShardDoesNotExistException;
+import io.zulia.server.field.FieldTypeUtil;
+import io.zulia.server.filestorage.DocumentStorage;
 import io.zulia.server.index.replication.ReplicaDirectoryApplier;
 import io.zulia.server.index.replication.ReplicaFileInfo;
 import io.zulia.server.index.replication.ReplicationRateLimiter;
 import io.zulia.server.index.replication.ReplicationShardState;
 import io.zulia.server.index.replication.ReplicationUtil;
 import io.zulia.server.index.replication.SegmentReplicationManager;
-import io.zulia.server.field.FieldTypeUtil;
-import io.zulia.server.filestorage.DocumentStorage;
-import io.zulia.server.search.aggregation.AggregationSettings;
 import io.zulia.server.search.GeoDistUtil;
 import io.zulia.server.search.MoreLikeThisLazyQuery;
 import io.zulia.server.search.QueryCacheKey;
 import io.zulia.server.search.ShardQuery;
+import io.zulia.server.search.aggregation.AggregationSettings;
 import io.zulia.server.search.queryparser.SetQueryHelper;
 import io.zulia.server.search.queryparser.ZuliaFlexibleQueryParser;
 import io.zulia.server.util.DeletingFileVisitor;
@@ -302,7 +302,20 @@ public class ZuliaIndex {
 	private void loadPrimaryShard(int shardNumber) throws Exception {
 		ShardWriteManager shardWriteManager = new ShardWriteManager(shardNumber, getPathForIndex(shardNumber), getPathForFacetsIndex(shardNumber), indexConfig,
 				zuliaPerFieldAnalyzer, aggregationSettings);
-		ZuliaShard s = new ZuliaShard(shardWriteManager);
+		ZuliaShard s;
+		try {
+			s = new ZuliaShard(shardWriteManager);
+		}
+		catch (Exception e) {
+			// reader creation failed, so close the fully opened write manager or its write.lock stays held until JVM restart
+			try {
+				shardWriteManager.close();
+			}
+			catch (Exception cleanup) {
+				e.addSuppressed(cleanup);
+			}
+			throw e;
+		}
 		s.setPostCommitHook(() -> segmentReplicationManager.replicateAfterCommit(s));
 		LOG.info("Loaded primary shard {}:s{}", indexName, shardNumber);
 		primaryShardMap.put(shardNumber, s);
@@ -316,12 +329,20 @@ public class ZuliaIndex {
 		replicaShardMap.put(shardNumber, s);
 	}
 
-	private Path getPathForIndex(int shardNumber) {
+	public static Path getPathForIndex(ZuliaConfig zuliaConfig, String indexName, int shardNumber) {
 		return Paths.get(zuliaConfig.getDataPath(), "indexes", indexName + "_" + shardNumber + "_idx");
 	}
 
-	private Path getPathForFacetsIndex(int shardNumber) {
+	public static Path getPathForFacetsIndex(ZuliaConfig zuliaConfig, String indexName, int shardNumber) {
 		return Paths.get(zuliaConfig.getDataPath(), "indexes", indexName + "_" + shardNumber + "_facets");
+	}
+
+	private Path getPathForIndex(int shardNumber) {
+		return getPathForIndex(zuliaConfig, indexName, shardNumber);
+	}
+
+	private Path getPathForFacetsIndex(int shardNumber) {
+		return getPathForFacetsIndex(zuliaConfig, indexName, shardNumber);
 	}
 
 	protected void unloadShard(int shardNumber) throws IOException {
@@ -1417,6 +1438,18 @@ public class ZuliaIndex {
 		return indexShardMapping;
 	}
 
+	/**
+	 * True when any local primary shard has uncommitted changes. Used to avoid evicting actively written indexes.
+	 */
+	public boolean isDirty() {
+		for (ZuliaShard shard : primaryShardMap.values()) {
+			if (shard.isDirty()) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	public String getIndexName() {
 		return indexName;
 	}
@@ -1576,6 +1609,7 @@ public class ZuliaIndex {
 
 		ZuliaBase.IndexStats.Builder indexStats = ZuliaBase.IndexStats.newBuilder();
 		indexStats.setIndexName(indexName);
+		indexStats.setResident(true);
 		for (ZuliaShard zuliaShard : primaryShardMap.values()) {
 			indexStats.addShardCacheStat(zuliaShard.getShardCacheStats());
 		}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndexManager.java
@@ -7,8 +7,8 @@ import com.google.protobuf.util.JsonFormat;
 import io.grpc.stub.StreamObserver;
 import io.zulia.message.ZuliaBase;
 import io.zulia.message.ZuliaBase.IndexStats;
-import io.zulia.message.ZuliaBase.PrimaryReplicaSettings;
 import io.zulia.message.ZuliaBase.Node;
+import io.zulia.message.ZuliaBase.PrimaryReplicaSettings;
 import io.zulia.message.ZuliaIndex.AnalyzerSettings;
 import io.zulia.message.ZuliaIndex.FieldConfig;
 import io.zulia.message.ZuliaIndex.FieldMapping;
@@ -54,10 +54,16 @@ import io.zulia.server.index.federator.QueryRequestFederator;
 import io.zulia.server.index.federator.ReindexRequestFederator;
 import io.zulia.server.index.replication.ReplicationRateLimiter;
 import io.zulia.server.index.replication.ReplicationShardState;
+import io.zulia.server.index.resident.IndexLease;
+import io.zulia.server.index.resident.IndexLeases;
+import io.zulia.server.index.resident.LoadedIndexCache;
+import io.zulia.server.index.resident.RegisteredIndex;
+import io.zulia.server.index.resident.TransientIndexPolicy;
 import io.zulia.server.index.router.DeleteRequestRouter;
 import io.zulia.server.index.router.FetchRequestRouter;
 import io.zulia.server.index.router.StoreRequestRouter;
 import io.zulia.server.node.ZuliaNode;
+import io.zulia.server.util.DeletingFileVisitor;
 import io.zulia.server.util.MongoProvider;
 import io.zulia.util.IndexAliasUtil;
 import io.zulia.util.ResultHelper;
@@ -74,6 +80,8 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -85,11 +93,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -102,12 +110,11 @@ public class ZuliaIndexManager {
 	private final IndexService indexService;
 	private final InternalClient internalClient;
 	private final ExecutorService pool;
-	private final ConcurrentHashMap<String, ZuliaIndex> indexMap;
+	private final LoadedIndexCache loadedIndexCache;
 	private final ZuliaConfig zuliaConfig;
 	private final NodeService nodeService;
 	private final Node thisNode;
 	private volatile Collection<Node> currentOtherNodesActive = Collections.emptyList();
-	private final ConcurrentHashMap<String, Lock> indexUpdateMap = new ConcurrentHashMap<>();
 	private final ConcurrentHashMap<String, IndexAlias> indexAliasMap;
 	private final ReplicationRateLimiter replicationRateLimiter;
 
@@ -131,7 +138,8 @@ public class ZuliaIndexManager {
 
 		this.internalClient = new InternalClient();
 
-		this.indexMap = new ConcurrentHashMap<>();
+		TransientIndexPolicy policy = TransientIndexPolicy.fromConfig(zuliaConfig);
+		this.loadedIndexCache = new LoadedIndexCache(policy, this::loadIndexForCache);
 		this.indexAliasMap = new ConcurrentHashMap<>();
 
 		for (IndexAlias indexAlias : indexService.getIndexAliases()) {
@@ -143,12 +151,12 @@ public class ZuliaIndexManager {
 	}
 
 	public void handleNodeAdded(Collection<Node> currentOtherNodesActive, Node nodeAdded) {
-		LOG.info("{}:{} added node {}:{}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), nodeAdded.getServerAddress(), nodeAdded.getServicePort());
+		LOG.info("{}:{} added node {}:{}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), nodeAdded.getServerAddress(),
+				nodeAdded.getServicePort());
 
 		internalClient.addNode(nodeAdded);
 		this.currentOtherNodesActive = currentOtherNodesActive;
 	}
-
 
 	public void handleNodeRemoved(Collection<Node> currentOtherNodesActive, Node nodeRemoved) {
 		LOG.info("{}:{} removed node {}:{}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), nodeRemoved.getServerAddress(),
@@ -163,24 +171,54 @@ public class ZuliaIndexManager {
 
 		pool.shutdownNow();
 
-		indexMap.values().parallelStream().forEach(zuliaIndex -> {
-			try {
-				zuliaIndex.unload(false);
-			}
-			catch (IOException e) {
-				LOG.error("Failed to unload index: {}", zuliaIndex.getIndexName(), e);
-			}
-		});
+		loadedIndexCache.shutdown();
 
 	}
 
 	public void init() throws Exception {
 		List<IndexSettings> indexes = indexService.getIndexes();
+
+		Map<String, IndexShardMapping> mappingByName = new HashMap<>();
+		try {
+			for (IndexShardMapping indexShardMapping : indexService.getIndexShardMappings()) {
+				mappingByName.put(indexShardMapping.getIndexName(), indexShardMapping);
+			}
+		}
+		catch (Exception e) {
+			LOG.error("Failed to bulk read shard mappings, falling back to per-index reads", e);
+		}
+
+		List<String> eagerLoad = new ArrayList<>();
+		for (IndexSettings indexSettings : indexes) {
+			String indexName = indexSettings.getIndexName();
+			IndexShardMapping mapping = mappingByName.get(indexName);
+			if (mapping == null) {
+				try {
+					mapping = indexService.getIndexShardMapping(indexName);
+				}
+				catch (Exception e) {
+					LOG.error("Failed to read shard mapping for index {}", indexName, e);
+				}
+			}
+			if (mapping == null) {
+				// an index without a readable mapping cannot be routed or loaded, so skip it instead of failing startup
+				LOG.error("Index {} has no shard mapping and will not be registered", indexName);
+				continue;
+			}
+			loadedIndexCache.register(new RegisteredIndex(indexName, mapping));
+			if (indexSettings.getTransientIndex()) {
+				LOG.info("{}:{} registered transient index {} for on-demand loading", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), indexName);
+			}
+			else {
+				eagerLoad.add(indexName);
+			}
+		}
+
 		try (TaskExecutor initPool = WorkPool.nativePool(Runtime.getRuntime().availableProcessors(), "index-init")) {
-			for (IndexSettings indexSettings : indexes) {
+			for (String indexName : eagerLoad) {
 				initPool.execute(() -> {
-					try {
-						loadIndex(indexSettings);
+					try (IndexLease _ = loadedIndexCache.leaseOrLoad(indexName)) {
+						// load only, the index stays resident after the lease is released
 					}
 					catch (Exception e) {
 						LOG.error("{}:", e.getClass().getSimpleName(), e);
@@ -191,34 +229,54 @@ public class ZuliaIndexManager {
 		}
 	}
 
-	private void loadIndex(String indexName) throws Exception {
-
+	// builds a fully started index for the cache but never touches cache itself
+	private ZuliaIndex loadIndexForCache(String indexName) throws Exception {
 		IndexSettings indexSettings = indexService.getIndex(indexName);
 
 		if (indexSettings == null) {
 			throw new IndexDoesNotExistException(indexName);
 		}
 
-		loadIndex(indexSettings);
-	}
+		LOG.info("{}:{} loading index {}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), indexName);
 
-	private void loadIndex(IndexSettings indexSettings) throws Exception {
-		LOG.info("{}:{} loading index {}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), indexSettings.getIndexName());
+		IndexShardMapping currentMapping = indexService.getIndexShardMapping(indexName);
 
-		IndexShardMapping indexShardMapping = indexService.getIndexShardMapping(indexSettings.getIndexName());
+		// Load with the last mapping this node applied, then run the transitions to the current one, so a
+		// fault-in racing a mapping update cannot skip the on-disk cleanup for roles this node lost.
+		RegisteredIndex registered = loadedIndexCache.getRegistered(indexName);
+		IndexShardMapping previouslyApplied = registered != null && registered.shardMapping() != null ? registered.shardMapping() : currentMapping;
 
 		ServerIndexConfig serverIndexConfig = new ServerIndexConfig(indexSettings);
 
 		DocumentStorage documentStorage = getDocumentStorage(serverIndexConfig);
 
-		ZuliaIndex zuliaIndex = new ZuliaIndex(zuliaConfig, serverIndexConfig, documentStorage, indexService, indexShardMapping, internalClient,
+		ZuliaIndex zuliaIndex = new ZuliaIndex(zuliaConfig, serverIndexConfig, documentStorage, indexService, previouslyApplied, internalClient,
 				replicationRateLimiter);
 
-		indexMap.put(indexSettings.getIndexName(), zuliaIndex);
+		try {
+			zuliaIndex.loadShards((node) -> ZuliaNode.isEqual(thisNode, node));
 
-		zuliaIndex.loadShards((node) -> ZuliaNode.isEqual(thisNode, node));
+			if (!previouslyApplied.equals(currentMapping)) {
+				LOG.info("{}:{} applying shard mapping update for index {} during load", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(),
+						indexName);
+				zuliaIndex.applyShardMappingUpdate(currentMapping, node -> ZuliaNode.isEqual(thisNode, node));
+			}
 
-		zuliaIndex.startMaintenance();
+			zuliaIndex.startMaintenance();
+		}
+		catch (Exception e) {
+			// close whatever shards opened before the failure, or their writers hold the shard write.lock
+			// in-process and every retry of this load fails until a JVM restart
+			try {
+				zuliaIndex.unload(false);
+			}
+			catch (Exception cleanup) {
+				e.addSuppressed(cleanup);
+			}
+			throw e;
+		}
+
+		return zuliaIndex;
 	}
 
 	@NotNull
@@ -254,16 +312,19 @@ public class ZuliaIndexManager {
 	}
 
 	public FetchResponse fetch(FetchRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
-		FetchRequestRouter router = new FetchRequestRouter(thisNode, currentOtherNodesActive, request.getPrimaryReplicaSettings(), i, request.getUniqueId(),
-				internalClient);
-		return router.send(request);
-
+		try (IndexLease lease = leaseIndexFromName(request.getIndexName())) {
+			ZuliaIndex i = lease.getIndex();
+			FetchRequestRouter router = new FetchRequestRouter(thisNode, currentOtherNodesActive, request.getPrimaryReplicaSettings(), i, request.getUniqueId(),
+					internalClient);
+			return router.send(request);
+		}
 	}
 
 	public FetchResponse internalFetch(FetchRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
-		return FetchRequestRouter.internalFetch(i, request);
+		try (IndexLease lease = leaseIndexFromName(request.getIndexName())) {
+			ZuliaIndex i = lease.getIndex();
+			return FetchRequestRouter.internalFetch(i, request);
+		}
 	}
 
 	public void batchFetch(BatchFetchRequest request, StreamObserver<FetchResponse> responseObserver) throws Exception {
@@ -284,33 +345,35 @@ public class ZuliaIndexManager {
 			requestedIds += group.getUniqueIdCount();
 		}
 
-		Map<String, ZuliaIndex> indexCache = new HashMap<>();
-		for (String indexName : indexNames) {
-			indexCache.put(indexName, getIndexFromName(indexName));
-		}
+		try (IndexLeases leases = IndexLeases.acquire(indexNames, this::leaseIndexFromName)) {
+			Map<String, ZuliaIndex> indexCache = leases.getIndexes();
+			BatchFetchRequestFederator federator = new BatchFetchRequestFederator(thisNode, currentOtherNodesActive, pool, internalClient, indexCache);
+			List<FetchResponse> responses = federator.send(request);
+			for (FetchResponse response : responses) {
+				responseObserver.onNext(response);
+			}
 
-		BatchFetchRequestFederator federator = new BatchFetchRequestFederator(thisNode, currentOtherNodesActive, pool, internalClient, indexCache);
-		List<FetchResponse> responses = federator.send(request);
-		for (FetchResponse response : responses) {
-			responseObserver.onNext(response);
+			long endTime = System.currentTimeMillis();
+			LOG.info("Batch fetch for index(es) {}: requested <{}>, retrieved <{}> in {}ms", indexNames, requestedIds, responses.size(), (endTime - startTime));
 		}
-
-		long endTime = System.currentTimeMillis();
-		LOG.info("Batch fetch for index(es) {}: requested <{}>, retrieved <{}> in {}ms", indexNames, requestedIds, responses.size(), (endTime - startTime));
 	}
 
 	public List<FetchResponse> internalBatchFetch(InternalBatchFetchRequest request) throws Exception {
 		List<InternalShardBatchFetchRequest> shardRequests = request.getShardBatchFetchRequestList();
 		if (shardRequests.size() == 1) {
-			ZuliaIndex index = getIndexFromName(shardRequests.getFirst().getIndexName());
-			return index.internalShardBatchFetch(shardRequests.getFirst());
+			try (IndexLease lease = leaseIndexFromName(shardRequests.getFirst().getIndexName())) {
+				ZuliaIndex index = lease.getIndex();
+				return index.internalShardBatchFetch(shardRequests.getFirst());
+			}
 		}
 
 		List<Future<List<FetchResponse>>> futures = new ArrayList<>(shardRequests.size());
 		for (InternalShardBatchFetchRequest shardRequest : shardRequests) {
 			futures.add(pool.submit(() -> {
-				ZuliaIndex index = getIndexFromName(shardRequest.getIndexName());
-				return index.internalShardBatchFetch(shardRequest);
+				try (IndexLease lease = leaseIndexFromName(shardRequest.getIndexName())) {
+					ZuliaIndex index = lease.getIndex();
+					return index.internalShardBatchFetch(shardRequest);
+				}
 			}));
 		}
 
@@ -322,45 +385,60 @@ public class ZuliaIndexManager {
 	}
 
 	public ZuliaBase.AssociatedDocument getAssociatedDocument(String indexName, String uniqueId, String fileName) throws Exception {
-		ZuliaIndex i = getIndexFromName(indexName);
-		return i.getAssociatedDocument(uniqueId, fileName, ZuliaQuery.FetchType.FULL);
+		try (IndexLease lease = leaseIndexFromName(indexName)) {
+			ZuliaIndex index = lease.getIndex();
+			return index.getAssociatedDocument(uniqueId, fileName, ZuliaQuery.FetchType.FULL);
+		}
 	}
 
 	public Document getAssociatedDocumentMeta(String indexName, String uniqueId, String fileName) throws Exception {
-		ZuliaIndex i = getIndexFromName(indexName);
-		ZuliaBase.AssociatedDocument associatedDocument = i.getAssociatedDocument(uniqueId, fileName, ZuliaQuery.FetchType.META);
-		if (associatedDocument != null) {
-			byte[] metadataBSONBytes = associatedDocument.getMetadata().toByteArray();
-			return ZuliaUtil.byteArrayToMongoDocument(metadataBSONBytes);
+		try (IndexLease lease = leaseIndexFromName(indexName)) {
+			ZuliaIndex index = lease.getIndex();
+			ZuliaBase.AssociatedDocument associatedDocument = index.getAssociatedDocument(uniqueId, fileName, ZuliaQuery.FetchType.META);
+			if (associatedDocument != null) {
+				byte[] metadataBSONBytes = associatedDocument.getMetadata().toByteArray();
+				return ZuliaUtil.byteArrayToMongoDocument(metadataBSONBytes);
+			}
+			return null;
 		}
-		return null;
 	}
 
+	// the returned stream reads from document storage and outlives the lease, so eviction will need a stream-scoped hold
 	public InputStream getAssociatedDocumentStream(String indexName, String uniqueId, String fileName) throws Exception {
-		ZuliaIndex i = getIndexFromName(indexName);
-		return i.getAssociatedDocumentStream(uniqueId, fileName);
+		try (IndexLease lease = leaseIndexFromName(indexName)) {
+			ZuliaIndex index = lease.getIndex();
+			return index.getAssociatedDocumentStream(uniqueId, fileName);
+		}
 	}
 
+	// the returned stream writes to document storage and outlives the lease, so eviction will need a stream-scoped hold
 	public OutputStream getAssociatedDocumentOutputStream(String indexName, String uniqueId, String fileName, Document metadata) throws Exception {
-		ZuliaIndex i = getIndexForWrite(indexName);
-		long timestamp = System.currentTimeMillis();
-		return i.getAssociatedDocumentOutputStream(uniqueId, fileName, timestamp, metadata);
+		try (IndexLease lease = leaseIndexForWrite(indexName)) {
+			ZuliaIndex i = lease.getIndex();
+			long timestamp = System.currentTimeMillis();
+			return i.getAssociatedDocumentOutputStream(uniqueId, fileName, timestamp, metadata);
+		}
 	}
 
 	public List<String> getAssociatedFilenames(String indexName, String uniqueId) throws Exception {
-		ZuliaIndex i = getIndexFromName(indexName);
-		return i.getAssociatedFilenames(uniqueId);
+		try (IndexLease lease = leaseIndexFromName(indexName)) {
+			ZuliaIndex i = lease.getIndex();
+			return i.getAssociatedFilenames(uniqueId);
+		}
 	}
 
 	public Stream<AssociatedMetadataDTO> getAssociatedFilenames(String indexName, Document query) throws Exception {
-		ZuliaIndex i = getIndexFromName(indexName);
-		return i.getAssociatedMetadataForQuery(query);
+		try (IndexLease lease = leaseIndexFromName(indexName)) {
+			ZuliaIndex index = lease.getIndex();
+			return index.getAssociatedMetadataForQuery(query);
+		}
 	}
 
 	public GetNodesResponse getNodes(GetNodesRequest request) throws Exception {
 
 		if ((request.getActiveOnly())) {
-			List<IndexShardMapping> indexShardMappingList = indexMap.values().stream().map(ZuliaIndex::getIndexShardMapping).toList();
+			Collection<RegisteredIndex> registeredIndexes = loadedIndexCache.getRegisteredIndexes();
+			List<IndexShardMapping> indexShardMappingList = registeredIndexes.stream().map(RegisteredIndex::shardMapping).toList();
 			List<IndexAlias> indexAliasesList = List.copyOf(indexAliasMap.values());
 			return GetNodesResponse.newBuilder().addAllNode(currentOtherNodesActive).addNode(thisNode).addAllIndexShardMapping(indexShardMappingList)
 					.addAllIndexAlias(indexAliasesList).build();
@@ -375,12 +453,15 @@ public class ZuliaIndexManager {
 
 	public InternalQueryResponse internalQuery(InternalQueryRequest request) throws Exception {
 
-		Map<String, Query> queryMap = new HashMap<>();
-		Set<ZuliaIndex> indexes = new HashSet<>();
+		try (IndexLeases leases = leaseQueryIndexes(request.getQueryRequest().getIndexList())) {
+			Map<String, Query> queryMap = new HashMap<>();
+			Set<ZuliaIndex> indexes = new HashSet<>();
 
-		populateIndexesAndIndexMap(request.getQueryRequest(), queryMap, indexes);
+			Map<String, ZuliaIndex> resolvedIndexes = leases.getIndexes();
+			populateIndexesAndIndexMap(request.getQueryRequest(), resolvedIndexes, queryMap, indexes);
 
-		return QueryRequestFederator.internalQuery(indexes, request, queryMap);
+			return QueryRequestFederator.internalQuery(indexes, request, queryMap);
+		}
 	}
 
 	public QueryResponse query(QueryRequest request) throws Exception {
@@ -399,40 +480,57 @@ public class ZuliaIndexManager {
 			request = processMoreLikeThisQueries(request);
 		}
 
-		Map<String, Query> queryMap = new HashMap<>();
-		Set<ZuliaIndex> indexes = new HashSet<>();
+		try (IndexLeases leases = leaseQueryIndexes(request.getIndexList())) {
+			Map<String, Query> queryMap = new HashMap<>();
+			Set<ZuliaIndex> indexes = new HashSet<>();
 
-		populateIndexesAndIndexMap(request, queryMap, indexes);
+			Map<String, ZuliaIndex> resolvedIndexes = leases.getIndexes();
+			populateIndexesAndIndexMap(request, resolvedIndexes, queryMap, indexes);
 
-		QueryRequestFederator federator = new QueryRequestFederator(thisNode, currentOtherNodesActive, request.getPrimaryReplicaSettings(), indexes, pool,
-				internalClient, queryMap);
+			QueryRequestFederator federator = new QueryRequestFederator(thisNode, currentOtherNodesActive, request.getPrimaryReplicaSettings(), indexes, pool,
+					internalClient, queryMap);
 
-		return federator.getResponse(request);
+			return federator.getResponse(request);
+		}
 	}
 
 	private QueryRequest processMoreLikeThisQueries(QueryRequest request) throws Exception {
 		List<ZuliaQuery.Query> queryList = request.getQueryList();
 
-		Map<String, ZuliaIndex> queriedIndexes = resolveQueryIndexes(request.getIndexList());
+		try (IndexLeases queriedLeases = leaseQueryIndexes(request.getIndexList())) {
+			Map<String, ZuliaIndex> queriedIndexes = queriedLeases.getIndexes();
 
-		// For each MLT query: resolve its source indexes (its explicit sourceIndex list, or the queried indexes when none is given),
-		// validate, fetch the source docs, and rewrite the query with the resolved text/vectors.
-		QueryRequest.Builder requestBuilder = request.toBuilder().clearQuery();
-		for (ZuliaQuery.Query q : queryList) {
-			if (q.getQueryType() != ZuliaQuery.Query.QueryType.MORE_LIKE_THIS) {
-				requestBuilder.addQuery(q);
-				continue;
+			// For each MLT query: resolve its source indexes (its explicit sourceIndex list, or the queried indexes when none is given),
+			// validate, fetch the source docs, and rewrite the query with the resolved text/vectors.
+			QueryRequest.Builder requestBuilder = request.toBuilder().clearQuery();
+			for (ZuliaQuery.Query q : queryList) {
+				if (q.getQueryType() != ZuliaQuery.Query.QueryType.MORE_LIKE_THIS) {
+					requestBuilder.addQuery(q);
+					continue;
+				}
+				ZuliaQuery.MoreLikeThisParams mltParams = q.getMoreLikeThisParams();
+				if (mltParams.getSourceIndexCount() == 0) {
+					requestBuilder.addQuery(resolveMoreLikeThisQuery(q, queriedIndexes, queriedIndexes, request.getRealtime()));
+				}
+				else {
+					try (IndexLeases sourceLeases = leaseQueryIndexes(mltParams.getSourceIndexList())) {
+						Map<String, ZuliaIndex> indexMap = sourceLeases.getIndexes();
+						ZuliaQuery.Query moreLikeThisQuery = resolveMoreLikeThisQuery(q, queriedIndexes, indexMap, request.getRealtime());
+						requestBuilder.addQuery(moreLikeThisQuery);
+					}
+				}
 			}
-			ZuliaQuery.MoreLikeThisParams mltParams = q.getMoreLikeThisParams();
-			Map<String, ZuliaIndex> sourceIndexes = mltParams.getSourceIndexCount() == 0
-					? queriedIndexes
-					: resolveQueryIndexes(mltParams.getSourceIndexList());
-			validateMoreLikeThisParams(mltParams, queriedIndexes, sourceIndexes);
-			Map<String, Document> sourceDocs = fetchSourceDocs(mltParams, sourceIndexes, request.getRealtime());
-			requestBuilder.addQuery(rewriteMoreLikeThisQuery(q, queriedIndexes, sourceIndexes, sourceDocs));
-		}
 
-		return requestBuilder.build();
+			return requestBuilder.build();
+		}
+	}
+
+	private ZuliaQuery.Query resolveMoreLikeThisQuery(ZuliaQuery.Query q, Map<String, ZuliaIndex> queriedIndexes, Map<String, ZuliaIndex> sourceIndexes,
+			boolean realtime) throws Exception {
+		ZuliaQuery.MoreLikeThisParams mltParams = q.getMoreLikeThisParams();
+		validateMoreLikeThisParams(mltParams, queriedIndexes, sourceIndexes);
+		Map<String, Document> sourceDocs = fetchSourceDocs(mltParams, sourceIndexes, realtime);
+		return rewriteMoreLikeThisQuery(q, queriedIndexes, sourceIndexes, sourceDocs);
 	}
 
 	/**
@@ -456,8 +554,8 @@ public class ZuliaIndexManager {
 			}
 			BatchFetchRequest.Builder batchBuilder = BatchFetchRequest.newBuilder();
 			for (String docId : remaining) {
-				batchBuilder.addFetchRequest(FetchRequest.newBuilder().setUniqueId(docId).setIndexName(indexName).setResultFetchType(FetchType.FULL)
-						.setRealtime(realtime).build());
+				batchBuilder.addFetchRequest(
+						FetchRequest.newBuilder().setUniqueId(docId).setIndexName(indexName).setResultFetchType(FetchType.FULL).setRealtime(realtime).build());
 			}
 			for (FetchResponse response : federator.send(batchBuilder.build())) {
 				if (!response.hasResultDocument()) {
@@ -684,9 +782,10 @@ public class ZuliaIndexManager {
 		return q.toBuilder().setMoreLikeThisParams(resolvedParams).build();
 	}
 
-	private void populateIndexesAndIndexMap(QueryRequest queryRequest, Map<String, Query> queryMap, Set<ZuliaIndex> indexes) throws Exception {
+	private static void populateIndexesAndIndexMap(QueryRequest queryRequest, Map<String, ZuliaIndex> resolvedIndexes, Map<String, Query> queryMap,
+			Set<ZuliaIndex> indexes) throws Exception {
 
-		for (Map.Entry<String, ZuliaIndex> entry : resolveQueryIndexes(queryRequest.getIndexList()).entrySet()) {
+		for (Map.Entry<String, ZuliaIndex> entry : resolvedIndexes.entrySet()) {
 			ZuliaIndex index = entry.getValue();
 			if (indexes.add(index)) {
 				queryMap.put(entry.getKey(), index.getQuery(queryRequest));
@@ -697,8 +796,8 @@ public class ZuliaIndexManager {
 	/**
 	 * Resolves the request's index names (expanding wildcard patterns and aliases) to a map of resolved index name to index, preserving request order.
 	 */
-	private Map<String, ZuliaIndex> resolveQueryIndexes(List<String> indexNames) throws IndexDoesNotExistException {
-		Map<String, ZuliaIndex> resolved = new LinkedHashMap<>();
+	private Map<String, String> resolveQueryIndexes(List<String> indexNames) throws IndexDoesNotExistException {
+		Map<String, String> resolved = new LinkedHashMap<>();
 		for (String indexName : indexNames) {
 			if (isWildcardPattern(indexName)) {
 				List<String> matches = expandWildcard(indexName);
@@ -706,16 +805,85 @@ public class ZuliaIndexManager {
 					throw new IndexDoesNotExistException(indexName);
 				}
 				for (String matched : matches) {
-					resolved.put(matched, indexMap.get(matched));
+					resolved.putIfAbsent(matched, matched);
 				}
 			}
 			else {
 				for (String resolvedName : resolveAlias(indexName)) {
-					resolved.put(resolvedName, lookupIndex(indexName, resolvedName));
+					resolved.putIfAbsent(resolvedName, indexName);
 				}
 			}
 		}
 		return resolved;
+	}
+
+	/**
+	 * Leases the request's indexes (expanding wildcard patterns and aliases), keyed by resolved index name, preserving request order.
+	 * Indexes that are not resident are faulted in concurrently, bounded by the cache's load permits, so a
+	 * wildcard query over many unloaded transient indexes does not pay serial cold loads.
+	 */
+	private IndexLeases leaseQueryIndexes(List<String> indexNames) throws Exception {
+		Map<String, String> originalByResolved = resolveQueryIndexes(indexNames);
+
+		Map<String, IndexLease> acquired = new HashMap<>();
+		Map<String, Future<IndexLease>> loading = new HashMap<>();
+		try {
+			for (Map.Entry<String, String> entry : originalByResolved.entrySet()) {
+				String resolvedName = entry.getKey();
+				String originalName = entry.getValue();
+				IndexLease lease = loadedIndexCache.tryLease(resolvedName);
+				if (lease != null) {
+					acquired.put(resolvedName, lease);
+				}
+				else {
+					loading.put(resolvedName, pool.submit(() -> leaseIndex(originalName, resolvedName)));
+				}
+			}
+
+			LinkedHashMap<String, IndexLease> leases = new LinkedHashMap<>();
+			for (String resolvedName : originalByResolved.keySet()) {
+				IndexLease lease = acquired.get(resolvedName);
+				if (lease == null) {
+					try {
+						lease = loading.get(resolvedName).get();
+					}
+					catch (ExecutionException e) {
+						throw e.getCause() instanceof Exception cause ? cause : e;
+					}
+					acquired.put(resolvedName, lease);
+				}
+				leases.put(resolvedName, lease);
+			}
+			return new IndexLeases(leases);
+		}
+		catch (Exception e) {
+			// releasing every lease matters more than prompt interrupt response: a leaked lease pins its
+			// index resident forever, so the joins here retry through interrupts and the flag is restored after
+			boolean interrupted = Thread.interrupted();
+			for (Future<IndexLease> future : loading.values()) {
+				while (true) {
+					try {
+						IndexLease lease = future.get();
+						if (lease != null) {
+							lease.close();
+						}
+						break;
+					}
+					catch (InterruptedException duringCleanup) {
+						interrupted = true;
+					}
+					catch (Exception ignored) {
+						break;
+					}
+				}
+			}
+			// lease close is idempotent, so leases present in both maps close harmlessly twice
+			acquired.values().forEach(IndexLease::close);
+			if (interrupted) {
+				Thread.currentThread().interrupt();
+			}
+			throw e;
+		}
 	}
 
 	private static boolean isWildcardPattern(String indexName) {
@@ -725,7 +893,7 @@ public class ZuliaIndexManager {
 	private List<String> expandWildcard(String pattern) {
 		Pattern regex = globToRegex(pattern);
 		List<String> matches = new ArrayList<>();
-		for (String existingName : indexMap.keySet()) {
+		for (String existingName : loadedIndexCache.getRegisteredIndexNames()) {
 			if (regex.matcher(existingName).matches()) {
 				matches.add(existingName);
 			}
@@ -750,25 +918,33 @@ public class ZuliaIndexManager {
 	}
 
 	public StoreResponse store(StoreRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		StoreRequestRouter router = new StoreRequestRouter(thisNode, currentOtherNodesActive, i, request.getUniqueId(), internalClient);
-		return router.send(request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex i = lease.getIndex();
+			StoreRequestRouter router = new StoreRequestRouter(thisNode, currentOtherNodesActive, i, request.getUniqueId(), internalClient);
+			return router.send(request);
+		}
 	}
 
 	public StoreResponse internalStore(StoreRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		return StoreRequestRouter.internalStore(i, request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex i = lease.getIndex();
+			return StoreRequestRouter.internalStore(i, request);
+		}
 	}
 
 	public DeleteResponse delete(DeleteRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		DeleteRequestRouter router = new DeleteRequestRouter(thisNode, currentOtherNodesActive, i, request.getUniqueId(), internalClient);
-		return router.send(request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex i = lease.getIndex();
+			DeleteRequestRouter router = new DeleteRequestRouter(thisNode, currentOtherNodesActive, i, request.getUniqueId(), internalClient);
+			return router.send(request);
+		}
 	}
 
 	public DeleteResponse internalDelete(DeleteRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		return DeleteRequestRouter.internalDelete(i, request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex i = lease.getIndex();
+			return DeleteRequestRouter.internalDelete(i, request);
+		}
 	}
 
 	public void batchDelete(BatchDeleteRequest request, StreamObserver<DeleteResponse> responseObserver) throws Exception {
@@ -784,30 +960,32 @@ public class ZuliaIndexManager {
 			indexNames.add(group.getIndexName());
 		}
 
-		Map<String, ZuliaIndex> indexCache = new HashMap<>();
-		for (String indexName : indexNames) {
-			indexCache.put(indexName, getIndexForWrite(indexName));
-		}
-
-		BatchDeleteRequestFederator federator = new BatchDeleteRequestFederator(thisNode, currentOtherNodesActive, pool, internalClient, indexCache);
-		List<DeleteResponse> responses = federator.send(request);
-		for (DeleteResponse response : responses) {
-			responseObserver.onNext(response);
+		try (IndexLeases leases = IndexLeases.acquire(indexNames, this::leaseIndexForWrite)) {
+			Map<String, ZuliaIndex> indexMap = leases.getIndexes();
+			BatchDeleteRequestFederator federator = new BatchDeleteRequestFederator(thisNode, currentOtherNodesActive, pool, internalClient, indexMap);
+			List<DeleteResponse> responses = federator.send(request);
+			for (DeleteResponse response : responses) {
+				responseObserver.onNext(response);
+			}
 		}
 	}
 
 	public List<DeleteResponse> internalBatchDelete(InternalBatchDeleteRequest request) throws Exception {
 		List<InternalShardBatchDeleteRequest> shardRequests = request.getShardBatchDeleteRequestList();
 		if (shardRequests.size() == 1) {
-			ZuliaIndex index = getIndexForWrite(shardRequests.getFirst().getIndexName());
-			return index.internalShardBatchDelete(shardRequests.getFirst());
+			try (IndexLease lease = leaseIndexForWrite(shardRequests.getFirst().getIndexName())) {
+				ZuliaIndex index = lease.getIndex();
+				return index.internalShardBatchDelete(shardRequests.getFirst());
+			}
 		}
 
 		List<Future<List<DeleteResponse>>> futures = new ArrayList<>(shardRequests.size());
 		for (InternalShardBatchDeleteRequest shardRequest : shardRequests) {
 			futures.add(pool.submit(() -> {
-				ZuliaIndex index = getIndexForWrite(shardRequest.getIndexName());
-				return index.internalShardBatchDelete(shardRequest);
+				try (IndexLease lease = leaseIndexForWrite(shardRequest.getIndexName())) {
+					ZuliaIndex index = lease.getIndex();
+					return index.internalShardBatchDelete(shardRequest);
+				}
 			}));
 		}
 
@@ -864,51 +1042,62 @@ public class ZuliaIndexManager {
 		IndexSettings indexSettings = request.getIndexSettings();
 
 		String indexName = indexSettings.getIndexName();
-		IndexSettings existingIndex = indexService.getIndex(indexName);
 
-		indexSettings = applyDocValueSkipIndexPolicy(indexSettings, existingIndex);
+		// the same per-index lock updateIndex uses, so concurrent createIndex and updateIndex cannot
+		// interleave their read-modify-write of settings. Held only for the local store but not the federation.
+		Lock lock = loadedIndexCache.getUpdateLock(indexName);
+		IndexSettings existingIndex;
+		lock.lock();
+		try {
+			existingIndex = indexService.getIndex(indexName);
 
-		long currentTimeMillis = System.currentTimeMillis();
-		if (existingIndex == null) {
+			indexSettings = applyDocValueSkipIndexPolicy(indexSettings, existingIndex);
 
-			indexSettings = indexSettings.toBuilder().setCreateTime(currentTimeMillis).build();
+			long currentTimeMillis = System.currentTimeMillis();
+			if (existingIndex == null) {
 
-			IndexShardMapping indexShardMapping = buildInitialShardMapping(indexSettings, nodeWeightComputation);
-			indexService.storeIndexShardMapping(indexShardMapping);
-		}
-		else {
+				indexSettings = indexSettings.toBuilder().setCreateTime(currentTimeMillis).build();
 
-			IndexSettings existingComparable = existingIndex.toBuilder().clearCreateTime().clearUpdateTime().clearCreatedIndexVersion().build();
-			IndexSettings requestComparable = indexSettings.toBuilder().clearCreateTime().clearUpdateTime().clearCreatedIndexVersion().build();
-			if (existingComparable.equals(requestComparable)) {
-				LOG.info("No changes to existing index {}", indexName);
-				return CreateIndexResponse.newBuilder().build();
+				IndexShardMapping indexShardMapping = buildInitialShardMapping(indexSettings, nodeWeightComputation);
+				indexService.storeIndexShardMapping(indexShardMapping);
+			}
+			else {
+
+				IndexSettings existingComparable = existingIndex.toBuilder().clearCreateTime().clearUpdateTime().clearCreatedIndexVersion().build();
+				IndexSettings requestComparable = indexSettings.toBuilder().clearCreateTime().clearUpdateTime().clearCreatedIndexVersion().build();
+				if (existingComparable.equals(requestComparable)) {
+					LOG.info("No changes to existing index {}", indexName);
+					return CreateIndexResponse.newBuilder().build();
+				}
+
+				if (existingIndex.getNumberOfShards() != indexSettings.getNumberOfShards()) {
+					throw new IllegalArgumentException("Cannot change shards for existing index");
+				}
+
+				if (existingIndex.getNumberOfReplicas() != indexSettings.getNumberOfReplicas()) {
+					IndexShardMapping existingShardMapping = indexService.getIndexShardMapping(indexName);
+					IndexShardMapping newShardMapping = adjustReplicaCount(existingShardMapping, indexSettings, nodeWeightComputation);
+					indexService.storeIndexShardMapping(newShardMapping);
+				}
+
 			}
 
-			if (existingIndex.getNumberOfShards() != indexSettings.getNumberOfShards()) {
-				throw new IllegalArgumentException("Cannot change shards for existing index");
+			IndexSettings.Builder timestampBuilder = indexSettings.toBuilder().setUpdateTime(currentTimeMillis);
+			if (existingIndex != null) {
+				timestampBuilder.setCreateTime(existingIndex.getCreateTime());
+				// createdIndexVersion is stamped once at creation and frozen thereafter (server populated, like createTime).
+				timestampBuilder.setCreatedIndexVersion(existingIndex.getCreatedIndexVersion());
 			}
-
-			if (existingIndex.getNumberOfReplicas() != indexSettings.getNumberOfReplicas()) {
-				IndexShardMapping existingShardMapping = indexService.getIndexShardMapping(indexName);
-				IndexShardMapping newShardMapping = adjustReplicaCount(existingShardMapping, indexSettings, nodeWeightComputation);
-				indexService.storeIndexShardMapping(newShardMapping);
+			else {
+				timestampBuilder.setCreatedIndexVersion(ZuliaIndexVersion.CURRENT);
 			}
+			indexSettings = timestampBuilder.build();
 
+			indexService.storeIndex(indexSettings);
 		}
-
-		IndexSettings.Builder timestampBuilder = indexSettings.toBuilder().setUpdateTime(currentTimeMillis);
-		if (existingIndex != null) {
-			timestampBuilder.setCreateTime(existingIndex.getCreateTime());
-			// createdIndexVersion is stamped once at creation and frozen thereafter (server populated, like createTime).
-			timestampBuilder.setCreatedIndexVersion(existingIndex.getCreatedIndexVersion());
+		finally {
+			lock.unlock();
 		}
-		else {
-			timestampBuilder.setCreatedIndexVersion(ZuliaIndexVersion.CURRENT);
-		}
-		indexSettings = timestampBuilder.build();
-
-		indexService.storeIndex(indexSettings);
 
 		CreateOrUpdateIndexRequestFederator createOrUpdateIndexRequestFederator = new CreateOrUpdateIndexRequestFederator(thisNode, currentOtherNodesActive,
 				pool, internalClient, this);
@@ -945,11 +1134,11 @@ public class ZuliaIndexManager {
 			LOG.info("Update Index Following Alias {} to index {}", orgIndexName, indexName);
 		}
 
-		Lock lock = indexUpdateMap.computeIfAbsent(indexName, s -> new ReentrantLock());
+		Lock lock = loadedIndexCache.getUpdateLock(indexName);
+		IndexSettings indexSettings;
+		lock.lock();
 		try {
-			lock.lock();
-
-			IndexSettings indexSettings = indexService.getIndex(indexName);
+			indexSettings = indexService.getIndex(indexName);
 			if (indexSettings == null) {
 				LOG.error("Failed to update index {} that does not exist", indexName);
 
@@ -1110,6 +1299,10 @@ public class ZuliaIndexManager {
 				existingSettings.setNumberOfReplicas(updateIndexSettings.getNumberOfReplicas());
 			}
 
+			if (updateIndexSettings.getSetTransientIndex()) {
+				existingSettings.setTransientIndex(updateIndexSettings.getTransientIndex());
+			}
+
 			Operation metaUpdateOperation = updateIndexSettings.getMetaUpdateOperation();
 			if (metaUpdateOperation.getEnable()) {
 				Document existingMeta = ZuliaUtil.byteStringToMongoDocument(existingSettings.getMeta());
@@ -1155,22 +1348,24 @@ public class ZuliaIndexManager {
 			}
 
 			indexService.storeIndex(indexSettings);
-
-			CreateOrUpdateIndexRequestFederator createOrUpdateIndexRequestFederator = new CreateOrUpdateIndexRequestFederator(thisNode, currentOtherNodesActive,
-					pool, internalClient, this);
-
-			try {
-				@SuppressWarnings("unused") List<InternalCreateOrUpdateIndexResponse> send = createOrUpdateIndexRequestFederator.send(
-						InternalCreateOrUpdateIndexRequest.newBuilder().setIndexName(indexName).build());
-
-				return UpdateIndexResponse.newBuilder().setFullIndexSettings(indexSettings).setChanged(true).build();
-			}
-			catch (Exception e) {
-				throw new Exception("Failed to update index " + indexName + ": " + e.getMessage());
-			}
 		}
 		finally {
 			lock.unlock();
+		}
+
+		// Federate outside the per-index lock because the internal apply on this node may need the same lock to
+		// fault in an unloaded index
+		CreateOrUpdateIndexRequestFederator createOrUpdateIndexRequestFederator = new CreateOrUpdateIndexRequestFederator(thisNode, currentOtherNodesActive,
+				pool, internalClient, this);
+
+		try {
+			@SuppressWarnings("unused") List<InternalCreateOrUpdateIndexResponse> send = createOrUpdateIndexRequestFederator.send(
+					InternalCreateOrUpdateIndexRequest.newBuilder().setIndexName(indexName).build());
+
+			return UpdateIndexResponse.newBuilder().setFullIndexSettings(indexSettings).setChanged(true).build();
+		}
+		catch (Exception e) {
+			throw new Exception("Failed to update index " + indexName + ": " + e.getMessage());
 		}
 	}
 
@@ -1287,12 +1482,49 @@ public class ZuliaIndexManager {
 
 	public InternalCreateOrUpdateIndexResponse internalCreateOrUpdateIndex(String indexName) throws Exception {
 
-		ZuliaIndex zuliaIndex = indexMap.get(indexName);
-		if (zuliaIndex == null) {
-			loadIndex(indexName);
-			return InternalCreateOrUpdateIndexResponse.newBuilder().setLoaded(true).build();
-		}
+		// the whole apply runs under the per-index lock: two federated applies can arrive concurrently
+		// (updateIndex federates outside this lock), and applyShardMappingUpdate must never run twice at once
+		Lock lock = loadedIndexCache.getUpdateLock(indexName);
+		lock.lock();
+		try {
+			IndexLease lease = loadedIndexCache.tryLease(indexName);
+			if (lease != null) {
+				try (lease) {
+					applyIndexUpdateToResident(lease.getIndex(), indexName);
+					return InternalCreateOrUpdateIndexResponse.newBuilder().setLoaded(false).build();
+				}
+			}
 
+			IndexShardMapping newShardMapping = indexService.getIndexShardMapping(indexName);
+			RegisteredIndex registered = loadedIndexCache.getRegistered(indexName);
+			if (registered == null) {
+				// new index on this node: register and load. Transient indexes load here too so creation
+				// verifies them, and the evictor prunes them later.
+				loadedIndexCache.register(new RegisteredIndex(indexName, newShardMapping));
+				try (IndexLease loadLease = loadedIndexCache.leaseOrLoad(indexName)) {
+					// load only
+				}
+				return InternalCreateOrUpdateIndexResponse.newBuilder().setLoaded(true).build();
+			}
+
+			// not resident: settings apply at the next load, and only a role change for this node needs a
+			// fault-in now (the load path reconciles the transitions from the previously applied mapping)
+			if (checkIfLocalRolesChanged(registered.shardMapping(), newShardMapping)) {
+				try (IndexLease loadLease = loadedIndexCache.leaseOrLoad(indexName)) {
+					// fault in only, buildIndex applies the transitions
+				}
+			}
+			else {
+				loadedIndexCache.register(new RegisteredIndex(indexName, newShardMapping));
+			}
+			return InternalCreateOrUpdateIndexResponse.newBuilder().setLoaded(false).build();
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	private void applyIndexUpdateToResident(ZuliaIndex zuliaIndex, String indexName) throws Exception {
 		IndexShardMapping newShardMapping = indexService.getIndexShardMapping(indexName);
 		if (!zuliaIndex.getIndexShardMapping().equals(newShardMapping)) {
 			LOG.info("{}:{} applying shard mapping update for index {}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), indexName);
@@ -1300,8 +1532,28 @@ public class ZuliaIndexManager {
 		}
 
 		zuliaIndex.reloadIndexSettings();
-		return InternalCreateOrUpdateIndexResponse.newBuilder().setLoaded(false).build();
+		loadedIndexCache.register(new RegisteredIndex(indexName, newShardMapping));
+	}
 
+	private record LocalShardRole(int shardNumber, boolean primary) {
+
+	}
+
+	private boolean checkIfLocalRolesChanged(IndexShardMapping oldMapping, IndexShardMapping newMapping) {
+		return !localShardRoles(oldMapping).equals(localShardRoles(newMapping));
+	}
+
+	private Set<LocalShardRole> localShardRoles(IndexShardMapping mapping) {
+		Set<LocalShardRole> roles = new HashSet<>();
+		for (ShardMapping shardMapping : mapping.getShardMappingList()) {
+			if (ZuliaNode.isEqual(shardMapping.getPrimaryNode(), thisNode)) {
+				roles.add(new LocalShardRole(shardMapping.getShardNumber(), true));
+			}
+			else if (shardMapping.getReplicaNodeList().stream().anyMatch(node -> ZuliaNode.isEqual(node, thisNode))) {
+				roles.add(new LocalShardRole(shardMapping.getShardNumber(), false));
+			}
+		}
+		return roles;
 	}
 
 	public DeleteIndexResponse deleteIndex(DeleteIndexRequest request) throws Exception {
@@ -1322,128 +1574,215 @@ public class ZuliaIndexManager {
 
 	public DeleteIndexResponse internalDeleteIndex(DeleteIndexRequest request) throws Exception {
 		String indexName = request.getIndexName();
-		ZuliaIndex zuliaIndex = indexMap.get(indexName);
-		if (zuliaIndex != null) {
-			LOG.info("{}:{} Deleting index {}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), request.getIndexName());
-			//zuliaIndex.unload(true);
-			zuliaIndex.deleteIndex(request.getDeleteAssociated());
-			indexMap.remove(indexName);
-			LOG.info("{}:{} Deleted index {}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), request.getIndexName());
+		Lock lock = loadedIndexCache.getUpdateLock(indexName);
+		lock.lock();
+		try {
+			if (!loadedIndexCache.isRegistered(indexName)) {
+				LOG.info("{}:{} Index {} was not found", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), request.getIndexName());
+				return DeleteIndexResponse.newBuilder().build();
+			}
+			// fault in an unloaded transient index so its on-disk shard data and document storage are removed too
+			try {
+				try (IndexLease lease = loadedIndexCache.leaseOrLoad(indexName)) {
+					if (lease != null) {
+						LOG.info("{}:{} Deleting index {}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), request.getIndexName());
+						lease.getIndex().deleteIndex(request.getDeleteAssociated());
+						// forget the index while still holding the lease so the evictor can never drain the
+						// handle in the gap between the teardown and the removal
+						loadedIndexCache.removeDeleted(indexName);
+						LOG.info("{}:{} Deleted index {}", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), request.getIndexName());
+					}
+					else {
+						loadedIndexCache.removeDeleted(indexName);
+					}
+				}
+			}
+			catch (Exception e) {
+				// delete is the recovery path for an index that cannot even load, so remove its data directly
+				LOG.warn("{}:{} Index {} could not be loaded for delete, removing its on-disk shard data directly", zuliaConfig.getServerAddress(),
+						zuliaConfig.getServicePort(), indexName, e);
+				deleteShardDataDirectlyFromDisk(indexName);
+				loadedIndexCache.removeDeleted(indexName);
+			}
 		}
-		else {
-			LOG.info("{}:{} Index {} was not found", zuliaConfig.getServerAddress(), zuliaConfig.getServicePort(), request.getIndexName());
+		finally {
+			lock.unlock();
 		}
 		return DeleteIndexResponse.newBuilder().build();
 	}
 
-	public GetNumberOfDocsResponse getNumberOfDocs(GetNumberOfDocsRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
-		GetNumberOfDocsRequestFederator federator = new GetNumberOfDocsRequestFederator(thisNode, currentOtherNodesActive, PrimaryReplicaSettings.PRIMARY_ONLY, i,
-				pool, internalClient);
-		return federator.getResponse(request);
+	private void deleteShardDataDirectlyFromDisk(String indexName) {
+		RegisteredIndex registered = loadedIndexCache.getRegistered(indexName);
+		int numberOfShards = registered != null && registered.shardMapping() != null ? registered.shardMapping().getNumberOfShards() : 0;
+		for (int shardNumber = 0; shardNumber < numberOfShards; shardNumber++) {
+			deleteDirectoryQuietly(ZuliaIndex.getPathForIndex(zuliaConfig, indexName, shardNumber));
+			deleteDirectoryQuietly(ZuliaIndex.getPathForFacetsIndex(zuliaConfig, indexName, shardNumber));
+		}
+	}
 
+	private static void deleteDirectoryQuietly(Path path) {
+		try {
+			if (Files.exists(path)) {
+				Files.walkFileTree(path, new DeletingFileVisitor());
+			}
+		}
+		catch (IOException e) {
+			LOG.warn("Failed to delete {}", path, e);
+		}
+	}
+
+	public GetNumberOfDocsResponse getNumberOfDocs(GetNumberOfDocsRequest request) throws Exception {
+		try (IndexLease lease = leaseIndexFromName(request.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			GetNumberOfDocsRequestFederator federator = new GetNumberOfDocsRequestFederator(thisNode, currentOtherNodesActive,
+					PrimaryReplicaSettings.PRIMARY_ONLY, index, pool, internalClient);
+			return federator.getResponse(request);
+		}
 	}
 
 	public GetNumberOfDocsResponse getNumberOfDocsInternal(InternalGetNumberOfDocsRequest internalRequest) throws Exception {
-		ZuliaIndex i = getIndexFromName(internalRequest.getGetNumberOfDocsRequest().getIndexName());
-		return GetNumberOfDocsRequestFederator.internalGetNumberOfDocs(i, internalRequest);
+		try (IndexLease lease = leaseIndexFromName(internalRequest.getGetNumberOfDocsRequest().getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			return GetNumberOfDocsRequestFederator.internalGetNumberOfDocs(index, internalRequest);
+		}
 	}
 
 	public ClearResponse clear(ClearRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		ClearRequestFederator federator = new ClearRequestFederator(thisNode, currentOtherNodesActive, PrimaryReplicaSettings.PRIMARY_ONLY, i, pool,
-				internalClient);
-		return federator.getResponse(request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			ClearRequestFederator federator = new ClearRequestFederator(thisNode, currentOtherNodesActive, PrimaryReplicaSettings.PRIMARY_ONLY, index, pool,
+					internalClient);
+			return federator.getResponse(request);
+		}
 	}
 
 	public ClearResponse internalClear(ClearRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		return ClearRequestFederator.internalClear(i, request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			return ClearRequestFederator.internalClear(index, request);
+		}
 	}
 
 	public OptimizeResponse optimize(OptimizeRequest request) throws Exception {
-
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		OptimizeRequestFederator federator = new OptimizeRequestFederator(thisNode, currentOtherNodesActive, PrimaryReplicaSettings.PRIMARY_ONLY, i, pool,
-				internalClient);
-		return federator.getResponse(request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			OptimizeRequestFederator federator = new OptimizeRequestFederator(thisNode, currentOtherNodesActive, PrimaryReplicaSettings.PRIMARY_ONLY, index,
+					pool, internalClient);
+			return federator.getResponse(request);
+		}
 	}
 
 	public OptimizeResponse internalOptimize(OptimizeRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		return OptimizeRequestFederator.internalOptimize(i, request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			return OptimizeRequestFederator.internalOptimize(index, request);
+		}
 	}
 
 	public ReindexResponse reindex(ReindexRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		ReindexRequestFederator federator = new ReindexRequestFederator(thisNode, currentOtherNodesActive, PrimaryReplicaSettings.PRIMARY_ONLY, i, pool,
-				internalClient);
-		return federator.getResponse(request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			ReindexRequestFederator federator = new ReindexRequestFederator(thisNode, currentOtherNodesActive, PrimaryReplicaSettings.PRIMARY_ONLY, index, pool,
+					internalClient);
+			return federator.getResponse(request);
+		}
 	}
 
 	public ReindexResponse internalReindex(ReindexRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		return ReindexRequestFederator.internalReindex(i, request);
+		try (IndexLease lease = leaseIndexForWrite(request.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			return ReindexRequestFederator.internalReindex(index, request);
+		}
 	}
 
 	public GetFieldNamesResponse getFieldNames(GetFieldNamesRequest request) throws Exception {
 		PrimaryReplicaSettings primaryReplicaSettings = request.getPrimaryReplicaSettings();
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
-		GetFieldNamesRequestFederator federator = new GetFieldNamesRequestFederator(thisNode, currentOtherNodesActive, primaryReplicaSettings, i, pool,
-				internalClient);
-		return federator.getResponse(request);
-
+		try (IndexLease lease = leaseIndexFromName(request.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			GetFieldNamesRequestFederator federator = new GetFieldNamesRequestFederator(thisNode, currentOtherNodesActive, primaryReplicaSettings, index, pool,
+					internalClient);
+			return federator.getResponse(request);
+		}
 	}
 
 	public GetFieldNamesResponse internalGetFieldNames(InternalGetFieldNamesRequest request) throws Exception {
 		GetFieldNamesRequest getFieldNamesRequest = request.getGetFieldNamesRequest();
-		ZuliaIndex i = getIndexFromName(getFieldNamesRequest.getIndexName());
-		return GetFieldNamesRequestFederator.internalGetFieldNames(i, request);
+		try (IndexLease lease = leaseIndexFromName(getFieldNamesRequest.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			return GetFieldNamesRequestFederator.internalGetFieldNames(index, request);
+		}
 	}
 
 	public GetTermsResponse getTerms(GetTermsRequest request) throws Exception {
-		ZuliaIndex i = getIndexFromName(request.getIndexName());
-		GetTermsRequestFederator federator = new GetTermsRequestFederator(thisNode, currentOtherNodesActive, request.getPrimaryReplicaSettings(), i, pool,
-				internalClient);
-		return federator.getResponse(request);
-
+		try (IndexLease lease = leaseIndexFromName(request.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			GetTermsRequestFederator federator = new GetTermsRequestFederator(thisNode, currentOtherNodesActive, request.getPrimaryReplicaSettings(), index,
+					pool, internalClient);
+			return federator.getResponse(request);
+		}
 	}
 
 	public InternalGetTermsResponse internalGetTerms(InternalGetTermsRequest request) throws Exception {
 		GetTermsRequest getTermsRequest = request.getGetTermsRequest();
-		ZuliaIndex i = getIndexFromName(getTermsRequest.getIndexName());
-		return GetTermsRequestFederator.internalGetTerms(i, request);
+		try (IndexLease lease = leaseIndexFromName(getTermsRequest.getIndexName())) {
+			ZuliaIndex index = lease.getIndex();
+			return GetTermsRequestFederator.internalGetTerms(index, request);
+		}
 	}
 
 	public GetIndexSettingsResponse getIndexSettings(GetIndexSettingsRequest request) throws Exception {
-		ZuliaIndex i = getIndexForWrite(request.getIndexName());
-		if (i != null) {
-			return GetIndexSettingsResponse.newBuilder().setIndexSettings(i.getIndexConfig().getIndexSettings()).build();
+		String resolvedName = resolveWriteIndex(request.getIndexName());
+		// must not load an unloaded transient index or refresh its recency so try quietly
+		try (IndexLease lease = loadedIndexCache.tryLeaseQuietly(resolvedName)) {
+			if (lease != null) {
+				return GetIndexSettingsResponse.newBuilder().setIndexSettings(lease.getIndex().getIndexConfig().getIndexSettings()).build();
+			}
 		}
-		return null;
+		IndexSettings indexSettings = indexService.getIndex(resolvedName);
+		if (indexSettings == null) {
+			if (resolvedName.equals(request.getIndexName())) {
+				throw new IndexDoesNotExistException(resolvedName);
+			}
+			throw new IndexDoesNotExistException(request.getIndexName() + "->" + resolvedName);
+		}
+		return GetIndexSettingsResponse.newBuilder().setIndexSettings(indexSettings).build();
 	}
 
 	public List<ReplicationShardState> getReplicationState(String indexName) throws Exception {
-		return getIndexFromName(indexName).getReplicationState();
+		String resolvedName = resolveSingleIndex(indexName);
+		// must not load an unloaded transient index or refresh its recency so try quietly
+		try (IndexLease lease = loadedIndexCache.tryLeaseQuietly(resolvedName)) {
+			if (lease != null) {
+				return lease.getIndex().getReplicationState();
+			}
+		}
+		if (!loadedIndexCache.isRegistered(resolvedName)) {
+			throw new IndexDoesNotExistException(indexName);
+		}
+		return List.of();
 	}
 
-	public ZuliaIndex getIndexFromName(String indexName) throws Exception {
-		return lookupIndex(indexName, resolveSingleIndex(indexName));
+	public LoadedIndexCache getLoadedIndexCache() {
+		return loadedIndexCache;
 	}
 
-	private ZuliaIndex getIndexForWrite(String indexName) throws Exception {
-		return lookupIndex(indexName, resolveWriteIndex(indexName));
+	public IndexLease leaseIndexFromName(String indexName) throws Exception {
+		return leaseIndex(indexName, resolveSingleIndex(indexName));
 	}
 
-	private ZuliaIndex lookupIndex(String originalName, String resolvedName) throws IndexDoesNotExistException {
-		ZuliaIndex i = indexMap.get(resolvedName);
-		if (i == null) {
+	private IndexLease leaseIndexForWrite(String indexName) throws Exception {
+		return leaseIndex(indexName, resolveWriteIndex(indexName));
+	}
+
+	private IndexLease leaseIndex(String originalName, String resolvedName) throws Exception {
+		IndexLease lease = loadedIndexCache.leaseOrLoad(resolvedName);
+		if (lease == null) {
 			if (resolvedName.equals(originalName)) {
 				throw new IndexDoesNotExistException(originalName);
 			}
 			throw new IndexDoesNotExistException(originalName + "->" + resolvedName);
 		}
-		return i;
+		return lease;
 	}
 
 	private List<String> resolveAlias(String indexName) {
@@ -1480,7 +1819,7 @@ public class ZuliaIndexManager {
 			}
 		}
 
-		if (indexMap.containsKey(aliasName)) {
+		if (loadedIndexCache.isRegistered(aliasName)) {
 			throw new IllegalArgumentException("Alias name <" + aliasName + "> collides with an existing index");
 		}
 
@@ -1539,10 +1878,17 @@ public class ZuliaIndexManager {
 	}
 
 	public List<IndexStats> getIndexStats() throws IOException {
+		// every registered index is reported, and an unloaded transient index is a bare non-resident entry
 		List<IndexStats> list = new ArrayList<>();
-		for (ZuliaIndex zuliaIndex : indexMap.values()) {
-			IndexStats indexStats = zuliaIndex.getIndexStats();
-			list.add(indexStats);
+		for (String indexName : loadedIndexCache.getRegisteredIndexNames().stream().sorted().toList()) {
+			try (IndexLease lease = loadedIndexCache.tryLeaseQuietly(indexName)) {
+				if (lease != null) {
+					list.add(lease.getIndex().getIndexStats());
+				}
+				else {
+					list.add(IndexStats.newBuilder().setIndexName(indexName).setResident(false).build());
+				}
+			}
 		}
 		return list;
 	}

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaShard.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaShard.java
@@ -72,6 +72,18 @@ public class ZuliaShard {
 		return primary;
 	}
 
+	/**
+	 * True when this primary shard has changes that are not yet committed. Always false for replicas.
+	 */
+	public boolean isDirty() {
+		if (shardWriteManager == null) {
+			return false;
+		}
+		Long lastChange = shardWriteManager.getLastChanged();
+		Long lastCommit = shardWriteManager.getLastCommit();
+		return lastChange != null && (lastCommit == null || lastChange > lastCommit);
+	}
+
 	public void updateIndexSettings() {
 		if (shardWriteManager != null) {
 			shardWriteManager.updateIndexSettings();

--- a/zulia-server/src/main/java/io/zulia/server/index/federator/NodeRequestFederator.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/federator/NodeRequestFederator.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
@@ -40,23 +41,30 @@ public abstract class NodeRequestFederator<I, O> extends NodeRequestBase<I, O> {
 			futureResponses.add(futureResponse);
 		}
 
+		// Join every subtask before reporting a failure. Abandoning still-running subtasks would let them
+		// outlive the caller's index lease, so an eviction could unload the index under a live operation.
 		ArrayList<O> results = new ArrayList<>();
+		Exception firstFailure = null;
 		for (Future<O> response : futureResponses) {
 			try {
-				O result = response.get();
-				results.add(result);
+				results.add(response.get());
 			}
 			catch (InterruptedException e) {
 				throw e;
 			}
-			catch (Exception e) {
-				Throwable cause = e.getCause();
-				if (cause instanceof Exception) {
-					throw (Exception) cause;
+			catch (ExecutionException e) {
+				Exception failure = e.getCause() instanceof Exception cause ? cause : e;
+				if (firstFailure == null) {
+					firstFailure = failure;
 				}
-
-				throw e;
+				else if (firstFailure != failure) {
+					firstFailure.addSuppressed(failure);
+				}
 			}
+		}
+
+		if (firstFailure != null) {
+			throw firstFailure;
 		}
 
 		return results;

--- a/zulia-server/src/main/java/io/zulia/server/index/resident/IndexHandle.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/resident/IndexHandle.java
@@ -1,0 +1,107 @@
+package io.zulia.server.index.resident;
+
+import io.zulia.server.index.ZuliaIndex;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Pairs a resident index with its lease count, recency, and handle state
+ */
+class IndexHandle {
+
+	enum HandleState {
+		/**
+		 * Resident and serving. The only state in which leases can be acquired.
+		 */
+		ACTIVE,
+		/**
+		 * Eviction has claimed the handle. No new leases, and it reverts to ACTIVE if a lease raced the mark.
+		 */
+		DRAINING,
+		/**
+		 * Terminal. The index is unloaded or deleted and the handle never serves again.
+		 */
+		CLOSED
+	}
+
+	private final ZuliaIndex index;
+	private final AtomicInteger leaseCount = new AtomicInteger();
+	private final AtomicReference<HandleState> state = new AtomicReference<>(HandleState.ACTIVE);
+	private volatile long lastAccessMillis;
+	private final long loadedMillis;
+	private final CompletableFuture<Void> closed = new CompletableFuture<>();
+
+	IndexHandle(ZuliaIndex index) {
+		this.index = index;
+		this.loadedMillis = System.currentTimeMillis();
+		this.lastAccessMillis = loadedMillis;
+	}
+
+	long getLoadedMillis() {
+		return loadedMillis;
+	}
+
+	long getLastAccessMillis() {
+		return lastAccessMillis;
+	}
+
+	ZuliaIndex getIndex() {
+		return index;
+	}
+
+	IndexLease tryAcquire() {
+		return doTryAcquire(true);
+	}
+
+	/**
+	 * Acquire without refreshing recency, for monitoring reads that must not keep an index resident
+	 */
+	IndexLease tryAcquireQuietly() {
+		return doTryAcquire(false);
+	}
+
+	private IndexLease doTryAcquire(boolean updateRecency) {
+		leaseCount.incrementAndGet();
+		if (!isActive()) {
+			leaseCount.decrementAndGet();
+			return null;
+		}
+		if (updateRecency) {
+			lastAccessMillis = System.currentTimeMillis();
+		}
+		return new IndexLease(this);
+	}
+
+	void release() {
+		leaseCount.decrementAndGet();
+	}
+
+	int getLeaseCount() {
+		return leaseCount.get();
+	}
+
+	void close() {
+		state.set(HandleState.CLOSED);
+	}
+
+	boolean compareAndSetState(HandleState expectedState, HandleState newState) {
+		return state.compareAndSet(expectedState, newState);
+	}
+
+	boolean isActive() {
+		return state.get() == HandleState.ACTIVE;
+	}
+
+	void waitForClosed(int timeout, TimeUnit timeUnit) throws ExecutionException, InterruptedException, TimeoutException {
+		closed.get(timeout, timeUnit);
+	}
+
+	void markClosedComplete() {
+		closed.complete(null);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/resident/IndexLease.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/resident/IndexLease.java
@@ -1,0 +1,31 @@
+package io.zulia.server.index.resident;
+
+import io.zulia.server.index.ZuliaIndex;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * A hold on a resident index for the duration of an operation, released on close. While any lease is
+ * held, the index must not be unloaded, so bounded residency can defer eviction until the
+ * lease count reaches zero. Close is idempotent.
+ */
+public final class IndexLease implements AutoCloseable {
+
+	private final IndexHandle handle;
+	private final AtomicBoolean closed = new AtomicBoolean();
+
+	IndexLease(IndexHandle handle) {
+		this.handle = handle;
+	}
+
+	public ZuliaIndex getIndex() {
+		return handle.getIndex();
+	}
+
+	@Override
+	public void close() {
+		if (closed.compareAndSet(false, true)) {
+			handle.release();
+		}
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/resident/IndexLeases.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/resident/IndexLeases.java
@@ -1,0 +1,58 @@
+package io.zulia.server.index.resident;
+
+import io.zulia.server.exceptions.IndexDoesNotExistException;
+import io.zulia.server.index.ZuliaIndex;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Leases for the set of indexes an operation touches, keyed in acquisition order by the name the
+ * caller chose (resolved index name or original request name). Closing releases every lease.
+ */
+public final class IndexLeases implements AutoCloseable {
+
+	private final Map<String, IndexLease> leases;
+	private final Map<String, ZuliaIndex> indexes;
+
+	public IndexLeases(LinkedHashMap<String, IndexLease> leases) {
+		this.leases = leases;
+		LinkedHashMap<String, ZuliaIndex> indexByName = new LinkedHashMap<>();
+		leases.forEach((name, lease) -> indexByName.put(name, lease.getIndex()));
+		this.indexes = Collections.unmodifiableMap(indexByName);
+	}
+
+	/**
+	 * Acquires a lease per distinct name, releasing any already acquired if one fails.
+	 */
+	public static IndexLeases acquire(Collection<String> indexNames, LeaseFunction leaser) throws Exception {
+		LinkedHashMap<String, IndexLease> leases = new LinkedHashMap<>();
+		try {
+			for (String indexName : indexNames) {
+				if (!leases.containsKey(indexName)) {
+					IndexLease lease = leaser.lease(indexName);
+					if (lease == null) {
+						throw new IndexDoesNotExistException(indexName);
+					}
+					leases.put(indexName, lease);
+				}
+			}
+			return new IndexLeases(leases);
+		}
+		catch (Exception e) {
+			leases.values().forEach(IndexLease::close);
+			throw e;
+		}
+	}
+
+	public Map<String, ZuliaIndex> getIndexes() {
+		return indexes;
+	}
+
+	@Override
+	public void close() {
+		leases.values().forEach(IndexLease::close);
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/resident/IndexLoader.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/resident/IndexLoader.java
@@ -1,0 +1,14 @@
+package io.zulia.server.index.resident;
+
+import io.zulia.server.index.ZuliaIndex;
+
+@FunctionalInterface
+public interface IndexLoader {
+
+	/**
+	 * Builds the index, loads its shards, applies any shard mapping transitions this node has not yet
+	 * applied, and starts maintenance. Must not touch the cache except reads of the registry. Returns a
+	 * started index or throws, never null: the cache publishes the result into a handle unconditionally.
+	 */
+	ZuliaIndex load(String indexName) throws Exception;
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/resident/LeaseFunction.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/resident/LeaseFunction.java
@@ -1,0 +1,6 @@
+package io.zulia.server.index.resident;
+
+@FunctionalInterface
+public interface LeaseFunction {
+	IndexLease lease(String indexName) throws Exception;
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/resident/LoadedIndexCache.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/resident/LoadedIndexCache.java
@@ -1,0 +1,394 @@
+package io.zulia.server.index.resident;
+
+import io.zulia.message.ZuliaIndex.IndexShardMapping;
+import io.zulia.message.ZuliaIndex.ShardMapping;
+import io.zulia.server.exceptions.IndexDoesNotExistException;
+import io.zulia.server.index.ZuliaIndex;
+import io.zulia.server.index.resident.IndexHandle.HandleState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Owns the registry of every index defined for this node and the set of indexes resident in memory.
+ * Non-transient indexes (the default) load at startup and stay resident. Indexes marked transient in
+ * their settings load lazily on first access, and when the node's {@link TransientIndexPolicy} sets a
+ * bound, an evictor unloads the longest-idle transient index back to disk. Callers only hold a resident
+ * index through an {@link IndexLease}, so eviction is deferred while any operation is in flight.
+ */
+public class LoadedIndexCache {
+
+	private final static Logger LOG = LoggerFactory.getLogger(LoadedIndexCache.class);
+
+	// How often the evictor re-examines resident transient indexes.
+	private static final long EVICTOR_INTERVAL_MS = 5_000;
+
+	// A just-loaded index cannot be evicted until this old, so size pressure never unloads it before first use
+	private static final long MIN_RESIDENCY_MILLIS = 10_000;
+
+	// Bound for waiting on a draining handle to finish closing before a fresh load of the same index.
+	private static final long DRAIN_WAIT_MILLIS = 120_000;
+
+	// Bounds the IO of a wildcard query faulting in many transient indexes while matching the
+	// parallelism startup loads have always had.
+	private static final int LOAD_PERMITS = Math.max(2, Runtime.getRuntime().availableProcessors());
+
+	private final ConcurrentHashMap<String, RegisteredIndex> registeredIndexMap = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, IndexHandle> residentIndexMap = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<String, Lock> indexLockMap = new ConcurrentHashMap<>();
+	private final Semaphore loadSemaphore = new Semaphore(LOAD_PERMITS);
+	private final Semaphore evictorSignal = new Semaphore(0);
+	private final LongAdder loadCount = new LongAdder();
+	private final LongAdder evictionCount = new LongAdder();
+
+	private final TransientIndexPolicy policy;
+	private final IndexLoader loader;
+	private final Thread evictorThread;
+	private volatile boolean running = true;
+
+	public LoadedIndexCache(TransientIndexPolicy policy, IndexLoader loader) {
+		this.policy = policy;
+		this.loader = loader;
+		this.evictorThread = policy.enabled() ? Thread.ofVirtual().name("index-evictor").start(this::evictorLoop) : null;
+	}
+
+	public void register(RegisteredIndex registeredIndex) {
+		registeredIndexMap.put(registeredIndex.indexName(), registeredIndex);
+	}
+
+	public boolean isRegistered(String indexName) {
+		return registeredIndexMap.containsKey(indexName);
+	}
+
+	public RegisteredIndex getRegistered(String indexName) {
+		return registeredIndexMap.get(indexName);
+	}
+
+	public Set<String> getRegisteredIndexNames() {
+		return Collections.unmodifiableSet(registeredIndexMap.keySet());
+	}
+
+	public Collection<RegisteredIndex> getRegisteredIndexes() {
+		return Collections.unmodifiableCollection(registeredIndexMap.values());
+	}
+
+	/**
+	 * Leases the resident index without loading, or returns null when it is not resident.
+	 */
+	public IndexLease tryLease(String indexName) {
+		IndexHandle handle = residentIndexMap.get(indexName);
+		return handle != null ? handle.tryAcquire() : null;
+	}
+
+	/**
+	 * Leases the resident index without loading or refreshing recency, or returns null when it is not resident.
+	 */
+	public IndexLease tryLeaseQuietly(String indexName) {
+		IndexHandle handle = residentIndexMap.get(indexName);
+		return handle != null ? handle.tryAcquireQuietly() : null;
+	}
+
+	/**
+	 * Leases the resident index, loading it first when it is registered but not resident. Returns null when
+	 * the index is not registered.
+	 */
+	public IndexLease leaseOrLoad(String indexName) throws Exception {
+		IndexLease lease = tryLease(indexName);
+		if (lease != null) {
+			return lease;
+		}
+		if (!registeredIndexMap.containsKey(indexName)) {
+			return null;
+		}
+		Lock lock = getUpdateLock(indexName);
+		lock.lock();
+		try {
+			lease = tryLease(indexName);
+			if (lease != null) {
+				return lease;
+			}
+			IndexHandle draining = residentIndexMap.get(indexName);
+			if (draining != null) {
+				lease = awaitDrainOutcome(draining);
+				if (lease != null) {
+					return lease;
+				}
+			}
+			if (!registeredIndexMap.containsKey(indexName)) {
+				return null;
+			}
+			return loadLocked(indexName);
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
+	// A DRAINING handle either finishes closing or reverts to ACTIVE when a lease raced the evictor's mark
+	private IndexLease awaitDrainOutcome(IndexHandle handle) throws Exception {
+		long deadline = System.nanoTime() + DRAIN_WAIT_MILLIS * 1_000_000L;
+		while (System.nanoTime() < deadline) {
+			IndexLease lease = handle.tryAcquire();
+			if (lease != null) {
+				return lease;
+			}
+			try {
+				handle.waitForClosed(100, TimeUnit.MILLISECONDS);
+				return null;
+			}
+			catch (TimeoutException stillDraining) {
+			}
+		}
+		throw new IOException("Timed out waiting for index <" + handle.getIndex().getIndexName() + "> to finish unloading after " + DRAIN_WAIT_MILLIS + "ms");
+	}
+
+	private IndexLease loadLocked(String indexName) throws Exception {
+		loadSemaphore.acquire();
+		try {
+			long start = System.currentTimeMillis();
+			ZuliaIndex index;
+			try {
+				index = loader.load(indexName);
+			}
+			catch (IndexDoesNotExistException e) {
+				// the index service no longer knows this index (i.e., a partially failed delete)
+				// heal the registry, so wildcard expansion and routing stop advertising it
+				registeredIndexMap.remove(indexName);
+				throw e;
+			}
+
+			IndexHandle handle = new IndexHandle(index);
+			IndexLease lease = handle.tryAcquire();
+			residentIndexMap.put(indexName, handle);
+			registeredIndexMap.put(indexName, new RegisteredIndex(indexName, index.getIndexShardMapping()));
+			loadCount.increment();
+			LOG.info("Loaded index {} in {}ms ({} resident)", indexName, System.currentTimeMillis() - start, residentIndexMap.size());
+			evictorSignal.release();
+			return lease;
+		}
+		finally {
+			loadSemaphore.release();
+		}
+	}
+
+	/**
+	 * Per-index lock serializing loads, unload waits, deletes, and settings updates for one index name.
+	 * Must not be held while federating to other nodes: the federated call comes back to this node on
+	 * another thread and may need this same lock.
+	 */
+	public Lock getUpdateLock(String indexName) {
+		return indexLockMap.computeIfAbsent(indexName, name -> new ReentrantLock());
+	}
+
+	/**
+	 * Forgets a deleted index entirely. The caller has already deleted the index's data under the update lock.
+	 */
+	public void removeDeleted(String indexName) {
+		registeredIndexMap.remove(indexName);
+		IndexHandle handle = residentIndexMap.get(indexName);
+		if (handle != null) {
+			// close before removing from the map so a thread that already fetched the handle cannot
+			// acquire a fresh lease on the deleted index
+			handle.close();
+			residentIndexMap.remove(indexName, handle);
+			handle.markClosedComplete();
+		}
+	}
+
+	public List<String> getResidentIndexNames() {
+		return List.copyOf(residentIndexMap.keySet());
+	}
+
+	public int getResidentCount() {
+		return residentIndexMap.size();
+	}
+
+	public long getLoadCount() {
+		return loadCount.sum();
+	}
+
+	public long getEvictionCount() {
+		return evictionCount.sum();
+	}
+
+	private void evictorLoop() {
+		while (running) {
+			try {
+				if (evictorSignal.tryAcquire(EVICTOR_INTERVAL_MS, TimeUnit.MILLISECONDS)) {
+					evictorSignal.drainPermits();
+				}
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				return;
+			}
+			if (!running) {
+				return;
+			}
+			try {
+				evictionPass();
+			}
+			catch (Exception e) {
+				LOG.error("Eviction pass failed", e);
+			}
+		}
+	}
+
+	// snapshot of a candidate's recency so the eviction sort key is immutable while sorting
+	private record EvictionCandidate(String indexName, IndexHandle handle, long lastAccessMillis) {
+
+	}
+
+	private void evictionPass() {
+		long now = System.currentTimeMillis();
+
+		List<EvictionCandidate> transientResident = residentIndexMap.entrySet().stream()
+				.filter(entry -> entry.getValue().isActive() && isTransient(entry.getValue()))
+				.map(entry -> new EvictionCandidate(entry.getKey(), entry.getValue(), entry.getValue().getLastAccessMillis()))
+				.sorted(Comparator.comparingLong(EvictionCandidate::lastAccessMillis)).toList();
+
+		int overCount = policy.maxLoadedIndexes() > 0 ? transientResident.size() - policy.maxLoadedIndexes() : 0;
+		long idleCutoff = policy.idleTimeoutSeconds() > 0 ? now - policy.idleTimeoutSeconds() * 1000L : Long.MIN_VALUE;
+
+		for (EvictionCandidate candidate : transientResident) {
+			IndexHandle handle = candidate.handle();
+			boolean idleExpired = handle.getLastAccessMillis() < idleCutoff;
+			if (overCount <= 0 && !idleExpired) {
+				continue;
+			}
+			if (!isEvictable(handle, now)) {
+				continue;
+			}
+			if (beginDrain(handle)) {
+				overCount--;
+				unloadDraining(candidate.indexName(), handle, now);
+			}
+		}
+	}
+
+	private static boolean isTransient(IndexHandle handle) {
+		return handle.getIndex().getIndexConfig().getIndexSettings().getTransientIndex();
+	}
+
+	private boolean isEvictable(IndexHandle handle, long now) {
+		if (now - handle.getLoadedMillis() < MIN_RESIDENCY_MILLIS) {
+			return false;
+		}
+		if (handle.getLeaseCount() > 0) {
+			return false;
+		}
+		ZuliaIndex index = handle.getIndex();
+		if (!policy.evictReplicated() && hasReplicas(index.getIndexShardMapping())) {
+			return false;
+		}
+		// dirty primaries commit within the index's commit interval, so wait rather than force a commit-and-close cycle
+		return !index.isDirty();
+	}
+
+	private static boolean hasReplicas(IndexShardMapping mapping) {
+		for (ShardMapping shardMapping : mapping.getShardMappingList()) {
+			if (shardMapping.getReplicaNodeCount() > 0) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	// Mark first, then re-check the lease count: pairs with doTryAcquire's increment-then-check so a racing
+	// lease either forces the revert here or observes DRAINING and backs off. Both transitions are CAS so a
+	// concurrent delete that closed the handle is never resurrected into DRAINING or ACTIVE.
+	private boolean beginDrain(IndexHandle handle) {
+		if (!handle.compareAndSetState(HandleState.ACTIVE, HandleState.DRAINING)) {
+			return false;
+		}
+		if (handle.getLeaseCount() > 0) {
+			handle.compareAndSetState(HandleState.DRAINING, HandleState.ACTIVE);
+			return false;
+		}
+		return true;
+	}
+
+	private void unloadDraining(String indexName, IndexHandle handle, long now) {
+		long idleSeconds = (now - handle.getLastAccessMillis()) / 1000;
+		try {
+			startUnloadThread(indexName, handle, idleSeconds);
+		}
+		catch (Throwable t) {
+			// the unload thread never started, so revert or the handle is stranded DRAINING forever
+			handle.compareAndSetState(HandleState.DRAINING, HandleState.ACTIVE);
+			LOG.error("Failed to start eviction of index {}", indexName, t);
+		}
+	}
+
+	private void startUnloadThread(String indexName, IndexHandle handle, long idleSeconds) {
+		Thread.ofVirtual().name("evict-" + indexName).start(() -> {
+			long start = System.currentTimeMillis();
+			try {
+				handle.getIndex().unload(false);
+				evictionCount.increment();
+				LOG.info("Evicted index {} after {}s idle (unload took {}ms)", indexName, idleSeconds, System.currentTimeMillis() - start);
+			}
+			catch (Exception e) {
+				LOG.error("Failed to unload index {} during eviction", indexName, e);
+			}
+			finally {
+				handle.close();
+				residentIndexMap.remove(indexName, handle);
+				handle.markClosedComplete();
+			}
+		});
+	}
+
+	/**
+	 * Stops the evictor and unloads every resident index, waiting out any eviction already in flight.
+	 */
+	public void shutdown() {
+		running = false;
+		if (evictorThread != null) {
+			evictorSignal.release();
+			try {
+				evictorThread.join(5_000);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		residentIndexMap.values().parallelStream().forEach(handle -> {
+			// winning the CAS gives this thread sole ownership of the unload, so a still-running evictor
+			// pass or a second shutdown call can never unload the same handle twice
+			if (handle.compareAndSetState(HandleState.ACTIVE, HandleState.CLOSED)) {
+				try {
+					handle.getIndex().unload(false);
+				}
+				catch (IOException e) {
+					LOG.error("Failed to unload index: {}", handle.getIndex().getIndexName(), e);
+				}
+				finally {
+					handle.markClosedComplete();
+				}
+			}
+			else {
+				try {
+					handle.waitForClosed(30, TimeUnit.SECONDS);
+				}
+				catch (Exception e) {
+					LOG.warn("Index {} did not finish unloading during shutdown", handle.getIndex().getIndexName());
+				}
+			}
+		});
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/index/resident/RegisteredIndex.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/resident/RegisteredIndex.java
@@ -1,0 +1,11 @@
+package io.zulia.server.index.resident;
+
+import io.zulia.message.ZuliaIndex.IndexShardMapping;
+
+/**
+ * A defined index this node knows about, resident or not.
+ */
+public record RegisteredIndex(String indexName, IndexShardMapping shardMapping) {
+
+}
+

--- a/zulia-server/src/main/java/io/zulia/server/index/resident/TransientIndexPolicy.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/resident/TransientIndexPolicy.java
@@ -1,0 +1,15 @@
+package io.zulia.server.index.resident;
+
+import io.zulia.server.config.ZuliaConfig;
+
+public record TransientIndexPolicy(int maxLoadedIndexes, int idleTimeoutSeconds, boolean evictReplicated) {
+
+	public static TransientIndexPolicy fromConfig(ZuliaConfig zuliaConfig) {
+		return new TransientIndexPolicy(zuliaConfig.getTransientIndexCacheSize(), zuliaConfig.getTransientIndexIdleTimeoutSeconds(),
+				zuliaConfig.isTransientIndexEvictReplicated());
+	}
+
+	public boolean enabled() {
+		return maxLoadedIndexes > 0 || idleTimeoutSeconds > 0;
+	}
+}

--- a/zulia-server/src/main/java/io/zulia/server/rest/controllers/StatsController.java
+++ b/zulia-server/src/main/java/io/zulia/server/rest/controllers/StatsController.java
@@ -16,6 +16,7 @@ import io.zulia.ZuliaRESTConstants;
 import io.zulia.message.ZuliaBase;
 import io.zulia.message.ZuliaBase.NodeStats;
 import io.zulia.server.index.ZuliaIndexManager;
+import io.zulia.server.index.resident.LoadedIndexCache;
 import io.zulia.server.node.ZuliaNode;
 import io.zulia.util.ZuliaVersion;
 
@@ -69,6 +70,11 @@ public class StatsController {
 
 		List<ZuliaBase.IndexStats> stats = indexManager.getIndexStats();
 		nodeStats.addAllIndexStat(stats);
+
+		LoadedIndexCache loadedIndexCache = indexManager.getLoadedIndexCache();
+		nodeStats.setResidentIndexCount(loadedIndexCache.getResidentCount());
+		nodeStats.setIndexLoadCount(loadedIndexCache.getLoadCount());
+		nodeStats.setIndexEvictionCount(loadedIndexCache.getEvictionCount());
 
 		return nodeStats.build();
 

--- a/zulia-server/src/test/java/io/zulia/server/test/node/FsTransientIndexTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/FsTransientIndexTest.java
@@ -1,0 +1,163 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.server.index.resident.LoadedIndexCache;
+import io.zulia.server.test.node.shared.FsNodeExtension;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Transient index behavior in single-node filesystem mode: FSIndexService metadata reads happen on
+ * every lazy load, so this suite also asserts that evict and reload churn does not grow the process
+ * file descriptor count (the FSIndexService FileReader leak would grow it by two per reload).
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class FsTransientIndexTest {
+
+	private static final String STABLE_INDEX = "fsStable";
+	private static final String TRANSIENT_A = "fsTransientA";
+	private static final String TRANSIENT_B = "fsTransientB";
+	private static final int DOCS_PER_INDEX = 20;
+
+	@RegisterExtension
+	static final FsNodeExtension fsNode = new FsNodeExtension(zuliaConfig -> zuliaConfig.setTransientIndexCacheSize(1));
+
+	private static LoadedIndexCache cache() {
+		return fsNode.getNode().getIndexManager().getLoadedIndexCache();
+	}
+
+	@Test
+	@Order(1)
+	public void createAndIndex() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = fsNode.getClient();
+		createIndex(zuliaWorkPool, STABLE_INDEX, false);
+		createIndex(zuliaWorkPool, TRANSIENT_A, true);
+		createIndex(zuliaWorkPool, TRANSIENT_B, true);
+
+		for (String indexName : List.of(STABLE_INDEX, TRANSIENT_A, TRANSIENT_B)) {
+			for (int i = 0; i < DOCS_PER_INDEX; i++) {
+				indexRecord(zuliaWorkPool, indexName, indexName + "-" + i, "message " + i);
+			}
+			Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, indexName));
+		}
+	}
+
+	@Test
+	@Order(2)
+	public void evictionChurnDoesNotLeakFileDescriptors() throws Exception {
+		Path fdDir = Path.of("/proc/self/fd");
+		Assumptions.assumeTrue(Files.isDirectory(fdDir), "file descriptor check requires /proc (Linux)");
+
+		ZuliaWorkPool zuliaWorkPool = fsNode.getClient();
+		LoadedIndexCache cache = cache();
+
+		// both transient indexes resident at measurement time so the baseline and end states match
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_A));
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_B));
+		Thread.sleep(3000);
+		long loadsBefore = cache.getLoadCount();
+		long fdBefore = countFileDescriptors(fdDir);
+
+		// with a cache bound of 1, alternating access keeps evicting the older index and reloading it,
+		// and every reload reads settings and mapping from FSIndexService
+		long end = System.currentTimeMillis() + 80_000;
+		while (System.currentTimeMillis() < end) {
+			Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_A));
+			Thread.sleep(2000);
+			Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_B));
+			Thread.sleep(2000);
+		}
+
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_A));
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_B));
+		Thread.sleep(3000);
+		long loadDelta = cache.getLoadCount() - loadsBefore;
+		long fdGrowth = countFileDescriptors(fdDir) - fdBefore;
+
+		Assertions.assertTrue(loadDelta >= 5, "expected evict and reload churn but only saw " + loadDelta + " loads");
+		Assertions.assertTrue(fdGrowth < loadDelta,
+				"file descriptors grew by " + fdGrowth + " over " + loadDelta + " reloads, which indicates a per-reload descriptor leak");
+	}
+
+	@Test
+	@Order(3)
+	public void lazyLoadAfterRestart() throws Exception {
+		fsNode.restartNode();
+		ZuliaWorkPool zuliaWorkPool = fsNode.getClient();
+
+		List<String> resident = cache().getResidentIndexNames();
+		Assertions.assertTrue(resident.contains(STABLE_INDEX), "non-transient index loads at startup in FS mode");
+		Assertions.assertFalse(resident.contains(TRANSIENT_A), "transient index must not load at startup in FS mode");
+		Assertions.assertFalse(resident.contains(TRANSIENT_B), "transient index must not load at startup in FS mode");
+
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_A));
+		Assertions.assertTrue(cache().getResidentIndexNames().contains(TRANSIENT_A));
+	}
+
+	@Test
+	@Order(4)
+	public void deleteUnloadedTransientIndexRemovesFsState() throws Exception {
+		fsNode.restartNode();
+		ZuliaWorkPool zuliaWorkPool = fsNode.getClient();
+		Assertions.assertFalse(cache().getResidentIndexNames().contains(TRANSIENT_B), "transient index must not load at startup");
+
+		zuliaWorkPool.deleteIndex(TRANSIENT_B);
+
+		Path settingsFile = Path.of(fsNode.getDataPath(), "settings", TRANSIENT_B + "_index.json");
+		Path shardDir = Path.of(fsNode.getDataPath(), "indexes", TRANSIENT_B + "_0_idx");
+		Assertions.assertFalse(Files.exists(settingsFile), "deleting an unloaded transient index must remove its FS settings file");
+		Assertions.assertFalse(Files.exists(shardDir), "deleting an unloaded transient index must remove its on-disk shard data");
+		Assertions.assertFalse(zuliaWorkPool.getIndexes().getIndexNames().contains(TRANSIENT_B));
+
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, STABLE_INDEX));
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_A));
+	}
+
+	private long countFileDescriptors(Path fdDir) throws IOException {
+		try (var fds = Files.list(fdDir)) {
+			return fds.count();
+		}
+	}
+
+	private long count(ZuliaWorkPool zuliaWorkPool, String indexName) throws Exception {
+		return zuliaWorkPool.search(new Search(indexName).setAmount(0).setRealtime(true)).getTotalHits();
+	}
+
+	private void createIndex(ZuliaWorkPool zuliaWorkPool, String indexName, boolean transientIndex) throws Exception {
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("message");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("message").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.setIndexName(indexName);
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setShardCommitInterval(20);
+		indexConfig.setTransientIndex(transientIndex);
+		zuliaWorkPool.createIndex(indexConfig);
+	}
+
+	private void indexRecord(ZuliaWorkPool zuliaWorkPool, String index, String uniqueId, String message) throws Exception {
+		Document mongoDocument = new Document();
+		mongoDocument.put("id", uniqueId);
+		mongoDocument.put("message", message);
+		Store store = new Store(uniqueId, index);
+		store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(mongoDocument));
+		zuliaWorkPool.store(store);
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/TransientEvictReplicatedTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/TransientEvictReplicatedTest.java
@@ -1,0 +1,122 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.message.ZuliaBase.PrimaryReplicaSettings;
+import io.zulia.server.node.ZuliaNode;
+import io.zulia.server.test.node.shared.NodeExtension;
+import io.zulia.server.test.node.shared.TestHelper;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Tests eviction of replicated transient indexes with transientIndexEvictReplicated enabled.
+ * The replicated index must actually evict on idle, reload on demand, and its replica must catch up with
+ * writes made after the reload.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TransientEvictReplicatedTest {
+
+	private static final String INDEX_NAME = "transientEvictableReplicated";
+	private static final int INITIAL_DOCS = 30;
+	private static final int SECOND_WAVE_DOCS = 10;
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(2, zuliaConfig -> {
+		zuliaConfig.setTransientIndexIdleTimeoutSeconds(15);
+		zuliaConfig.setTransientIndexEvictReplicated(true);
+	});
+
+	@Test
+	@Order(1)
+	public void createAndIndex() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("message");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("message").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.setIndexName(INDEX_NAME);
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setNumberOfReplicas(1);
+		indexConfig.setShardCommitInterval(20);
+		indexConfig.setTransientIndex(true);
+		zuliaWorkPool.createIndex(indexConfig);
+
+		for (int i = 0; i < INITIAL_DOCS; i++) {
+			indexRecord(zuliaWorkPool, INDEX_NAME + "-" + i, "message " + i);
+		}
+		Assertions.assertEquals(INITIAL_DOCS, countDocsForIndex(zuliaWorkPool));
+	}
+
+	@Test
+	@Order(2)
+	public void replicatedIndexEvictsOnIdle() throws Exception {
+		long deadline = System.currentTimeMillis() + 120_000;
+		while (System.currentTimeMillis() < deadline && indexIsResidentOnNode()) {
+			Thread.sleep(1000);
+		}
+		Assertions.assertFalse(indexIsResidentOnNode(), "replicated transient index should evict on idle when transientIndexEvictReplicated is enabled");
+
+		long evictions = TestHelper.getZuliaNodes().stream().mapToLong(node -> node.getIndexManager().getLoadedIndexCache().getEvictionCount()).sum();
+		Assertions.assertTrue(evictions >= 1, "expected at least one eviction across the cluster");
+	}
+
+	@Test
+	@Order(3)
+	public void reloadServesWritesAndReplicaCatchesUp() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// writes fault the evicted primary back in and succeed
+		for (int i = 0; i < SECOND_WAVE_DOCS; i++) {
+			indexRecord(zuliaWorkPool, INDEX_NAME + "-second-" + i, "second wave " + i);
+		}
+		int expected = INITIAL_DOCS + SECOND_WAVE_DOCS;
+		Assertions.assertEquals(expected, countDocsForIndex(zuliaWorkPool));
+
+		// the replica catches up after the post-write commit is pushed (idle commit plus replication)
+		long deadline = System.currentTimeMillis() + 120_000;
+		long replicaHits = -1;
+		while (System.currentTimeMillis() < deadline) {
+			replicaHits = zuliaWorkPool.search(
+					new Search(INDEX_NAME).setAmount(0).setRealtime(true).setPrimaryReplicaSettings(PrimaryReplicaSettings.REPLICA_ONLY)).getTotalHits();
+			if (replicaHits == expected) {
+				break;
+			}
+			Thread.sleep(1000);
+		}
+		Assertions.assertEquals(expected, replicaHits, "replica must catch up with writes made after the primary was evicted and reloaded");
+	}
+
+	private boolean indexIsResidentOnNode() {
+		for (ZuliaNode zuliaNode : TestHelper.getZuliaNodes()) {
+			if (zuliaNode.getIndexManager().getLoadedIndexCache().getResidentIndexNames().contains(INDEX_NAME)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	private long countDocsForIndex(ZuliaWorkPool zuliaWorkPool) throws Exception {
+		return zuliaWorkPool.search(new Search(INDEX_NAME).setAmount(0).setRealtime(true)).getTotalHits();
+	}
+
+	private void indexRecord(ZuliaWorkPool zuliaWorkPool, String uniqueId, String message) throws Exception {
+		Document mongoDocument = new Document();
+		mongoDocument.put("id", uniqueId);
+		mongoDocument.put("message", message);
+		Store store = new Store(uniqueId, INDEX_NAME);
+		store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(mongoDocument));
+		zuliaWorkPool.store(store);
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/TransientIndexLoaderTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/TransientIndexLoaderTest.java
@@ -1,0 +1,213 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.UpdateIndex;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.UpdateIndexResult;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.message.ZuliaBase;
+import io.zulia.server.index.resident.LoadedIndexCache;
+import io.zulia.server.test.node.shared.NodeExtension;
+import io.zulia.server.test.node.shared.TestHelper;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TransientIndexLoaderTest {
+
+	private static final String STABLE_INDEX = "stableIndex";
+	private static final String TRANSIENT_A = "transientA";
+	private static final String TRANSIENT_B = "transientB";
+	private static final String ALIAS_A = "transientAliasA";
+	private static final int DOCS_PER_INDEX = 50;
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(1, zuliaConfig -> zuliaConfig.setTransientIndexCacheSize(1));
+
+	private static LoadedIndexCache cache() {
+		return TestHelper.getZuliaNodes().getFirst().getIndexManager().getLoadedIndexCache();
+	}
+
+	@Test
+	@Order(1)
+	public void createAndIndex() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		createIndex(zuliaWorkPool, STABLE_INDEX, false);
+		createIndex(zuliaWorkPool, TRANSIENT_A, true);
+		createIndex(zuliaWorkPool, TRANSIENT_B, true);
+		zuliaWorkPool.createIndexAlias(ALIAS_A, TRANSIENT_A);
+
+		for (String indexName : List.of(STABLE_INDEX, TRANSIENT_A, TRANSIENT_B)) {
+			for (int i = 0; i < DOCS_PER_INDEX; i++) {
+				indexRecord(zuliaWorkPool, indexName, indexName + "-" + i, "message " + i);
+			}
+			Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, indexName));
+		}
+	}
+
+	@Test
+	@Order(2)
+	public void evictionUnderSizeBound() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// touch A so B is the longest-idle transient index
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_A));
+
+		LoadedIndexCache cache = cache();
+		long deadline = System.currentTimeMillis() + 90_000;
+		while (System.currentTimeMillis() < deadline && cache.getEvictionCount() == 0) {
+			Thread.sleep(1000);
+		}
+		Assertions.assertTrue(cache.getEvictionCount() >= 1, "expected an eviction with cache size 1, resident: " + cache.getResidentIndexNames());
+		Assertions.assertTrue(cache.getResidentIndexNames().contains(STABLE_INDEX), "non-transient index must never be evicted");
+
+		// evicted transient indexes reload on demand with correct results
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_A));
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_B));
+	}
+
+	@Test
+	@Order(3)
+	public void concurrentAccessDuringEvictionChurn() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		AtomicReference<Throwable> failure = new AtomicReference<>();
+		long end = System.currentTimeMillis() + 20_000;
+
+		List<Thread> threads = new ArrayList<>();
+		for (int i = 0; i < 6; i++) {
+			String indexName = (i % 2 == 0) ? TRANSIENT_A : TRANSIENT_B;
+			threads.add(Thread.ofVirtual().name("hammer-" + i).start(() -> {
+				try {
+					while (System.currentTimeMillis() < end && failure.get() == null) {
+						long hits = count(zuliaWorkPool, indexName);
+						if (hits != DOCS_PER_INDEX) {
+							failure.compareAndSet(null, new AssertionError("expected " + DOCS_PER_INDEX + " docs in " + indexName + " but got " + hits));
+						}
+					}
+				}
+				catch (Throwable t) {
+					failure.compareAndSet(null, t);
+				}
+			}));
+		}
+		for (Thread thread : threads) {
+			thread.join();
+		}
+		Assertions.assertNull(failure.get(), () -> "query failed during eviction churn: " + failure.get());
+	}
+
+	@Test
+	@Order(4)
+	public void lazyLoadAfterRestart() throws Exception {
+		nodeExtension.restartNodes();
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		LoadedIndexCache cache = cache();
+		List<String> resident = cache.getResidentIndexNames();
+		Assertions.assertTrue(resident.contains(STABLE_INDEX), "non-transient index loads at startup");
+		Assertions.assertFalse(resident.contains(TRANSIENT_A), "transient index must not load at startup");
+		Assertions.assertFalse(resident.contains(TRANSIENT_B), "transient index must not load at startup");
+
+		// stats report every registered index with its residency, without loading the unloaded ones
+		Map<String, Boolean> residentByIndex = TestHelper.getZuliaNodes().getFirst().getIndexManager().getIndexStats().stream()
+				.collect(Collectors.toMap(ZuliaBase.IndexStats::getIndexName, ZuliaBase.IndexStats::getResident));
+		Assertions.assertEquals(Boolean.TRUE, residentByIndex.get(STABLE_INDEX));
+		Assertions.assertEquals(Boolean.FALSE, residentByIndex.get(TRANSIENT_A));
+		Assertions.assertEquals(Boolean.FALSE, residentByIndex.get(TRANSIENT_B));
+		Assertions.assertFalse(cache.getResidentIndexNames().contains(TRANSIENT_A), "stats must not load an unloaded transient index");
+
+		// settings are readable without loading the index
+		Assertions.assertEquals(Boolean.TRUE, zuliaWorkPool.getIndexConfig(TRANSIENT_A).getIndexConfig().getTransientIndex());
+		Assertions.assertFalse(cache.getResidentIndexNames().contains(TRANSIENT_A), "reading settings must not load the index");
+
+		// an alias to an unloaded transient index faults it in on query
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, ALIAS_A));
+		Assertions.assertTrue(cache.getResidentIndexNames().contains(TRANSIENT_A), "alias query must load the aliased transient index");
+
+		// a wildcard query faults the remaining unloaded transient index in and sees every document
+		long hits = zuliaWorkPool.search(new Search("transient*").setAmount(0).setRealtime(true)).getTotalHits();
+		Assertions.assertEquals(2L * DOCS_PER_INDEX, hits);
+		Assertions.assertTrue(cache.getResidentIndexNames().contains(TRANSIENT_B));
+	}
+
+	@Test
+	@Order(5)
+	public void deleteUnloadedTransientIndex() throws Exception {
+		nodeExtension.restartNodes();
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		Assertions.assertFalse(cache().getResidentIndexNames().contains(TRANSIENT_B), "transient index must not load at startup");
+
+		zuliaWorkPool.deleteIndex(TRANSIENT_B);
+
+		Path shardDir = Path.of("/tmp/zuliaTest/node0/indexes/" + TRANSIENT_B + "_0_idx");
+		Assertions.assertFalse(Files.exists(shardDir), "deleting an unloaded transient index must remove its on-disk shard data");
+		Assertions.assertFalse(zuliaWorkPool.getIndexes().getIndexNames().contains(TRANSIENT_B));
+
+		// the remaining indexes are unaffected
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, STABLE_INDEX));
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, TRANSIENT_A));
+	}
+
+	@Test
+	@Order(6)
+	public void flipIndexToTransientByUpdate() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// the same partial-update path zuliaadmin updateIndex --transientIndex true uses
+		UpdateIndexResult updateResult = zuliaWorkPool.updateIndex(new UpdateIndex(STABLE_INDEX).setTransientIndex(true));
+		Assertions.assertTrue(updateResult.getFullIndexSettings().getTransientIndex(), "updateIndex must persist the transient flag");
+
+		nodeExtension.restartNodes();
+		Assertions.assertFalse(cache().getResidentIndexNames().contains(STABLE_INDEX), "index flipped to transient must not load at startup");
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, STABLE_INDEX), "flipped index must lazy-load with correct results");
+		Assertions.assertTrue(cache().getResidentIndexNames().contains(STABLE_INDEX));
+
+		// flip back: the index loads at startup and is pinned resident again
+		zuliaWorkPool.updateIndex(new UpdateIndex(STABLE_INDEX).setTransientIndex(false));
+		nodeExtension.restartNodes();
+		Assertions.assertTrue(cache().getResidentIndexNames().contains(STABLE_INDEX), "index flipped back to non-transient must load at startup");
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, STABLE_INDEX));
+	}
+
+	private long count(ZuliaWorkPool zuliaWorkPool, String indexName) throws Exception {
+		return zuliaWorkPool.search(new Search(indexName).setAmount(0).setRealtime(true)).getTotalHits();
+	}
+
+	private void createIndex(ZuliaWorkPool zuliaWorkPool, String indexName, boolean transientIndex) throws Exception {
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("message");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("message").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.setIndexName(indexName);
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setShardCommitInterval(20);
+		indexConfig.setTransientIndex(transientIndex);
+		zuliaWorkPool.createIndex(indexConfig);
+	}
+
+	private void indexRecord(ZuliaWorkPool zuliaWorkPool, String index, String uniqueId, String message) throws Exception {
+		Document mongoDocument = new Document();
+		mongoDocument.put("id", uniqueId);
+		mongoDocument.put("message", message);
+		Store store = new Store(uniqueId, index);
+		store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(mongoDocument));
+		zuliaWorkPool.store(store);
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/TransientIndexScaleTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/TransientIndexScaleTest.java
@@ -1,0 +1,283 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.GetIndexesResult;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.server.index.resident.LoadedIndexCache;
+import io.zulia.server.test.node.shared.NodeExtension;
+import io.zulia.server.test.node.shared.TestHelper;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Stress test for transient index residency
+ * 100 transient indexes cycled against a cache bound of 10, so nearly every access cold loads and the evictor churns constantly.
+ * Every phase asserts exact document counts, so a lost write, a query against a half-closed index, or a wrong reload surfaces as
+ * a count mismatch rather than only as an exception.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TransientIndexScaleTest {
+
+	private static final int INDEX_COUNT = 100;
+	private static final int TRANSIENT_INDEX_COUNT = 10;
+	private static final int SEED_DOCS = 5;
+	private static final int WRITER_THREADS = 4;
+	private static final int READER_THREADS = 2;
+
+	private static final int CYCLE_ROUNDS = 3;
+	private static final int DOCS_PER_CYCLE = 2;
+
+	// the last VICTIM_COUNT indexes are excluded from the writers and instead rotate through
+	// delete and recreate, one per round, to exercise the registry lifecycle under churn
+	private static final int VICTIM_COUNT = 4;
+	private static final int WRITABLE_COUNT = INDEX_COUNT - VICTIM_COUNT;
+
+	// expected document count per index, shared across the ordered test methods
+	private static final int[] EXPECTED = new int[INDEX_COUNT];
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(1, zuliaConfig -> zuliaConfig.setTransientIndexCacheSize(TRANSIENT_INDEX_COUNT));
+
+	private static String indexName(int i) {
+		return String.format("scale-%03d", i);
+	}
+
+	private static LoadedIndexCache cache() {
+		return TestHelper.getZuliaNodes().getFirst().getIndexManager().getLoadedIndexCache();
+	}
+
+	@Test
+	@Order(1)
+	public void createIndexes() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		for (int i = 0; i < INDEX_COUNT; i++) {
+			createIndex(zuliaWorkPool, i);
+		}
+
+		GetIndexesResult getIndexesResult = zuliaWorkPool.getIndexes();
+		List<String> allIndexes = getIndexesResult.getIndexNames();
+		for (int i = 0; i < INDEX_COUNT; i++) {
+			Assertions.assertTrue(allIndexes.contains(indexName(i)), "index " + indexName(i) + " missing from index list");
+		}
+	}
+
+	private void createIndex(ZuliaWorkPool zuliaWorkPool, int index) throws Exception {
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("message");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("message").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.setIndexName(indexName(index));
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setShardCommitInterval(20);
+		indexConfig.setTransientIndex(true);
+		zuliaWorkPool.createIndex(indexConfig);
+	}
+
+	@Test
+	@Order(2)
+	public void seedAllIndexes() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		for (int i = 0; i < INDEX_COUNT; i++) {
+			storeDocs(zuliaWorkPool, i, SEED_DOCS);
+			Assertions.assertEquals(EXPECTED[i], count(zuliaWorkPool, indexName(i)), "wrong count in " + indexName(i) + " after seeding");
+		}
+	}
+
+	@Test
+	@Order(3)
+	public void wildcardSweepSeesEverything() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		// faults ~90 unloaded indexes in through the parallel load path in one query
+		Assertions.assertEquals(expectedTotal(), count(zuliaWorkPool, "scale-*"));
+	}
+
+	@Test
+	@Order(4)
+	public void concurrentCyclingKeepsCountsExact() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		LoadedIndexCache cache = cache();
+		long loadsBefore = cache.getLoadCount();
+
+		for (int round = 0; round < CYCLE_ROUNDS; round++) {
+			// drain to the cap first so this round's accesses hit unloaded indexes and interleave with live evictions
+			awaitResidentCountThreshold(cache);
+
+			// rotate one victim per round: delete it (typically while unloaded), recreate it, reseed it.
+			// Exercises delete and recreate racing the evictor and the registry lifecycle under churn.
+			int victim = WRITABLE_COUNT + (round % VICTIM_COUNT);
+			zuliaWorkPool.deleteIndex(indexName(victim));
+			EXPECTED[victim] = 0;
+			createIndex(zuliaWorkPool, victim);
+			storeDocs(zuliaWorkPool, victim, SEED_DOCS);
+			Assertions.assertEquals(SEED_DOCS, count(zuliaWorkPool, indexName(victim)), "wrong count in recreated " + indexName(victim));
+
+			// per-index count bounds for this round: readers race the writers, so an owned index may hold
+			// anywhere from its floor to floor + DOCS_PER_CYCLE at any instant, and never anything else
+			int[] floors = EXPECTED.clone();
+			int[] ceilings = floors.clone();
+			for (int i = 0; i < WRITABLE_COUNT; i++) {
+				ceilings[i] += DOCS_PER_CYCLE;
+			}
+
+			AtomicReference<Throwable> failure = new AtomicReference<>();
+			AtomicBoolean writersDone = new AtomicBoolean();
+
+			// each writer owns a disjoint quarter of the indexes, so per-index expected counts have a single writer
+			List<Thread> writers = new ArrayList<>();
+			for (int t = 0; t < WRITER_THREADS; t++) {
+				int threadIndex = t;
+				writers.add(Thread.ofVirtual().name("cycler-" + t).start(() -> {
+					try {
+						for (int i = threadIndex; i < WRITABLE_COUNT; i += WRITER_THREADS) {
+							if (failure.get() != null) {
+								return;
+							}
+							storeDocs(zuliaWorkPool, i, DOCS_PER_CYCLE);
+							long hits = count(zuliaWorkPool, indexName(i));
+							if (hits != EXPECTED[i]) {
+								failure.compareAndSet(null, new AssertionError("expected " + EXPECTED[i] + " docs in " + indexName(i) + " but got " + hits));
+							}
+						}
+					}
+					catch (Throwable t2) {
+						failure.compareAndSet(null, t2);
+					}
+				}));
+			}
+
+			// readers sweep every index while the writers and the evictor run, and counts must stay inside the bounds
+			List<Thread> readers = new ArrayList<>();
+			for (int r = 0; r < READER_THREADS; r++) {
+				readers.add(Thread.ofVirtual().name("reader-" + r).start(() -> {
+					try {
+						while (!writersDone.get() && failure.get() == null) {
+							for (int i = 0; i < WRITABLE_COUNT && !writersDone.get() && failure.get() == null; i++) {
+								long hits = count(zuliaWorkPool, indexName(i));
+								if (hits < floors[i] || hits > ceilings[i]) {
+									failure.compareAndSet(null, new AssertionError(
+											"count " + hits + " in " + indexName(i) + " outside bounds [" + floors[i] + ", " + ceilings[i] + "]"));
+								}
+							}
+						}
+					}
+					catch (Throwable t2) {
+						failure.compareAndSet(null, t2);
+					}
+				}));
+			}
+
+			// one wildcard sweep mid-round: the cluster-wide total must stay inside the round's bounds
+			long wildcardHits = count(zuliaWorkPool, "scale-*");
+			long floorSum = sum(floors);
+			long ceilingSum = sum(ceilings);
+			Assertions.assertTrue(wildcardHits >= floorSum && wildcardHits <= ceilingSum,
+					"mid-round wildcard total " + wildcardHits + " outside bounds [" + floorSum + ", " + ceilingSum + "]");
+
+			for (Thread writer : writers) {
+				writer.join();
+			}
+			writersDone.set(true);
+			for (Thread reader : readers) {
+				reader.join();
+			}
+			int roundNumber = round;
+			Assertions.assertNull(failure.get(), () -> "round " + roundNumber + " failed: " + failure.get());
+		}
+
+		// every drained round must reload most of the indexes cold, or the churn this test exists for never happened
+		long coldLoads = cache.getLoadCount() - loadsBefore;
+		Assertions.assertTrue(coldLoads >= (long) CYCLE_ROUNDS * (INDEX_COUNT - TRANSIENT_INDEX_COUNT) / 2,
+				"expected heavy cold reloading during cycling but only saw " + coldLoads + " loads");
+	}
+
+	private static long sum(int[] counts) {
+		long total = 0;
+		for (int count : counts) {
+			total += count;
+		}
+		return total;
+	}
+
+	private void awaitResidentCountThreshold(LoadedIndexCache cache) throws InterruptedException {
+		long deadline = System.currentTimeMillis() + 90_000;
+		while (System.currentTimeMillis() < deadline && cache.getResidentCount() > TRANSIENT_INDEX_COUNT) {
+			Thread.sleep(500);
+		}
+		Assertions.assertTrue(cache.getResidentCount() <= TRANSIENT_INDEX_COUNT,
+				"evictor failed to drain to the cap within 90s, resident: " + cache.getResidentIndexNames());
+	}
+
+	@Test
+	@Order(5)
+	public void wildcardSweepAfterChurn() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		Assertions.assertEquals(expectedTotal(), count(zuliaWorkPool, "scale-*"));
+	}
+
+	@Test
+	@Order(6)
+	public void residencyConvergesToCap() throws Exception {
+		LoadedIndexCache cache = cache();
+
+		long deadline = System.currentTimeMillis() + 180_000;
+		while (System.currentTimeMillis() < deadline && cache.getResidentCount() > TRANSIENT_INDEX_COUNT) {
+			Thread.sleep(1000);
+		}
+
+		Assertions.assertTrue(cache.getResidentCount() <= TRANSIENT_INDEX_COUNT,
+				"expected at most " + TRANSIENT_INDEX_COUNT + " resident indexes after churn stopped but found " + cache.getResidentCount() + ": "
+						+ cache.getResidentIndexNames());
+		Assertions.assertTrue(cache.getEvictionCount() >= INDEX_COUNT - TRANSIENT_INDEX_COUNT,
+				"expected heavy eviction churn but only saw " + cache.getEvictionCount() + " evictions");
+	}
+
+	@Test
+	@Order(7)
+	public void finalIntegritySweep() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		for (int i = 0; i < INDEX_COUNT; i++) {
+			Assertions.assertEquals(EXPECTED[i], count(zuliaWorkPool, indexName(i)), "wrong count in " + indexName(i) + " on final sweep");
+		}
+	}
+
+	private static long expectedTotal() {
+		long total = 0;
+		for (int expected : EXPECTED) {
+			total += expected;
+		}
+		return total;
+	}
+
+	private long count(ZuliaWorkPool zuliaWorkPool, String indexName) throws Exception {
+		return zuliaWorkPool.search(new Search(indexName).setAmount(0).setRealtime(true)).getTotalHits();
+	}
+
+	private void storeDocs(ZuliaWorkPool zuliaWorkPool, int index, int docCount) throws Exception {
+		String indexName = indexName(index);
+		for (int d = 0; d < docCount; d++) {
+			String uniqueId = indexName + "-doc-" + EXPECTED[index];
+			Document mongoDocument = new Document();
+			mongoDocument.put("id", uniqueId);
+			mongoDocument.put("message", "message " + EXPECTED[index]);
+			Store store = new Store(uniqueId, indexName);
+			store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(mongoDocument));
+			zuliaWorkPool.store(store);
+			EXPECTED[index]++;
+		}
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/TransientIndexSoakTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/TransientIndexSoakTest.java
@@ -1,0 +1,354 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.server.index.resident.LoadedIndexCache;
+import io.zulia.server.test.node.shared.NodeExtension;
+import io.zulia.server.test.node.shared.TestHelper;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Hour-scale soak test that tests 5000 transient indexes against a residency cap of 100, hammered by paced writers
+ * and readers whose access pattern is ~50x wider than the cap, so nearly every operation pays a cold
+ * load while the evictor runs continuously. Victim indexes rotate through delete and recreate, and
+ * rotating 100-index wildcard windows fan cold loads in bursts. Excluded from the regular test task,
+ * run with: ./gradlew :zulia-server:soakTest (duration knob: -Dzulia.soak.minutes, default 60).
+ * <p>
+ * Invariants asserted throughout: single-writer indexes always count exactly, racing readers always
+ * observe counts inside [expected-before, expected-after + 1], wildcard windows stay inside summed
+ * bounds, residency stays under a thrash ceiling while hammering, and after quiescing the node
+ * converges back to the cap with every one of the 5000 indexes still counting exactly.
+ * <p>
+ * A 90 minute run at this sizing (~5M seeded documents) passed on 2026-07-14 with 167300 cold loads,
+ * 166872 evictions, peak residency 535, and an exact final sweep of all 5000 indexes.
+ */
+@Tag("soak")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TransientIndexSoakTest {
+
+	private static final Logger LOG = LoggerFactory.getLogger(TransientIndexSoakTest.class);
+
+	private static final int INDEX_COUNT = 5000;
+	private static final int CACHE_SIZE = 100;
+	private static final int VICTIM_COUNT = 8;
+	private static final int WRITABLE_COUNT = INDEX_COUNT - VICTIM_COUNT;
+	private static final int SEED_DOCS = 1000;
+	private static final int SEED_THREADS = 16;
+	private static final int DOCS_PER_WRITE = 10;
+	private static final int WRITER_THREADS = 8;
+	private static final int READER_THREADS = 4;
+	private static final long WRITER_PAUSE_MS = 200;
+	private static final long READER_PAUSE_MS = 150;
+	// paced load rate times the 10s minimum residency bounds the soft-cap overshoot, and far above it means thrash
+	private static final int RESIDENT_CEILING = 2500;
+	// setup, convergence, and the final 5000-index sweep get this slice of the total budget
+	private static final long RESERVE_MS = 8 * 60_000;
+
+	private static final long SUITE_START_MS = System.currentTimeMillis();
+	private static final long TOTAL_BUDGET_MS = Long.parseLong(System.getProperty("zulia.soak.minutes", "60")) * 60_000;
+
+	private static final AtomicIntegerArray EXPECTED = new AtomicIntegerArray(WRITABLE_COUNT);
+	private static final AtomicIntegerArray VICTIM_EXPECTED = new AtomicIntegerArray(VICTIM_COUNT);
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(1, zuliaConfig -> zuliaConfig.setTransientIndexCacheSize(CACHE_SIZE));
+
+	private static LoadedIndexCache cache() {
+		return TestHelper.getZuliaNodes().getFirst().getIndexManager().getLoadedIndexCache();
+	}
+
+	private static String indexName(int i) {
+		return String.format("soak-%04d", i);
+	}
+
+	private static String victimName(int v) {
+		return "soakvictim-" + v;
+	}
+
+	@Test
+	@Order(1)
+	public void createIndexes() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		for (int i = 0; i < WRITABLE_COUNT; i++) {
+			createIndex(zuliaWorkPool, indexName(i));
+			if (i % 500 == 499) {
+				LOG.info("Soak: created {} of {} indexes ({} resident)", i + 1, WRITABLE_COUNT, cache().getResidentCount());
+			}
+		}
+		for (int v = 0; v < VICTIM_COUNT; v++) {
+			createIndex(zuliaWorkPool, victimName(v));
+		}
+		Assertions.assertEquals(INDEX_COUNT, zuliaWorkPool.getIndexes().getIndexNames().stream().filter(name -> name.startsWith("soak")).count());
+	}
+
+	@Test
+	@Order(2)
+	public void seedIndexes() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// ~5M seed documents: parallel seeders own disjoint index sets so per-index counts stay single-writer
+		AtomicReference<Throwable> failure = new AtomicReference<>();
+		List<Thread> seeders = new ArrayList<>();
+		for (int t = 0; t < SEED_THREADS; t++) {
+			int threadIndex = t;
+			seeders.add(Thread.ofVirtual().name("soak-seeder-" + t).start(() -> {
+				try {
+					for (int i = threadIndex; i < WRITABLE_COUNT && failure.get() == null; i += SEED_THREADS) {
+						storeWritableDocs(zuliaWorkPool, i, SEED_DOCS);
+						if (i % 500 < SEED_THREADS) {
+							LOG.info("Soak: seeding progressed past index {} of {}", i, WRITABLE_COUNT);
+						}
+					}
+				}
+				catch (Throwable t2) {
+					failure.compareAndSet(null, t2);
+				}
+			}));
+		}
+		for (Thread seeder : seeders) {
+			seeder.join();
+		}
+		Assertions.assertNull(failure.get(), () -> "seeding failed: " + failure.get());
+
+		for (int i = 0; i < WRITABLE_COUNT; i += 500) {
+			Assertions.assertEquals(EXPECTED.get(i), count(zuliaWorkPool, indexName(i)), "wrong count in " + indexName(i) + " after seeding");
+		}
+		for (int v = 0; v < VICTIM_COUNT; v++) {
+			seedVictim(zuliaWorkPool, v);
+		}
+	}
+
+	@Test
+	@Order(3)
+	public void hammer() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		LoadedIndexCache cache = cache();
+
+		long deadline = SUITE_START_MS + TOTAL_BUDGET_MS - RESERVE_MS;
+		long hammerMillis = Math.max(60_000, deadline - System.currentTimeMillis());
+		deadline = System.currentTimeMillis() + hammerMillis;
+		LOG.info("Soak: hammering for {} minutes", hammerMillis / 60_000);
+
+		long loadsBefore = cache.getLoadCount();
+		long evictionsBefore = cache.getEvictionCount();
+
+		AtomicBoolean stop = new AtomicBoolean();
+		AtomicReference<Throwable> failure = new AtomicReference<>();
+
+		List<Thread> threads = new ArrayList<>();
+		for (int t = 0; t < WRITER_THREADS; t++) {
+			int threadIndex = t;
+			threads.add(Thread.ofVirtual().name("soak-writer-" + t).start(() -> writerLoop(zuliaWorkPool, threadIndex, stop, failure)));
+		}
+		for (int r = 0; r < READER_THREADS; r++) {
+			int threadIndex = r;
+			threads.add(Thread.ofVirtual().name("soak-reader-" + r).start(() -> readerLoop(zuliaWorkPool, threadIndex, stop, failure)));
+		}
+
+		int tick = 0;
+		int peakResident = 0;
+		try {
+			while (System.currentTimeMillis() < deadline && failure.get() == null) {
+				Thread.sleep(15_000);
+				tick++;
+
+				int resident = cache.getResidentCount();
+				peakResident = Math.max(peakResident, resident);
+				Assertions.assertTrue(resident <= RESIDENT_CEILING,
+						"resident count " + resident + " exceeded the thrash ceiling " + RESIDENT_CEILING + " during the hammer phase");
+
+				if (tick % 2 == 0) {
+					wildcardWindowSweep(zuliaWorkPool, tick / 2, failure);
+				}
+				if (tick % 4 == 0) {
+					rotateVictim(zuliaWorkPool, (tick / 4) % VICTIM_COUNT);
+				}
+				if (tick % 8 == 0) {
+					LOG.info("Soak: {} min in, {} resident (peak {}), {} loads, {} evictions", tick / 4, resident, peakResident,
+							cache.getLoadCount() - loadsBefore, cache.getEvictionCount() - evictionsBefore);
+				}
+			}
+		}
+		finally {
+			stop.set(true);
+			for (Thread thread : threads) {
+				thread.join();
+			}
+		}
+
+		Assertions.assertNull(failure.get(), () -> "soak hammer failed: " + failure.get());
+
+		long loads = cache.getLoadCount() - loadsBefore;
+		long evictions = cache.getEvictionCount() - evictionsBefore;
+		LOG.info("Soak: hammer finished with {} loads and {} evictions, peak resident {}", loads, evictions, peakResident);
+		// the paced workload sustains ~40 cold loads per second; 5 per second is the churn floor at any duration
+		long minExpected = Math.max(500, hammerMillis / 1000 * 5);
+		Assertions.assertTrue(loads >= minExpected, "expected at least " + minExpected + " cold loads over the hammer phase but only saw " + loads);
+		Assertions.assertTrue(evictions >= minExpected, "expected at least " + minExpected + " evictions over the hammer phase but only saw " + evictions);
+	}
+
+	@Test
+	@Order(4)
+	public void convergesToCap() throws Exception {
+		LoadedIndexCache cache = cache();
+		long deadline = System.currentTimeMillis() + 300_000;
+		while (System.currentTimeMillis() < deadline && cache.getResidentCount() > CACHE_SIZE) {
+			Thread.sleep(2000);
+		}
+		Assertions.assertTrue(cache.getResidentCount() <= CACHE_SIZE,
+				"expected convergence to " + CACHE_SIZE + " resident after quiescing but found " + cache.getResidentCount());
+	}
+
+	@Test
+	@Order(5)
+	public void finalIntegritySweep() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		for (int i = 0; i < WRITABLE_COUNT; i++) {
+			long hits = count(zuliaWorkPool, indexName(i));
+			Assertions.assertEquals(EXPECTED.get(i), hits, "wrong count in " + indexName(i) + " on the final sweep");
+			if (i % 500 == 499) {
+				LOG.info("Soak: final sweep verified {} of {} indexes", i + 1, WRITABLE_COUNT);
+			}
+		}
+		for (int v = 0; v < VICTIM_COUNT; v++) {
+			Assertions.assertEquals(VICTIM_EXPECTED.get(v), count(zuliaWorkPool, victimName(v)), "wrong count in " + victimName(v) + " on the final sweep");
+		}
+	}
+
+	private void writerLoop(ZuliaWorkPool zuliaWorkPool, int threadIndex, AtomicBoolean stop, AtomicReference<Throwable> failure) {
+		try {
+			int i = threadIndex;
+			while (!stop.get() && failure.get() == null) {
+				storeWritableDocs(zuliaWorkPool, i, DOCS_PER_WRITE);
+				long hits = count(zuliaWorkPool, indexName(i));
+				if (hits != EXPECTED.get(i)) {
+					failure.compareAndSet(null, new AssertionError("writer expected " + EXPECTED.get(i) + " docs in " + indexName(i) + " but got " + hits));
+					return;
+				}
+				i += WRITER_THREADS;
+				if (i >= WRITABLE_COUNT) {
+					i = threadIndex;
+				}
+				Thread.sleep(WRITER_PAUSE_MS);
+			}
+		}
+		catch (Throwable t) {
+			failure.compareAndSet(null, t);
+		}
+	}
+
+	private void readerLoop(ZuliaWorkPool zuliaWorkPool, int threadIndex, AtomicBoolean stop, AtomicReference<Throwable> failure) {
+		try {
+			// stride by a prime unaligned with the writer stride so readers sweep all indexes
+			int i = threadIndex * 631;
+			while (!stop.get() && failure.get() == null) {
+				i = (i + 631) % WRITABLE_COUNT;
+				int before = EXPECTED.get(i);
+				long hits = count(zuliaWorkPool, indexName(i));
+				int after = EXPECTED.get(i);
+				// the single writer increments after every stored document, even inside a multi-doc write,
+				// so at most one store is uncounted at any instant
+				if (hits < before || hits > after + 1) {
+					failure.compareAndSet(null,
+							new AssertionError("reader saw " + hits + " docs in " + indexName(i) + " outside bounds [" + before + ", " + (after + 1) + "]"));
+					return;
+				}
+				Thread.sleep(READER_PAUSE_MS);
+			}
+		}
+		catch (Throwable t) {
+			failure.compareAndSet(null, t);
+		}
+	}
+
+	private void wildcardWindowSweep(ZuliaWorkPool zuliaWorkPool, int sweep, AtomicReference<Throwable> failure) throws Exception {
+		int window = sweep % 50;
+		int from = window * 100;
+		int to = Math.min(WRITABLE_COUNT, from + 100);
+
+		long floor = 0;
+		for (int i = from; i < to; i++) {
+			floor += EXPECTED.get(i);
+		}
+		long hits = count(zuliaWorkPool, String.format("soak-%02d*", window));
+		long ceiling = WRITER_THREADS;
+		for (int i = from; i < to; i++) {
+			ceiling += EXPECTED.get(i);
+		}
+		if (hits < floor || hits > ceiling) {
+			failure.compareAndSet(null, new AssertionError(
+					"wildcard window soak-" + String.format("%02d", window) + "* saw " + hits + " outside bounds [" + floor + ", " + ceiling + "]"));
+		}
+	}
+
+	private void rotateVictim(ZuliaWorkPool zuliaWorkPool, int victim) throws Exception {
+		zuliaWorkPool.deleteIndex(victimName(victim));
+		VICTIM_EXPECTED.set(victim, 0);
+		createIndex(zuliaWorkPool, victimName(victim));
+		seedVictim(zuliaWorkPool, victim);
+	}
+
+	private void seedVictim(ZuliaWorkPool zuliaWorkPool, int victim) throws Exception {
+		String name = victimName(victim);
+		for (int d = 0; d < SEED_DOCS; d++) {
+			indexRecord(zuliaWorkPool, name, name + "-doc-" + VICTIM_EXPECTED.get(victim), "victim message");
+			VICTIM_EXPECTED.incrementAndGet(victim);
+		}
+		Assertions.assertEquals(SEED_DOCS, count(zuliaWorkPool, name), "wrong count in recreated " + name);
+	}
+
+	private void storeWritableDocs(ZuliaWorkPool zuliaWorkPool, int index, int docCount) throws Exception {
+		String name = indexName(index);
+		for (int d = 0; d < docCount; d++) {
+			indexRecord(zuliaWorkPool, name, name + "-doc-" + EXPECTED.get(index), "message " + EXPECTED.get(index));
+			EXPECTED.incrementAndGet(index);
+		}
+	}
+
+	private void indexRecord(ZuliaWorkPool zuliaWorkPool, String index, String uniqueId, String message) throws Exception {
+		Document mongoDocument = new Document();
+		mongoDocument.put("id", uniqueId);
+		mongoDocument.put("message", message);
+		Store store = new Store(uniqueId, index);
+		store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(mongoDocument));
+		zuliaWorkPool.store(store);
+	}
+
+	private long count(ZuliaWorkPool zuliaWorkPool, String indexName) throws Exception {
+		return zuliaWorkPool.search(new Search(indexName).setAmount(0).setRealtime(true)).getTotalHits();
+	}
+
+	private void createIndex(ZuliaWorkPool zuliaWorkPool, String indexName) throws Exception {
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("message");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("message").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.setIndexName(indexName);
+		indexConfig.setNumberOfShards(1);
+		// a small commit interval with 1000-doc seeds means 50 commits per index during seeding, while
+		// the idle commit still fires, which is what the eviction guards care about
+		indexConfig.setShardCommitInterval(1000);
+		indexConfig.setTransientIndex(true);
+		zuliaWorkPool.createIndex(indexConfig);
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/TransientReplicatedIndexTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/TransientReplicatedIndexTest.java
@@ -1,0 +1,102 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.server.node.ZuliaNode;
+import io.zulia.server.test.node.shared.NodeExtension;
+import io.zulia.server.test.node.shared.TestHelper;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.List;
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TransientReplicatedIndexTest {
+
+	private static final String REPLICATED_INDEX = "transientReplicated";
+	private static final String SOLO_INDEX = "transientSolo";
+	private static final int DOCS_PER_INDEX = 30;
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(2, zuliaConfig -> {
+		zuliaConfig.setTransientIndexCacheSize(1);
+		zuliaConfig.setTransientIndexIdleTimeoutSeconds(15);
+	});
+
+	@Test
+	@Order(1)
+	public void createAndIndex() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		createIndex(zuliaWorkPool, REPLICATED_INDEX, 1);
+		createIndex(zuliaWorkPool, SOLO_INDEX, 0);
+
+		for (String indexName : List.of(REPLICATED_INDEX, SOLO_INDEX)) {
+			for (int i = 0; i < DOCS_PER_INDEX; i++) {
+				indexRecord(zuliaWorkPool, indexName, indexName + "-" + i, "message " + i);
+			}
+			Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, indexName));
+		}
+	}
+
+	@Test
+	@Order(2)
+	public void replicatedTransientIndexIsExemptFromEviction() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// idle timeout is 15s: the unreplicated transient index gets evicted everywhere, the replicated one never does
+		long deadline = System.currentTimeMillis() + 120_000;
+		while (System.currentTimeMillis() < deadline && soloResidentOnANode()) {
+			Thread.sleep(1000);
+		}
+
+		Assertions.assertFalse(soloResidentOnANode(), "unreplicated transient index should be evicted after the idle timeout");
+		for (ZuliaNode zuliaNode : TestHelper.getZuliaNodes()) {
+			Assertions.assertTrue(zuliaNode.getIndexManager().getLoadedIndexCache().getResidentIndexNames().contains(REPLICATED_INDEX),
+					"an index with replicas must not be evicted while eviction of replicated indexes is disabled");
+		}
+
+		// both still serve correct results (the evicted one reloads on demand)
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, REPLICATED_INDEX));
+		Assertions.assertEquals(DOCS_PER_INDEX, count(zuliaWorkPool, SOLO_INDEX));
+	}
+
+	private boolean soloResidentOnANode() {
+		return TestHelper.getZuliaNodes().stream().anyMatch(node -> node.getIndexManager().getLoadedIndexCache().getResidentIndexNames().contains(SOLO_INDEX));
+	}
+
+	private long count(ZuliaWorkPool zuliaWorkPool, String indexName) throws Exception {
+		return zuliaWorkPool.search(new Search(indexName).setAmount(0).setRealtime(true)).getTotalHits();
+	}
+
+	private void createIndex(ZuliaWorkPool zuliaWorkPool, String indexName, int replicas) throws Exception {
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("message");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("message").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.setIndexName(indexName);
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setNumberOfReplicas(replicas);
+		indexConfig.setShardCommitInterval(20);
+		indexConfig.setTransientIndex(true);
+		zuliaWorkPool.createIndex(indexConfig);
+	}
+
+	private void indexRecord(ZuliaWorkPool zuliaWorkPool, String index, String uniqueId, String message) throws Exception {
+		Document mongoDocument = new Document();
+		mongoDocument.put("id", uniqueId);
+		mongoDocument.put("message", message);
+		Store store = new Store(uniqueId, index);
+		store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(mongoDocument));
+		zuliaWorkPool.store(store);
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/TransientReplicationSoakTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/TransientReplicationSoakTest.java
@@ -1,0 +1,346 @@
+package io.zulia.server.test.node;
+
+import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Store;
+import io.zulia.client.command.UpdateIndex;
+import io.zulia.client.command.builder.Search;
+import io.zulia.client.config.ClientIndexConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.doc.ResultDocBuilder;
+import io.zulia.fields.FieldConfigBuilder;
+import io.zulia.message.ZuliaBase.PrimaryReplicaSettings;
+import io.zulia.server.node.ZuliaNode;
+import io.zulia.server.test.node.shared.NodeExtension;
+import io.zulia.server.test.node.shared.TestHelper;
+import org.bson.Document;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicIntegerArray;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Replication torture test for transient indexes, run with eviction of replicated indexes ENABLED so
+ * primaries and replicas are constantly unloaded mid-traffic on a 3 node cluster. Every write round
+ * asserts the primary count exactly and then polls every replica to convergence, failing immediately
+ * if a replica ever reports MORE documents than its primary (duplication). Between rounds the replica
+ * count of a rotating index is flipped 1 to 2 and back (bootstrap and drop transitions under eviction,
+ * including transitions reconciled at fault-in time), and a victim index is deleted and recreated. A
+ * full cluster restart mid-soak verifies recovery with nothing resident.
+ * <p>
+ * Excluded from the regular test task by the soak tag. Run with:
+ * ./gradlew :zulia-server:soakTest --tests "io.zulia.server.test.node.TransientReplicationSoakTest"
+ * (duration knob: -Dzulia.soak.minutes, default 60).
+ * <p>
+ * A full 60 minute run passed on 2026-07-14: 339 rounds, ~12200 replica convergence checks, 339 replica
+ * count flips, ~19400 loads and ~18400 evictions cluster-wide, zero duplication or convergence failures.
+ */
+@Tag("soak")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class TransientReplicationSoakTest {
+
+	private static final Logger LOG = LoggerFactory.getLogger(TransientReplicationSoakTest.class);
+
+	private static final int WRITABLE_COUNT = 36;
+	private static final int VICTIM_COUNT = 4;
+	private static final int CACHE_SIZE = 6;
+	private static final int IDLE_TIMEOUT_SECONDS = 20;
+	private static final int SEED_DOCS = 500;
+	private static final int DOCS_PER_WRITE = 10;
+	private static final int WRITER_THREADS = 4;
+	// covers idle commit (5s), a watchdog pass (30s), reload chains, and a fresh replica bootstrap
+	private static final long REPLICA_CONVERGE_MILLIS = 180_000;
+	// create, seed, restart recovery, and the final sweep get this slice of the total budget
+	private static final long RESERVE_MS = 10 * 60_000;
+
+	private static final long SUITE_START_MS = System.currentTimeMillis();
+	private static final long TOTAL_BUDGET_MS = Long.parseLong(System.getProperty("zulia.soak.minutes", "60")) * 60_000;
+
+	private static final AtomicIntegerArray EXPECTED = new AtomicIntegerArray(WRITABLE_COUNT);
+	private static final AtomicIntegerArray VICTIM_EXPECTED = new AtomicIntegerArray(VICTIM_COUNT);
+
+	@RegisterExtension
+	static final NodeExtension nodeExtension = new NodeExtension(3, zuliaConfig -> {
+		zuliaConfig.setTransientIndexCacheSize(CACHE_SIZE);
+		zuliaConfig.setTransientIndexIdleTimeoutSeconds(IDLE_TIMEOUT_SECONDS);
+		zuliaConfig.setTransientIndexEvictReplicated(true);
+	});
+
+	private static String indexName(int i) {
+		return String.format("repsoak-%02d", i);
+	}
+
+	private static String victimName(int v) {
+		return "repsoakvictim-" + v;
+	}
+
+	// every fourth index runs with two replicas so both single and multi replica push paths churn
+	private static int baseReplicas(int i) {
+		return i % 4 == 3 ? 2 : 1;
+	}
+
+	@Test
+	@Order(1)
+	public void createAndSeed() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		for (int i = 0; i < WRITABLE_COUNT; i++) {
+			createIndex(zuliaWorkPool, indexName(i), baseReplicas(i));
+		}
+		for (int v = 0; v < VICTIM_COUNT; v++) {
+			createIndex(zuliaWorkPool, victimName(v), 1);
+		}
+
+		AtomicReference<Throwable> failure = new AtomicReference<>();
+		List<Thread> seeders = new ArrayList<>();
+		for (int t = 0; t < WRITER_THREADS; t++) {
+			int threadIndex = t;
+			seeders.add(Thread.ofVirtual().name("repsoak-seeder-" + t).start(() -> {
+				try {
+					for (int i = threadIndex; i < WRITABLE_COUNT && failure.get() == null; i += WRITER_THREADS) {
+						storeWritableDocs(zuliaWorkPool, i, SEED_DOCS);
+						Assertions.assertEquals(EXPECTED.get(i), primaryCount(zuliaWorkPool, indexName(i)));
+					}
+				}
+				catch (Throwable t2) {
+					failure.compareAndSet(null, t2);
+				}
+			}));
+		}
+		for (Thread seeder : seeders) {
+			seeder.join();
+		}
+		Assertions.assertNull(failure.get(), () -> "seeding failed: " + failure.get());
+
+		for (int v = 0; v < VICTIM_COUNT; v++) {
+			seedVictim(zuliaWorkPool, v);
+		}
+	}
+
+	@Test
+	@Order(2)
+	public void replicationChurn() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		long deadline = SUITE_START_MS + TOTAL_BUDGET_MS - RESERVE_MS;
+		LOG.info("RepSoak: churning for {} minutes", Math.max(0, deadline - System.currentTimeMillis()) / 60_000);
+
+		int round = 0;
+		while (System.currentTimeMillis() < deadline) {
+			round++;
+
+			AtomicReference<Throwable> failure = new AtomicReference<>();
+			List<Thread> writers = new ArrayList<>();
+			for (int t = 0; t < WRITER_THREADS; t++) {
+				int threadIndex = t;
+				writers.add(Thread.ofVirtual().name("repsoak-writer-" + t).start(() -> {
+					try {
+						for (int i = threadIndex; i < WRITABLE_COUNT && failure.get() == null; i += WRITER_THREADS) {
+							storeWritableDocs(zuliaWorkPool, i, DOCS_PER_WRITE);
+							long primaryHits = primaryCount(zuliaWorkPool, indexName(i));
+							if (primaryHits != EXPECTED.get(i)) {
+								failure.compareAndSet(null,
+										new AssertionError("primary expected " + EXPECTED.get(i) + " docs in " + indexName(i) + " but got " + primaryHits));
+								return;
+							}
+						}
+						// every owned replica must converge to exactly the primary's count before the round ends
+						for (int i = threadIndex; i < WRITABLE_COUNT && failure.get() == null; i += WRITER_THREADS) {
+							awaitReplicaConvergence(zuliaWorkPool, indexName(i), EXPECTED.get(i), failure);
+						}
+					}
+					catch (Throwable t2) {
+						failure.compareAndSet(null, t2);
+					}
+				}));
+			}
+			for (Thread writer : writers) {
+				writer.join();
+			}
+			int roundNumber = round;
+			Assertions.assertNull(failure.get(), () -> "round " + roundNumber + " failed: " + failure.get());
+
+			// live topology churn between rounds: flip a rotating single-replica index to two replicas and
+			// back, and delete plus recreate a victim, both while eviction keeps unloading the participants
+			int flipTarget = nextSingleReplicaIndex(round);
+			int flippedReplicas = round % 2 == 1 ? 2 : 1;
+			zuliaWorkPool.updateIndex(new UpdateIndex(indexName(flipTarget)).setNumberOfReplicas(flippedReplicas));
+
+			rotateVictim(zuliaWorkPool, round % VICTIM_COUNT);
+
+			if (round % 4 == 0) {
+				logClusterState(round);
+			}
+		}
+
+		Assertions.assertTrue(round >= 2, "expected at least two churn rounds but ran " + round + "; raise zulia.soak.minutes");
+		LOG.info("RepSoak: churn finished after {} rounds", round);
+	}
+
+	@Test
+	@Order(3)
+	public void fullClusterRestartRecovers() throws Exception {
+		nodeExtension.restartNodes();
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+
+		// nothing is resident after restart, and every primary and every replica must still count exactly
+		AtomicReference<Throwable> failure = new AtomicReference<>();
+		for (int i = 0; i < WRITABLE_COUNT; i++) {
+			Assertions.assertEquals(EXPECTED.get(i), primaryCount(zuliaWorkPool, indexName(i)), "wrong primary count in " + indexName(i) + " after restart");
+			awaitReplicaConvergence(zuliaWorkPool, indexName(i), EXPECTED.get(i), failure);
+			Assertions.assertNull(failure.get(), () -> "replica recovery failed: " + failure.get());
+		}
+		for (int v = 0; v < VICTIM_COUNT; v++) {
+			Assertions.assertEquals(VICTIM_EXPECTED.get(v), primaryCount(zuliaWorkPool, victimName(v)), "wrong victim count after restart");
+		}
+	}
+
+	@Test
+	@Order(4)
+	public void residencyConvergesOnEveryNode() throws Exception {
+		long deadline = System.currentTimeMillis() + 300_000;
+		while (System.currentTimeMillis() < deadline && maxResidentTransient() > CACHE_SIZE) {
+			Thread.sleep(2000);
+		}
+		Assertions.assertTrue(maxResidentTransient() <= CACHE_SIZE, "a node failed to converge to the cap: " + describeResidency());
+	}
+
+	@Test
+	@Order(5)
+	public void finalIntegritySweep() throws Exception {
+		ZuliaWorkPool zuliaWorkPool = nodeExtension.getClient();
+		AtomicReference<Throwable> failure = new AtomicReference<>();
+		for (int i = 0; i < WRITABLE_COUNT; i++) {
+			Assertions.assertEquals(EXPECTED.get(i), primaryCount(zuliaWorkPool, indexName(i)), "wrong primary count in " + indexName(i) + " on final sweep");
+			awaitReplicaConvergence(zuliaWorkPool, indexName(i), EXPECTED.get(i), failure);
+			Assertions.assertNull(failure.get(), () -> "final replica sweep failed: " + failure.get());
+		}
+	}
+
+	/**
+	 * Rotates through the single-replica indexes only, so flips always toggle between 1 and 2 replicas.
+	 */
+	private static int nextSingleReplicaIndex(int round) {
+		int candidate = round % WRITABLE_COUNT;
+		while (baseReplicas(candidate) != 1) {
+			candidate = (candidate + 1) % WRITABLE_COUNT;
+		}
+		return candidate;
+	}
+
+	private void awaitReplicaConvergence(ZuliaWorkPool zuliaWorkPool, String indexName, int expected, AtomicReference<Throwable> failure) {
+		long deadline = System.currentTimeMillis() + REPLICA_CONVERGE_MILLIS;
+		long hits = -1;
+		try {
+			while (System.currentTimeMillis() < deadline && failure.get() == null) {
+				hits = replicaCount(zuliaWorkPool, indexName);
+				if (hits == expected) {
+					return;
+				}
+				if (hits > expected) {
+					failure.compareAndSet(null,
+							new AssertionError("replica of " + indexName + " reports " + hits + " docs but the primary has " + expected + " (duplication)"));
+					return;
+				}
+				Thread.sleep(500);
+			}
+			if (failure.get() == null) {
+				failure.compareAndSet(null, new AssertionError(
+						"replica of " + indexName + " did not converge: " + hits + " of " + expected + " after " + REPLICA_CONVERGE_MILLIS + "ms"));
+			}
+		}
+		catch (Throwable t) {
+			failure.compareAndSet(null, t);
+		}
+	}
+
+	private void rotateVictim(ZuliaWorkPool zuliaWorkPool, int victim) throws Exception {
+		zuliaWorkPool.deleteIndex(victimName(victim));
+		VICTIM_EXPECTED.set(victim, 0);
+		createIndex(zuliaWorkPool, victimName(victim), 1);
+		seedVictim(zuliaWorkPool, victim);
+	}
+
+	private void seedVictim(ZuliaWorkPool zuliaWorkPool, int victim) throws Exception {
+		String name = victimName(victim);
+		for (int d = 0; d < SEED_DOCS / 10; d++) {
+			indexRecord(zuliaWorkPool, name, name + "-doc-" + VICTIM_EXPECTED.get(victim), "victim message");
+			VICTIM_EXPECTED.incrementAndGet(victim);
+		}
+		Assertions.assertEquals(VICTIM_EXPECTED.get(victim), primaryCount(zuliaWorkPool, name), "wrong count in recreated " + name);
+	}
+
+	private void storeWritableDocs(ZuliaWorkPool zuliaWorkPool, int index, int docCount) throws Exception {
+		String name = indexName(index);
+		for (int d = 0; d < docCount; d++) {
+			indexRecord(zuliaWorkPool, name, name + "-doc-" + EXPECTED.get(index), "message " + EXPECTED.get(index));
+			EXPECTED.incrementAndGet(index);
+		}
+	}
+
+	private void indexRecord(ZuliaWorkPool zuliaWorkPool, String index, String uniqueId, String message) throws Exception {
+		Document mongoDocument = new Document();
+		mongoDocument.put("id", uniqueId);
+		mongoDocument.put("message", message);
+		Store store = new Store(uniqueId, index);
+		store.setResultDocument(ResultDocBuilder.newBuilder().setDocument(mongoDocument));
+		zuliaWorkPool.store(store);
+	}
+
+	private long primaryCount(ZuliaWorkPool zuliaWorkPool, String indexName) throws Exception {
+		return zuliaWorkPool.search(new Search(indexName).setAmount(0).setRealtime(true).setPrimaryReplicaSettings(PrimaryReplicaSettings.PRIMARY_ONLY))
+				.getTotalHits();
+	}
+
+	private long replicaCount(ZuliaWorkPool zuliaWorkPool, String indexName) throws Exception {
+		return zuliaWorkPool.search(new Search(indexName).setAmount(0).setRealtime(true).setPrimaryReplicaSettings(PrimaryReplicaSettings.REPLICA_ONLY))
+				.getTotalHits();
+	}
+
+	private long maxResidentTransient() {
+		long max = 0;
+		for (ZuliaNode zuliaNode : TestHelper.getZuliaNodes()) {
+			max = Math.max(max, zuliaNode.getIndexManager().getLoadedIndexCache().getResidentCount());
+		}
+		return max;
+	}
+
+	private String describeResidency() {
+		StringBuilder description = new StringBuilder();
+		for (ZuliaNode zuliaNode : TestHelper.getZuliaNodes()) {
+			description.append(zuliaNode.getIndexManager().getLoadedIndexCache().getResidentIndexNames()).append(" ");
+		}
+		return description.toString();
+	}
+
+	private void logClusterState(int round) {
+		StringBuilder state = new StringBuilder();
+		for (ZuliaNode zuliaNode : TestHelper.getZuliaNodes()) {
+			var cache = zuliaNode.getIndexManager().getLoadedIndexCache();
+			state.append(cache.getResidentCount()).append(" resident/").append(cache.getLoadCount()).append(" loads/").append(cache.getEvictionCount())
+					.append(" evictions  ");
+		}
+		LOG.info("RepSoak: round {} cluster state: {}", round, state);
+	}
+
+	private void createIndex(ZuliaWorkPool zuliaWorkPool, String indexName, int replicas) throws Exception {
+		ClientIndexConfig indexConfig = new ClientIndexConfig();
+		indexConfig.addDefaultSearchField("message");
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("id").indexAs(DefaultAnalyzers.LC_KEYWORD).sort());
+		indexConfig.addFieldConfig(FieldConfigBuilder.createString("message").indexAs(DefaultAnalyzers.STANDARD));
+		indexConfig.setIndexName(indexName);
+		indexConfig.setNumberOfShards(1);
+		indexConfig.setNumberOfReplicas(replicas);
+		indexConfig.setShardCommitInterval(1000);
+		indexConfig.setTransientIndex(true);
+		zuliaWorkPool.createIndex(indexConfig);
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/shared/FsNodeExtension.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/shared/FsNodeExtension.java
@@ -1,0 +1,115 @@
+package io.zulia.server.test.node.shared;
+
+import io.zulia.client.config.ZuliaPoolConfig;
+import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.message.ZuliaBase;
+import io.zulia.server.config.ZuliaConfig;
+import io.zulia.server.config.single.SingleNodeService;
+import io.zulia.server.node.ZuliaNode;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.function.Consumer;
+
+/**
+ * Starts a single Zulia node in filesystem mode (cluster false): FSIndexService for index metadata,
+ * FileDocumentStorage for associated documents, and no MongoDB. Complements {@link NodeExtension},
+ * which only covers cluster mode. Data persists across {@link #restartNode()} within one suite and is
+ * wiped before the suite starts.
+ */
+public class FsNodeExtension implements BeforeAllCallback, AfterAllCallback {
+
+	private final static Logger LOG = LoggerFactory.getLogger(FsNodeExtension.class);
+
+	private static final String BASE_PATH = "/tmp/zuliaTestFs";
+	private static final String DATA_PATH = BASE_PATH + "/node0";
+	private static final int SERVICE_PORT = 21191;
+	private static final int REST_PORT = 21192;
+
+	private final Consumer<ZuliaConfig> configCustomizer;
+
+	private ZuliaNode zuliaNode;
+	private ZuliaWorkPool zuliaWorkPool;
+
+	public FsNodeExtension() {
+		this(null);
+	}
+
+	public FsNodeExtension(Consumer<ZuliaConfig> configCustomizer) {
+		this.configCustomizer = configCustomizer;
+	}
+
+	public ZuliaWorkPool getClient() {
+		return zuliaWorkPool;
+	}
+
+	public ZuliaNode getNode() {
+		return zuliaNode;
+	}
+
+	public String getDataPath() {
+		return DATA_PATH;
+	}
+
+	@Override
+	public void beforeAll(ExtensionContext context) throws Exception {
+		LOG.info("FS mode suite started: {}", context.getTestClass().orElse(null));
+		deleteBaseDir();
+		Files.createDirectories(Path.of(DATA_PATH));
+		startNode();
+		Thread.sleep(2000);
+
+		ZuliaPoolConfig zuliaPoolConfig = new ZuliaPoolConfig();
+		zuliaPoolConfig.addNode(ZuliaBase.Node.newBuilder().setServerAddress("localhost").setServicePort(SERVICE_PORT).setRestPort(REST_PORT).build());
+		zuliaWorkPool = new ZuliaWorkPool(zuliaPoolConfig);
+	}
+
+	@Override
+	public void afterAll(ExtensionContext context) {
+		if (zuliaNode != null) {
+			zuliaNode.shutdown();
+		}
+		if (zuliaWorkPool != null) {
+			zuliaWorkPool.close();
+		}
+		LOG.info("FS mode suite finished: {}", context.getTestClass().orElse(null));
+	}
+
+	public void restartNode() throws Exception {
+		zuliaNode.shutdown();
+		Thread.sleep(2000);
+		startNode();
+		Thread.sleep(2000);
+	}
+
+	private void startNode() throws Exception {
+		ZuliaConfig zuliaConfig = new ZuliaConfig();
+		zuliaConfig.setServerAddress("localhost");
+		zuliaConfig.setCluster(false);
+		zuliaConfig.setDataPath(DATA_PATH);
+		zuliaConfig.setServicePort(SERVICE_PORT);
+		zuliaConfig.setRestPort(REST_PORT);
+		if (configCustomizer != null) {
+			configCustomizer.accept(zuliaConfig);
+		}
+		zuliaNode = new ZuliaNode(zuliaConfig, new SingleNodeService(zuliaConfig));
+		zuliaNode.start(false);
+	}
+
+	private void deleteBaseDir() throws IOException {
+		Path basePath = Path.of(BASE_PATH);
+		if (Files.exists(basePath)) {
+			try (var paths = Files.walk(basePath)) {
+				paths.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+			}
+		}
+	}
+}

--- a/zulia-server/src/test/java/io/zulia/server/test/node/shared/NodeExtension.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/shared/NodeExtension.java
@@ -68,7 +68,7 @@ public class NodeExtension implements BeforeAllCallback, AfterAllCallback, Befor
 	public void restartNodes() throws Exception {
 		TestHelper.stopNodes();
 		Thread.sleep(2000);
-		TestHelper.startNodes(false); // micronaut does not like starting again on the same port
+		TestHelper.startNodes(false, configCustomizer); // micronaut does not like starting again on the same port
 		Thread.sleep(2000);
 	}
 }

--- a/zulia-server/src/test/java/io/zulia/server/test/node/shared/TestHelper.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/shared/TestHelper.java
@@ -85,6 +85,10 @@ public class TestHelper {
 
 	}
 
+	public static List<ZuliaNode> getZuliaNodes() {
+		return List.copyOf(ZULIA_NODES);
+	}
+
 	public static void startNodes(boolean startRest) throws Exception {
 		startNodes(startRest, null);
 	}

--- a/zulia-tools/src/main/java/io/zulia/tools/cmd/zuliaadmin/UpdateIndexCmd.java
+++ b/zulia-tools/src/main/java/io/zulia/tools/cmd/zuliaadmin/UpdateIndexCmd.java
@@ -69,6 +69,9 @@ public class UpdateIndexCmd implements Callable<Integer> {
 	@CommandLine.Option(names = "--disableCompression", arity = "1", paramLabel = "true|false", description = "When true, disables compression of stored documents (default false)")
 	private Boolean disableCompression;
 
+	@CommandLine.Option(names = "--transientIndex", arity = "1", paramLabel = "true|false", description = "When true the index loads lazily and can be unloaded when idle or over the node's transient cache bound (default false)")
+	private Boolean transientIndex;
+
 	@Override
 	public Integer call() throws Exception {
 
@@ -142,6 +145,9 @@ public class UpdateIndexCmd implements Callable<Integer> {
 		}
 		if (disableCompression != null) {
 			updateIndex.setDisableCompression(disableCompression);
+		}
+		if (transientIndex != null) {
+			updateIndex.setTransientIndex(transientIndex);
 		}
 
 		return updateIndex;

--- a/zulia-ui-rest/src/test/java/io/zulia/ui/rest/AccessTokenExpiredTest.java
+++ b/zulia-ui-rest/src/test/java/io/zulia/ui/rest/AccessTokenExpiredTest.java
@@ -11,6 +11,7 @@ import io.micronaut.security.endpoints.TokenRefreshRequest;
 import io.micronaut.security.token.render.AccessRefreshToken;
 import io.micronaut.security.token.render.BearerAccessRefreshToken;
 import io.zulia.ui.rest.beans.UserEntity;
+import io.zulia.ui.rest.persistence.MongoUserPersistence;
 import io.zulia.ui.rest.persistence.RefreshTokenRepository;
 import org.junit.jupiter.api.Test;
 
@@ -35,14 +36,7 @@ public class AccessTokenExpiredTest {
 	@Test
 	public void verifyJWTAccessTokenRefreshWorks() throws InterruptedException {
 
-		{
-			// create user
-			UserEntity user = new UserEntity();
-			user.setUsername("zulia-test");
-			user.setPassword("password");
-			HttpRequest<?> request = HttpRequest.POST("/zuliauirest/create-user", user); // <4>
-			HttpResponse<BearerAccessRefreshToken> rsp = client.toBlocking().exchange(request, BearerAccessRefreshToken.class);
-		}
+		TestUsers.ensureTestUser(embeddedServer);
 
 		{
 			// Login to obtain an access token

--- a/zulia-ui-rest/src/test/java/io/zulia/ui/rest/DeclarativeHttpClientWithJwtTest.java
+++ b/zulia-ui-rest/src/test/java/io/zulia/ui/rest/DeclarativeHttpClientWithJwtTest.java
@@ -7,6 +7,7 @@ import io.micronaut.runtime.server.EmbeddedServer;
 import io.micronaut.security.authentication.UsernamePasswordCredentials;
 import io.micronaut.security.token.render.BearerAccessRefreshToken;
 import io.zulia.ui.rest.beans.UserEntity;
+import io.zulia.ui.rest.persistence.MongoUserPersistence;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
@@ -26,11 +27,7 @@ public class DeclarativeHttpClientWithJwtTest {
 	@Test
 	void verifyJwtAuthenticationWorksWithDeclarativeClient() throws ParseException {
 
-		// create user
-		UserEntity user = new UserEntity();
-		user.setUsername("zulia-test");
-		user.setPassword("password");
-		appClient.createUser(user);
+		TestUsers.ensureTestUser(embeddedServer);
 
 		UsernamePasswordCredentials creds = new UsernamePasswordCredentials(USERNAME, PASSWORD);
 		BearerAccessRefreshToken loginRsp = appClient.login(creds);

--- a/zulia-ui-rest/src/test/java/io/zulia/ui/rest/JwtAuthenticationTest.java
+++ b/zulia-ui-rest/src/test/java/io/zulia/ui/rest/JwtAuthenticationTest.java
@@ -57,14 +57,7 @@ public class JwtAuthenticationTest {
 
 	@Test
 	void uponSuccessfulAuthenticationAJsonWebTokenIsIssuedToTheUser() throws ParseException {
-		{
-			// create user
-			UserEntity user = new UserEntity();
-			user.setUsername("zulia-test");
-			user.setPassword("password");
-			HttpRequest<?> request = HttpRequest.POST("/zuliauirest/create-user", user); // <4>
-			HttpResponse<BearerAccessRefreshToken> rsp = client.toBlocking().exchange(request, BearerAccessRefreshToken.class);
-		}
+		TestUsers.ensureTestUser(embeddedServer);
 
 		UsernamePasswordCredentials creds = new UsernamePasswordCredentials(USERNAME, PASSWORD);
 		HttpRequest<?> request = HttpRequest.POST("/zuliauirest/login", creds); // <4>

--- a/zulia-ui-rest/src/test/java/io/zulia/ui/rest/LoginIncludesRefreshTokenTest.java
+++ b/zulia-ui-rest/src/test/java/io/zulia/ui/rest/LoginIncludesRefreshTokenTest.java
@@ -28,14 +28,7 @@ public class LoginIncludesRefreshTokenTest {
 
 	@Test
 	void uponSuccessfulAuthenticationUserGetsAccessTokenAndRefreshToken() throws ParseException {
-		{
-			// create user
-			UserEntity user = new UserEntity();
-			user.setUsername("zulia-test");
-			user.setPassword("password");
-			HttpRequest<?> request = HttpRequest.POST("/zuliauirest/create-user", user); // <4>
-			HttpResponse<BearerAccessRefreshToken> rsp = client.toBlocking().exchange(request, BearerAccessRefreshToken.class);
-		}
+		TestUsers.ensureTestUser(embeddedServer);
 
 		UsernamePasswordCredentials creds = new UsernamePasswordCredentials(USERNAME, PASSWORD);
 		HttpRequest<?> request = HttpRequest.POST("/zuliauirest/login", creds);

--- a/zulia-ui-rest/src/test/java/io/zulia/ui/rest/OauthAccessTokenTest.java
+++ b/zulia-ui-rest/src/test/java/io/zulia/ui/rest/OauthAccessTokenTest.java
@@ -30,14 +30,7 @@ public class OauthAccessTokenTest {
 	@Test
 	void verifyJWTAccessTokenRefreshWorks() throws InterruptedException {
 
-		{
-			// create user
-			UserEntity user = new UserEntity();
-			user.setUsername("zulia-test");
-			user.setPassword("password");
-			HttpRequest<?> request = HttpRequest.POST("/zuliauirest/create-user", user); // <4>
-			HttpResponse<BearerAccessRefreshToken> rsp = client.toBlocking().exchange(request, BearerAccessRefreshToken.class);
-		}
+		TestUsers.ensureTestUser(embeddedServer);
 
 		UsernamePasswordCredentials creds = new UsernamePasswordCredentials(USERNAME, PASSWORD);
 		HttpRequest<?> request = HttpRequest.POST("/zuliauirest/login", creds);

--- a/zulia-ui-rest/src/test/java/io/zulia/ui/rest/TestUsers.java
+++ b/zulia-ui-rest/src/test/java/io/zulia/ui/rest/TestUsers.java
@@ -1,0 +1,24 @@
+package io.zulia.ui.rest;
+
+import io.micronaut.runtime.server.EmbeddedServer;
+import io.zulia.ui.rest.beans.UserEntity;
+import io.zulia.ui.rest.persistence.MongoUserPersistence;
+
+import static io.zulia.ui.rest.TestConstants.PASSWORD;
+import static io.zulia.ui.rest.TestConstants.USERNAME;
+
+public final class TestUsers {
+
+	private TestUsers() {
+	}
+
+	public static void ensureTestUser(EmbeddedServer embeddedServer) {
+		MongoUserPersistence persistence = embeddedServer.getApplicationContext().getBean(MongoUserPersistence.class);
+		if (persistence.getUser(USERNAME) == null) {
+			UserEntity user = new UserEntity();
+			user.setUsername(USERNAME);
+			user.setPassword(PASSWORD);
+			persistence.createUser(user);
+		}
+	}
+}


### PR DESCRIPTION
# Add transient indexes with lazy loading and eviction

## Summary

Adds a per-index transientIndex flag (default false). Existing and unflagged indexes load at startup and stay resident exactly as before. Flagged indexes load lazily on first use and can be unloaded when idle or when the node is over its transient cache bound, then reload on demand. This lets a node serve far more indexes than it can keep open at once.

## How it works

- New ZuliaConfig settings: transientIndexCacheSize, transientIndexIdleTimeoutSeconds, and transientIndexEvictReplicated (default false, so replicated indexes are never evicted unless opted in)
- LoadedIndexCache (io.zulia.server.index.resident) keeps a registry of every defined index independent of residency for routing, wildcards, aliases, and settings reads. Every operation holds its index through a lease so eviction defers to in-flight work
- Explicit evictor with an ACTIVE/DRAINING/CLOSED handle state machine. Candidates must be transient, lease-free, committed, past minimum residency, and unreplicated unless eviction of replicated indexes is enabled
- Deleting or updating an unloaded index faults it in for on-disk cleanup, and every fault-in reconciles shard mapping transitions from the last applied mapping
- Settable via ClientIndexConfig, UpdateIndex, and zuliaadmin updateIndex --transientIndex
- IndexStats gains a resident flag and NodeStats gains resident, load, and eviction counters

## Bug fixes found along the way

- NodeRequestFederator.send now joins every subtask before throwing, with later failures added as suppressed exceptions, so a still-running subtask can no longer outlive its request's index lease
- Fixed resource leaks on the load and unload paths: an FSIndexService FileReader per settings read, a leaked IndexWriter and write.lock when a load failed partway, and skipped closes after a rollback failure (now Lucene's IOUtils.close)
- Hardened connection lifecycle against close races: InternalRpcConnection no longer nulls its channel on close and escalates to shutdownNow on timeout, and ZuliaPool rejects new work before draining and preserves a command's real failure instead of converting it into a pool-closed error
- Fixed the zulia-ui-rest JWT tests broken by the create-user endpoint lockdown

Testing

- TransientIndexLoaderTest: eviction under the cache bound, reload correctness, lazy loading after restart, delete of an unloaded index, and flipping transientIndex through updateIndex
- TransientReplicatedIndexTest: with the default settings, a replicated transient index stays resident while an unreplicated one evicts, and both serve exact counts
- TransientEvictReplicatedTest: with transientIndexEvictReplicated enabled, a replicated index evicts on idle, faults back in on write, and its replica catches up
- FsNodeExtension and FsTransientIndexTest: single node filesystem mode (no MongoDB) with a per-reload file descriptor leak check
- TransientIndexScaleTest: 100 indexes against a cap of 10 with concurrent writers, readers, victim delete and recreate, and wildcard fault-in sweeps
- Hour-scale soak tests behind a soak tag with a new :zulia-server:soakTest task: TransientIndexSoakTest (5000 indexes, ~5M documents, cap 100) and TransientReplicationSoakTest (3 nodes, eviction of replicated indexes enabled, asserting every replica converges to exactly its primary's count through replica flips and a mid-soak cluster restart). Both passed full one hour runs with zero count violations
