### PR TITLE
Serve fetch from replica shards

### DIFF
--- a/zulia-client/src/main/java/io/zulia/client/command/Fetch.java
+++ b/zulia-client/src/main/java/io/zulia/client/command/Fetch.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import io.zulia.message.ZuliaBase.PrimaryReplicaSettings;
+
 import static io.zulia.message.ZuliaQuery.FetchType;
 import static io.zulia.message.ZuliaServiceGrpc.ZuliaServiceBlockingStub;
 import static io.zulia.message.ZuliaServiceOuterClass.FetchRequest;
@@ -26,6 +28,7 @@ public class Fetch extends SimpleCommand<FetchRequest, FetchResult> implements S
 	private Set<String> documentMaskedFields = Collections.emptySet();
 
 	private Boolean realtime;
+	private PrimaryReplicaSettings primaryReplicaSettings;
 
 	public Fetch(String uniqueId, String indexName) {
 		this.uniqueId = uniqueId;
@@ -93,6 +96,15 @@ public class Fetch extends SimpleCommand<FetchRequest, FetchResult> implements S
 		return this;
 	}
 
+	public PrimaryReplicaSettings getPrimaryReplicaSettings() {
+		return primaryReplicaSettings;
+	}
+
+	public Fetch setPrimaryReplicaSettings(PrimaryReplicaSettings primaryReplicaSettings) {
+		this.primaryReplicaSettings = primaryReplicaSettings;
+		return this;
+	}
+
 	public Boolean getRealtime() {
 		return realtime;
 	}
@@ -122,6 +134,9 @@ public class Fetch extends SimpleCommand<FetchRequest, FetchResult> implements S
 		}
 		if (realtime != null) {
 			fetchRequestBuilder.setRealtime(realtime);
+		}
+		if (primaryReplicaSettings != null) {
+			fetchRequestBuilder.setPrimaryReplicaSettings(primaryReplicaSettings);
 		}
 
 		fetchRequestBuilder.addAllDocumentFields(documentFields);

--- a/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
+++ b/zulia-server/src/main/java/io/zulia/server/index/ZuliaIndex.java
@@ -456,6 +456,26 @@ public class ZuliaIndex {
 		return zuliaShard;
 	}
 
+	/**
+	 * Read-path lookup: routing already chose this node under the request's primary/replica settings, and a
+	 * node holds a shard in at most one role, so serve from whichever role this node has. Writes must keep
+	 * using {@link #findShardFromUniqueId}, which is primary-only.
+	 */
+	private ZuliaShard findShardForRead(int shardNumber) throws ShardDoesNotExistException {
+		ZuliaShard zuliaShard = primaryShardMap.get(shardNumber);
+		if (zuliaShard == null) {
+			zuliaShard = replicaShardMap.get(shardNumber);
+		}
+		if (zuliaShard == null) {
+			throw new ShardDoesNotExistException(indexName, shardNumber);
+		}
+		return zuliaShard;
+	}
+
+	private ZuliaShard findShardForReadFromUniqueId(String uniqueId) throws ShardDoesNotExistException {
+		return findShardForRead(ShardUtil.findShardForUniqueId(uniqueId, numberOfShards));
+	}
+
 	public DeleteResponse deleteDocument(DeleteRequest deleteRequest) throws Exception {
 
 		String uniqueId = deleteRequest.getUniqueId();
@@ -1402,17 +1422,14 @@ public class ZuliaIndex {
 	private ResultDocument getSourceDocument(String uniqueId, FetchType resultFetchType, List<String> fieldsToReturn, List<String> fieldsToMask,
 			boolean realtime) throws Exception {
 
-		ZuliaShard s = findShardFromUniqueId(uniqueId);
+		ZuliaShard s = findShardForReadFromUniqueId(uniqueId);
 		return s.getSourceDocument(uniqueId, resultFetchType, fieldsToReturn, fieldsToMask, realtime);
 
 	}
 
 	public List<FetchResponse> internalShardBatchFetch(InternalShardBatchFetchRequest shardRequest) throws Exception {
 		int shardNumber = shardRequest.getShardNumber();
-		ZuliaShard shard = primaryShardMap.get(shardNumber);
-		if (shard == null) {
-			throw new ShardDoesNotExistException(indexName, shardNumber);
-		}
+		ZuliaShard shard = findShardForRead(shardNumber);
 
 		List<String> uniqueIds = shardRequest.getUniqueIdList();
 		FetchType resultFetchType = shardRequest.getResultFetchType();

--- a/zulia-server/src/test/java/io/zulia/server/test/node/ReplicationTest.java
+++ b/zulia-server/src/test/java/io/zulia/server/test/node/ReplicationTest.java
@@ -1,15 +1,18 @@
 package io.zulia.server.test.node;
 
 import io.zulia.DefaultAnalyzers;
+import io.zulia.client.command.Fetch;
 import io.zulia.client.command.Store;
 import io.zulia.client.command.builder.ScoredQuery;
 import io.zulia.client.command.builder.Search;
 import io.zulia.client.config.ClientIndexConfig;
 import io.zulia.client.pool.ZuliaWorkPool;
+import io.zulia.client.result.FetchResult;
 import io.zulia.client.result.SearchResult;
 import io.zulia.doc.ResultDocBuilder;
 import io.zulia.fields.FieldConfigBuilder;
 import io.zulia.message.ZuliaBase.PrimaryReplicaSettings;
+import io.zulia.message.ZuliaQuery.FetchType;
 import io.zulia.server.test.node.shared.RestNodeExtension;
 import org.bson.Document;
 import org.junit.jupiter.api.Assertions;
@@ -122,6 +125,22 @@ public class ReplicationTest {
 
 	@Test
 	@Order(6)
+	public void fetchByIdFromReplicaServesDocument() throws Exception {
+		// fetch execution used to consult only the primary shard map, so a fetch routed to the replica node
+		// failed with ShardDoesNotExistException for a shard the node actually hosts
+		Fetch fetch = new Fetch("42", INDEX).setResultFetchType(FetchType.FULL).setPrimaryReplicaSettings(PrimaryReplicaSettings.REPLICA_ONLY);
+		FetchResult result = nodeExtension.getGrpcClient().fetch(fetch);
+		Assertions.assertTrue(result.hasResultDocument(), "replica must serve the fetched document");
+		Assertions.assertEquals(42, result.getDocument().getInteger("seq"), "replica fetch must return the right document");
+
+		// the fallback mode must work from either role too
+		Fetch fallback = new Fetch("42", INDEX).setResultFetchType(FetchType.FULL)
+				.setPrimaryReplicaSettings(PrimaryReplicaSettings.PRIMARY_IF_AVAILABLE);
+		Assertions.assertTrue(nodeExtension.getGrpcClient().fetch(fallback).hasResultDocument(), "primary-if-available fetch must return the document");
+	}
+
+	@Test
+	@Order(7)
 	public void replicationStateEndpointReportsProgress() throws Exception {
 		// Both nodes return the full shard mapping, but only the primary has lastAttemptedGeneration set.
 		// Find the node that actually owns the primary by matching that field in the body.


### PR DESCRIPTION
Fetch routing honors REPLICA_ONLY and PRIMARY_IF_AVAILABLE and selects the replica node, but
execution looked the shard up only in the primary shard map, so every replica-routed fetch failed
with a misleading ShardDoesNotExistException for a shard the node actually hosts. Fetch by id was
therefore unavailable during a primary outage in exactly the fallback mode meant to survive it.

ZuliaIndex gains a read-path lookup that serves the shard from whichever role this node holds
(routing already chose the node under the request's settings, and a node holds a shard in at most
one role). getSourceDocument and internalShardBatchFetch use it. Writes keep the primary-only
lookup.

The client Fetch command gains setPrimaryReplicaSettings, matching what Search already exposes, so
callers can actually reach replicas for fetch.

ReplicationTest gains fetch-by-id coverage from the replica in REPLICA_ONLY and
PRIMARY_IF_AVAILABLE modes.