### PR TITLE
Parse Date and Boolean list elements and read blank cells as null

### DIFF
--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/CellParsers.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/CellParsers.java
@@ -1,0 +1,75 @@
+package io.zulia.data.source.spreadsheet;
+
+import io.zulia.util.BooleanUtil;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * How cell text is read as a Boolean or a Date, and how a Date is written back as text.
+ * One instance is shared by whole-cell reads and by {@link DefaultDelimitedListHandler}, so a value is read the same way
+ * whether it fills a cell or is one element of a delimited list, and a Date list element is written in the form the
+ * date parser reads.
+ *
+ * @param booleanParser parses one trimmed element or cell. Unrecognised text may map to null
+ * @param dateParser    parses one trimmed element or cell. Unparseable text should throw
+ * @param dateFormatter writes a Date as text the date parser reads back
+ */
+public record CellParsers(Function<String, Boolean> booleanParser, Function<String, Date> dateParser, Function<Date, String> dateFormatter) {
+
+	private static final CellParsers DEFAULTS = new CellParsers(BooleanUtil::parseBoolean, isoDateParser(ZoneId.systemDefault()),
+			isoDateFormatter(ZoneId.systemDefault()));
+
+	public CellParsers {
+		Objects.requireNonNull(booleanParser, "booleanParser");
+		Objects.requireNonNull(dateParser, "dateParser");
+		Objects.requireNonNull(dateFormatter, "dateFormatter");
+	}
+
+	/**
+	 * Keeps the default ISO date formatter, which reads back through the default date parser.
+	 */
+	public CellParsers(Function<String, Boolean> booleanParser, Function<String, Date> dateParser) {
+		this(booleanParser, dateParser, DEFAULTS.dateFormatter());
+	}
+
+	/**
+	 * {@link BooleanUtil#parseBoolean(String)} for booleans and ISO date time in the system default zone for dates, read and written.
+	 */
+	public static CellParsers defaults() {
+		return DEFAULTS;
+	}
+
+	/**
+	 * ISO date time with an optional offset or zone id, for example 2024-12-18T08:00:00Z[Etc/UTC] as written by the date target handlers.
+	 * A value without an offset or zone is read in the given zone.
+	 */
+	public static Function<String, Date> isoDateParser(ZoneId zoneId) {
+		DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME.withZone(zoneId);
+		return (s) -> Date.from(Instant.from(formatter.parse(s)));
+	}
+
+	/**
+	 * ISO date time with the offset and zone id, for example 2024-12-18T08:00:00Z[Etc/UTC], which {@link #isoDateParser(ZoneId)} reads.
+	 */
+	public static Function<Date, String> isoDateFormatter(ZoneId zoneId) {
+		DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME.withZone(zoneId);
+		return (date) -> formatter.format(date.toInstant());
+	}
+
+	public CellParsers withBooleanParser(Function<String, Boolean> booleanParser) {
+		return new CellParsers(booleanParser, dateParser, dateFormatter);
+	}
+
+	public CellParsers withDateParser(Function<String, Date> dateParser) {
+		return new CellParsers(booleanParser, dateParser, dateFormatter);
+	}
+
+	public CellParsers withDateFormatter(Function<Date, String> dateFormatter) {
+		return new CellParsers(booleanParser, dateParser, dateFormatter);
+	}
+}

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/DefaultDelimitedListHandler.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/DefaultDelimitedListHandler.java
@@ -1,48 +1,80 @@
 package io.zulia.data.source.spreadsheet;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Splits a cell on the list delimiter and converts each element to the requested class.
+ * Numeric elements use the JDK parsers. Date and Boolean elements use the {@link CellParsers} of the source config, so they follow
+ * the same rules as {@link SpreadsheetRecord#getDate(int)} and {@link SpreadsheetRecord#getBoolean(int)}. For every class but
+ * String an element is trimmed before it is converted and a blank element becomes a null placeholder, so positions line up with
+ * sibling list columns and {@link #collectionToCellValue} writes the list back the way it was read. A blank whole cell reads as an
+ * empty list, matching how a blank whole cell reads as null for a single value. String lists keep every element as written.
+ */
 public class DefaultDelimitedListHandler implements DelimitedListHandler {
 
 	private final char listDelimiter;
+	private final Map<Class<?>, Function<String, ?>> converters;
+	private final Function<Date, String> dateFormatter;
 
 	public DefaultDelimitedListHandler(char listDelimiter) {
-		this.listDelimiter = listDelimiter;
+		this(listDelimiter, CellParsers.defaults());
 	}
 
-	@SuppressWarnings("unchecked")
-	public <T> List<T> cellValueToList(Class<T> clazz, String cellValue) {
-		if (cellValue != null) {
-			Stream<String> listStream = Splitter.on(listDelimiter).splitToStream(cellValue);
-			if (clazz.equals(String.class)) {
-				return (List<T>) listStream.toList();
-			}
-			else if (clazz.equals(Integer.class)) {
-				return (List<T>) listStream.map(Integer::parseInt).toList();
-			}
-			else if (clazz.equals(Long.class)) {
-				return (List<T>) listStream.map(Long::parseLong).toList();
-			}
-			else if (clazz.equals(Float.class)) {
-				return (List<T>) listStream.map(Float::parseFloat).toList();
-			}
-			else if (clazz.equals(Double.class)) {
-				return (List<T>) listStream.map(Double::parseDouble).toList();
-			}
-			else {
-				throw new IllegalArgumentException("Unsupported clazz " + clazz);
-			}
-		}
-		return null;
+	public DefaultDelimitedListHandler(char listDelimiter, CellParsers parsers) {
+		this.listDelimiter = listDelimiter;
+		this.dateFormatter = parsers.dateFormatter();
+		this.converters = Map.of(
+				String.class, Function.identity(),
+				Integer.class, Integer::parseInt,
+				Long.class, Long::parseLong,
+				Float.class, Float::parseFloat,
+				Double.class, Double::parseDouble,
+				Date.class, parsers.dateParser(),
+				Boolean.class, parsers.booleanParser());
 	}
 
 	@Override
+	public <T> List<T> cellValueToList(Class<T> clazz, String cellValue) {
+		if (cellValue == null) {
+			return null;
+		}
+		Function<String, ?> converter = converters.get(clazz);
+		if (converter == null) {
+			throw new IllegalArgumentException("Unsupported class " + clazz);
+		}
+		if (clazz.equals(String.class)) {
+			return Splitter.on(listDelimiter).splitToStream(cellValue).map(clazz::cast).toList();
+		}
+		if (cellValue.isBlank()) {
+			return List.of();
+		}
+		Stream<String> elements = Splitter.on(listDelimiter).splitToStream(cellValue).map(String::trim);
+		return elements.map(element -> element.isEmpty() ? null : converter.apply(element)).map(clazz::cast).toList();
+	}
+
+	/**
+	 * Joins the elements with the list delimiter. A null element is written as a blank, so it reads back as a null placeholder,
+	 * and a Date is written with the date formatter so it reads back through the date parser. Other elements use toString,
+	 * which the numeric parsers and the default boolean parser read.
+	 */
+	@Override
 	public String collectionToCellValue(Collection<?> collection) {
-		return Joiner.on(listDelimiter).useForNull("").join(collection);
+		return collection.stream().map(this::elementToText).collect(Collectors.joining(String.valueOf(listDelimiter)));
+	}
+
+	private String elementToText(Object element) {
+		return switch (element) {
+			case null -> "";
+			case Date date -> dateFormatter.apply(date);
+			default -> element.toString();
+		};
 	}
 }

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/DelimitedListSettings.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/DelimitedListSettings.java
@@ -1,0 +1,48 @@
+package io.zulia.data.source.spreadsheet;
+
+import java.util.Objects;
+
+/**
+ * The delimited list configuration shared by the delimited and excel source configs: the list delimiter, the cell parsers and
+ * the list handler. The handler is either one set explicitly or the default handler built from the delimiter and parsers.
+ * Setting the delimiter drops an explicit handler, as the source configs always did, while a parser change keeps it.
+ */
+public final class DelimitedListSettings {
+
+	private char listDelimiter = ';';
+	private CellParsers parsers = CellParsers.defaults();
+	private DelimitedListHandler explicitHandler;
+	private DefaultDelimitedListHandler builtHandler;
+
+	public DelimitedListSettings withListDelimiter(char listDelimiter) {
+		this.listDelimiter = listDelimiter;
+		this.explicitHandler = null;
+		this.builtHandler = null;
+		return this;
+	}
+
+	public DelimitedListSettings withHandler(DelimitedListHandler handler) {
+		this.explicitHandler = Objects.requireNonNull(handler, "handler");
+		return this;
+	}
+
+	public DelimitedListSettings withParsers(CellParsers parsers) {
+		this.parsers = Objects.requireNonNull(parsers, "parsers");
+		this.builtHandler = null;
+		return this;
+	}
+
+	public CellParsers getParsers() {
+		return parsers;
+	}
+
+	public DelimitedListHandler getHandler() {
+		if (explicitHandler != null) {
+			return explicitHandler;
+		}
+		if (builtHandler == null) {
+			builtHandler = new DefaultDelimitedListHandler(listDelimiter, parsers);
+		}
+		return builtHandler;
+	}
+}

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/SpreadsheetRecord.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/SpreadsheetRecord.java
@@ -16,20 +16,27 @@ public interface SpreadsheetRecord extends DataSourceRecord {
 		return val != null ? val : defaultValue;
 	}
 
+	/**
+	 * Reads the cell as text and applies the parser to it. A null or blank cell returns the default value without calling the parser,
+	 * and the text is trimmed before the parser sees it, so a parser never receives leading or trailing whitespace.
+	 */
 	default <T> T parseFromString(String field, Function<String, T> parser, T defaultValue) {
 		String strVal = getString(field);
-		if (strVal == null || strVal.isEmpty()) {
+		if (strVal == null || strVal.isBlank()) {
 			return defaultValue;
 		}
-		return parser.apply(strVal);
+		return parser.apply(strVal.trim());
 	}
 
+	/**
+	 * Same as {@link #parseFromString(String, Function, Object)} for a column index.
+	 */
 	default <T> T parseFromString(int index, Function<String, T> parser, T defaultValue) {
 		String strVal = getString(index);
-		if (strVal == null || strVal.isEmpty()) {
+		if (strVal == null || strVal.isBlank()) {
 			return defaultValue;
 		}
-		return parser.apply(strVal);
+		return parser.apply(strVal.trim());
 	}
 
 	Boolean getBoolean(int index);

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/delimited/DelimitedSourceConfig.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/delimited/DelimitedSourceConfig.java
@@ -2,42 +2,31 @@ package io.zulia.data.source.spreadsheet.delimited;
 
 import io.zulia.data.common.HeaderConfig;
 import io.zulia.data.input.DataInputStream;
-import io.zulia.data.source.spreadsheet.DefaultDelimitedListHandler;
 import io.zulia.data.source.spreadsheet.DelimitedListHandler;
-import io.zulia.util.BooleanUtil;
+import io.zulia.data.source.spreadsheet.DelimitedListSettings;
 
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.function.Function;
 
 public class DelimitedSourceConfig {
 
-	private Function<String, Boolean> booleanParser;
-	private Function<String, Date> dateParser;
-
 	private final DataInputStream dataInputStream;
 
 	private HeaderConfig headerConfig;
 
-	private DelimitedListHandler delimitedListHandler = new DefaultDelimitedListHandler(';');
+	private final DelimitedListSettings listSettings = new DelimitedListSettings();
 
 	public DelimitedSourceConfig(DataInputStream dataInputStream) {
 		this.dataInputStream = dataInputStream;
-		this.booleanParser = BooleanUtil::parseBoolean;
-
-		DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME.withZone(ZoneId.systemDefault());
-		this.dateParser = (s) -> Date.from(Instant.from(formatter.parse(s)));
 	}
 
 	public DelimitedSourceConfig withListDelimiter(char listDelimiter) {
-		this.delimitedListHandler = new DefaultDelimitedListHandler(listDelimiter);
+		listSettings.withListDelimiter(listDelimiter);
 		return this;
 	}
 
 	public DelimitedSourceConfig withDelimitedListHandler(DelimitedListHandler delimitedListHandler) {
-		this.delimitedListHandler = delimitedListHandler;
+		listSettings.withHandler(delimitedListHandler);
 		return this;
 	}
 
@@ -68,7 +57,7 @@ public class DelimitedSourceConfig {
 	}
 
 	public DelimitedListHandler getDelimitedListHandler() {
-		return delimitedListHandler;
+		return listSettings.getHandler();
 	}
 
 	public HeaderConfig getHeaderConfig() {
@@ -76,20 +65,20 @@ public class DelimitedSourceConfig {
 	}
 
 	public Function<String, Boolean> getBooleanParser() {
-		return booleanParser;
+		return listSettings.getParsers().booleanParser();
 	}
 
 	public DelimitedSourceConfig withBooleanParser(Function<String, Boolean> booleanParser) {
-		this.booleanParser = booleanParser;
+		listSettings.withParsers(listSettings.getParsers().withBooleanParser(booleanParser));
 		return this;
 	}
 
 	public Function<String, Date> getDateParser() {
-		return dateParser;
+		return listSettings.getParsers().dateParser();
 	}
 
 	public DelimitedSourceConfig withDateParser(Function<String, Date> dateParser) {
-		this.dateParser = dateParser;
+		listSettings.withParsers(listSettings.getParsers().withDateParser(dateParser));
 		return this;
 	}
 }

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/DefaultExcelCellHandler.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/DefaultExcelCellHandler.java
@@ -1,5 +1,6 @@
 package io.zulia.data.source.spreadsheet.excel;
 
+import io.zulia.data.source.spreadsheet.CellParsers;
 import io.zulia.util.BooleanUtil;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
@@ -7,8 +8,22 @@ import org.apache.poi.ss.usermodel.DateUtil;
 
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
+import java.util.Objects;
+import java.util.function.Function;
+
 
 public class DefaultExcelCellHandler implements ExcelCellHandler {
+
+	private final CellParsers parsers;
+
+	public DefaultExcelCellHandler() {
+		this(CellParsers.defaults());
+	}
+
+	public DefaultExcelCellHandler(CellParsers parsers) {
+		this.parsers = Objects.requireNonNull(parsers, "parsers");
+	}
+
 	@Override
 	public String cellToString(Cell cell) {
 
@@ -48,7 +63,7 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 			return cell.getBooleanCellValue();
 		}
 		else if (isCellString(cell)) {
-			return BooleanUtil.parseBoolean(cell.getStringCellValue());
+			return parseText(cell.getStringCellValue(), parsers.booleanParser());
 		}
 		else if (isCellNumeric(cell)) {
 			return BooleanUtil.parseBoolean(cell.getNumericCellValue());
@@ -59,7 +74,7 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 				return cell.getBooleanCellValue();
 			}
 			else if (cachedFormulaResultType.equals(CellType.STRING)) {
-				return BooleanUtil.parseBoolean(cell.getRichStringCellValue().getString());
+				return parseText(cell.getRichStringCellValue().getString(), parsers.booleanParser());
 			}
 			else if (cachedFormulaResultType.equals(CellType.NUMERIC)) {
 				return BooleanUtil.parseBoolean(cell.getNumericCellValue());
@@ -81,7 +96,7 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 			}
 		}
 		else if (isCellString(cell)) {
-			return Integer.parseInt(cell.getStringCellValue());
+			return parseText(cell.getStringCellValue(), Integer::parseInt);
 		}
 
 		return null;
@@ -99,7 +114,7 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 			}
 		}
 		else if (isCellString(cell)) {
-			return Long.parseLong(cell.getStringCellValue());
+			return parseText(cell.getStringCellValue(), Long::parseLong);
 		}
 
 		return null;
@@ -117,7 +132,7 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 			}
 		}
 		else if (isCellString(cell)) {
-			return Float.parseFloat(cell.getStringCellValue());
+			return parseText(cell.getStringCellValue(), Float::parseFloat);
 		}
 
 		return null;
@@ -134,7 +149,7 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 			}
 		}
 		else if (isCellString(cell)) {
-			return Double.parseDouble(cell.getStringCellValue());
+			return parseText(cell.getStringCellValue(), Double::parseDouble);
 		}
 
 		return null;
@@ -142,7 +157,32 @@ public class DefaultExcelCellHandler implements ExcelCellHandler {
 
 	@Override
 	public Date cellToDate(Cell cell) {
-		return isCellNumeric(cell) ? cell.getDateCellValue() : null;
+
+		if (isCellNumeric(cell)) {
+			return cell.getDateCellValue();
+		}
+		else if (isCellFormula(cell)) {
+			CellType cachedFormulaResultType = cell.getCachedFormulaResultType();
+			if (cachedFormulaResultType.equals(CellType.NUMERIC)) {
+				return cell.getDateCellValue();
+			}
+			else if (cachedFormulaResultType.equals(CellType.STRING)) {
+				return parseText(cell.getRichStringCellValue().getString(), parsers.dateParser());
+			}
+		}
+		else if (isCellString(cell)) {
+			return parseText(cell.getStringCellValue(), parsers.dateParser());
+		}
+
+		return null;
+	}
+
+	/**
+	 * Applies the parser to the trimmed text, or returns null when the text is blank.
+	 */
+	private static <T> T parseText(String text, Function<String, T> parser) {
+		String trimmed = text.trim();
+		return trimmed.isEmpty() ? null : parser.apply(trimmed);
 	}
 
 	@Override

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSource.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSource.java
@@ -46,6 +46,8 @@ public class ExcelSource implements SpreadsheetSource<ExcelRecord>, AutoCloseabl
 
 	protected ExcelSource(ExcelSourceConfig excelSourceConfig) throws IOException {
 		this.excelSourceConfig = excelSourceConfig;
+		// the static block covers the thread that loaded the class, this covers the thread that opens the workbook
+		LocaleUtil.setUserTimeZone(LocaleUtil.TIMEZONE_UTC);
 		open();
 
 		if (Objects.equals(ExcelSourceConfig.OpenHandling.ACTIVE_SHEET, excelSourceConfig.getOpenHandling())) {

--- a/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSourceConfig.java
+++ b/zulia-data/src/main/java/io/zulia/data/source/spreadsheet/excel/ExcelSourceConfig.java
@@ -2,8 +2,12 @@ package io.zulia.data.source.spreadsheet.excel;
 
 import io.zulia.data.common.HeaderConfig;
 import io.zulia.data.input.DataInputStream;
-import io.zulia.data.source.spreadsheet.DefaultDelimitedListHandler;
 import io.zulia.data.source.spreadsheet.DelimitedListHandler;
+import io.zulia.data.source.spreadsheet.DelimitedListSettings;
+
+import java.util.Date;
+import java.util.Objects;
+import java.util.function.Function;
 
 public class ExcelSourceConfig {
 
@@ -11,14 +15,17 @@ public class ExcelSourceConfig {
 		return new ExcelSourceConfig(dataStream);
 	}
 
-	private DelimitedListHandler delimitedListHandler = new DefaultDelimitedListHandler(';');
+	// the parsers reach text cells through the default cell handler and list elements through the list handler
+	private final DelimitedListSettings listSettings = new DelimitedListSettings();
 
 	private final DataInputStream dataInputStream;
 	private HeaderConfig headerConfig;
 
 	private OpenHandling openHandling = OpenHandling.FIRST_SHEET;
 
-	private ExcelCellHandler excelCellHandler = new DefaultExcelCellHandler();
+	// the cell handler is either one set explicitly or the default handler built from the parsers
+	private ExcelCellHandler explicitCellHandler;
+	private DefaultExcelCellHandler builtCellHandler;
 
 	public enum OpenHandling {
 		ACTIVE_SHEET,
@@ -48,17 +55,41 @@ public class ExcelSourceConfig {
 	}
 
 	public ExcelSourceConfig withListDelimiter(char listDelimiter) {
-		this.delimitedListHandler = new DefaultDelimitedListHandler(listDelimiter);
+		listSettings.withListDelimiter(listDelimiter);
 		return this;
 	}
 
 	public ExcelSourceConfig withDelimitedListHandler(DelimitedListHandler delimitedListHandler) {
-		this.delimitedListHandler = delimitedListHandler;
+		listSettings.withHandler(delimitedListHandler);
 		return this;
 	}
 
+	/**
+	 * Replaces the default cell handler. A handler set here reads cells its own way and is not affected by {@link #withBooleanParser}
+	 * or {@link #withDateParser}, which still apply to delimited lists inside a cell.
+	 */
 	public ExcelSourceConfig withExcelCellHandler(ExcelCellHandler excelCellHandler) {
-		this.excelCellHandler = excelCellHandler;
+		this.explicitCellHandler = Objects.requireNonNull(excelCellHandler, "excelCellHandler");
+		return this;
+	}
+
+	/**
+	 * Parses boolean text, both a text cell read with getBoolean and each element of a delimited list read with getList.
+	 * Typed boolean cells are read from the cell type and do not go through the parser.
+	 */
+	public ExcelSourceConfig withBooleanParser(Function<String, Boolean> booleanParser) {
+		listSettings.withParsers(listSettings.getParsers().withBooleanParser(booleanParser));
+		builtCellHandler = null;
+		return this;
+	}
+
+	/**
+	 * Parses date text, both a text cell read with getDate and each element of a delimited list read with getList.
+	 * Date formatted numeric cells are read from the cell type and do not go through the parser.
+	 */
+	public ExcelSourceConfig withDateParser(Function<String, Date> dateParser) {
+		listSettings.withParsers(listSettings.getParsers().withDateParser(dateParser));
+		builtCellHandler = null;
 		return this;
 	}
 
@@ -80,14 +111,28 @@ public class ExcelSourceConfig {
 	}
 
 	public DelimitedListHandler getDelimitedListHandler() {
-		return delimitedListHandler;
+		return listSettings.getHandler();
 	}
 
 	public ExcelCellHandler getExcelCellHandler() {
-		return excelCellHandler;
+		if (explicitCellHandler != null) {
+			return explicitCellHandler;
+		}
+		if (builtCellHandler == null) {
+			builtCellHandler = new DefaultExcelCellHandler(listSettings.getParsers());
+		}
+		return builtCellHandler;
 	}
 
 	public HeaderConfig getHeaderConfig() {
 		return headerConfig;
+	}
+
+	public Function<String, Boolean> getBooleanParser() {
+		return listSettings.getParsers().booleanParser();
+	}
+
+	public Function<String, Date> getDateParser() {
+		return listSettings.getParsers().dateParser();
 	}
 }

--- a/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/excel/ExcelTarget.java
+++ b/zulia-data/src/main/java/io/zulia/data/target/spreadsheet/excel/ExcelTarget.java
@@ -8,6 +8,7 @@ import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.streaming.SXSSFCell;
 import org.apache.poi.xssf.streaming.SXSSFRow;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
+import org.apache.poi.util.LocaleUtil;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
 
 import java.io.IOException;
@@ -45,6 +46,9 @@ public class ExcelTarget extends SpreadsheetTarget<CellReference, ExcelTargetCon
 	protected ExcelTarget(ExcelTargetConfig excelDataTargetConfig) {
 		super(excelDataTargetConfig);
 		this.excelDataTargetConfig = excelDataTargetConfig;
+		// POI converts a Date to a cell serial in its thread local user time zone. ExcelSource reads in UTC, so write in UTC as well
+		// or a typed date shifts by the writer's offset when it is read back.
+		LocaleUtil.setUserTimeZone(LocaleUtil.TIMEZONE_UTC);
 		this.workbook = new SXSSFWorkbook();
 		if (excelDataTargetConfig.getPrimarySheetName() != null) {
 			this.sheet = this.workbook.createSheet(excelDataTargetConfig.getPrimarySheetName());

--- a/zulia-data/src/test/java/io/zulia/data/test/BlankNumericCellTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/BlankNumericCellTest.java
@@ -1,0 +1,91 @@
+package io.zulia.data.test;
+
+import io.zulia.data.input.SingleUseDataInputStream;
+import io.zulia.data.source.spreadsheet.csv.CSVSource;
+import io.zulia.data.source.spreadsheet.csv.CSVSourceConfig;
+import io.zulia.data.source.spreadsheet.delimited.DelimitedRecord;
+import io.zulia.data.source.spreadsheet.excel.ExcelRecord;
+import io.zulia.data.source.spreadsheet.excel.ExcelSource;
+import io.zulia.data.source.spreadsheet.excel.ExcelSourceConfig;
+import org.apache.poi.ss.usermodel.Row;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static io.zulia.data.test.SpreadsheetTestFiles.csvStream;
+import static io.zulia.data.test.SpreadsheetTestFiles.header;
+import static io.zulia.data.test.SpreadsheetTestFiles.workbook;
+
+/**
+ * A blank cell in a numeric column reads as null rather than throwing NumberFormatException.
+ * Excel keeps the STRING cell type for a cleared cell in a text formatted column, so the empty text has to be treated the same as a missing cell.
+ */
+public class BlankNumericCellTest {
+
+	@Test
+	void excelBlankStringCellsReadAsNullNumbers() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "id", "count", "amount");
+			Row blank = sheet.createRow(1);
+			blank.createCell(0).setCellValue("a");
+			blank.createCell(1).setCellValue("");
+			blank.createCell(2).setCellValue("   ");
+			Row filled = sheet.createRow(2);
+			filled.createCell(0).setCellValue("b");
+			filled.createCell(1).setCellValue(" 42 ");
+			filled.createCell(2).setCellValue("1.5");
+		});
+
+		try (ExcelSource source = ExcelSource.withConfig(ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders())) {
+			var iterator = source.iterator();
+			ExcelRecord blank = iterator.next();
+			Assertions.assertNull(blank.getLong("count"));
+			Assertions.assertNull(blank.getInt("count"));
+			Assertions.assertNull(blank.getDouble("amount"));
+			Assertions.assertNull(blank.getFloat("amount"));
+			Assertions.assertNull(blank.getLong(1));
+			Assertions.assertNull(blank.getDouble(2));
+
+			ExcelRecord filled = iterator.next();
+			Assertions.assertEquals(42L, filled.getLong("count"));
+			Assertions.assertEquals(42, filled.getInt("count"));
+			Assertions.assertEquals(1.5d, filled.getDouble("amount"));
+			Assertions.assertEquals(1.5f, filled.getFloat("amount"));
+		}
+	}
+
+	@Test
+	void excelNonNumericTextStillThrows() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "count");
+			sheet.createRow(1).createCell(0).setCellValue("N/A");
+		});
+
+		try (ExcelSource source = ExcelSource.withConfig(ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders())) {
+			ExcelRecord record = source.iterator().next();
+			Assertions.assertThrows(NumberFormatException.class, () -> record.getLong("count"));
+		}
+	}
+
+	@Test
+	void csvWhitespaceOnlyCellsReadAsNull() throws IOException {
+		String csv = "id,count,amount,flag\na,,   ,\nb, 7 ,2.5,true\n";
+		CSVSourceConfig config = CSVSourceConfig.from(csvStream(csv));
+		config.withHeaders();
+		try (CSVSource source = CSVSource.withConfig(config)) {
+			var iterator = source.iterator();
+			DelimitedRecord blank = iterator.next();
+			Assertions.assertNull(blank.getLong("count"));
+			Assertions.assertNull(blank.getDouble("amount"));
+			Assertions.assertNull(blank.getDouble(2));
+			Assertions.assertNull(blank.getBoolean("flag"));
+
+			DelimitedRecord filled = iterator.next();
+			Assertions.assertEquals(7L, filled.getLong("count"));
+			Assertions.assertEquals(2.5d, filled.getDouble("amount"));
+			Assertions.assertEquals(true, filled.getBoolean("flag"));
+		}
+	}
+
+}

--- a/zulia-data/src/test/java/io/zulia/data/test/DataSourceTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/DataSourceTest.java
@@ -8,6 +8,8 @@ import io.zulia.data.output.SingleUseDataOutputStream;
 import io.zulia.data.source.spreadsheet.SpreadsheetRecord;
 import io.zulia.data.source.spreadsheet.SpreadsheetSource;
 import io.zulia.data.source.spreadsheet.SpreadsheetSourceFactory;
+import io.zulia.data.source.spreadsheet.csv.CSVSource;
+import io.zulia.data.source.spreadsheet.csv.CSVSourceConfig;
 import io.zulia.data.source.spreadsheet.tsv.TSVRecord;
 import io.zulia.data.source.spreadsheet.tsv.TSVSource;
 import io.zulia.data.target.spreadsheet.SpreadsheetTargetFactory;
@@ -20,7 +22,9 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 public class DataSourceTest {
@@ -139,6 +143,34 @@ public class DataSourceTest {
 
 		try (SpreadsheetSource<?> dataSource = SpreadsheetSourceFactory.fromStreamWithHeaders(dataInputStream)) {
 			Assertions.assertEquals(0, countRows(dataSource));
+		}
+	}
+
+	@Test
+	void csvDelimitedListsOfDatesAndBooleans() throws IOException {
+		// the first date is the form the date target handlers write, the second has no zone id
+		String csv = "dates,flags\n\"2024-12-18T08:00:00Z[Etc/UTC]; 2024-12-19T00:00:00Z\",\"true;no;1\"\n";
+		List<Date> expectedDates = List.of(Date.from(Instant.parse("2024-12-18T08:00:00Z")), Date.from(Instant.parse("2024-12-19T00:00:00Z")));
+
+		SingleUseDataInputStream dataInputStream = SingleUseDataInputStream.from(new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8)), "test.csv");
+		try (SpreadsheetSource<?> dataSource = SpreadsheetSourceFactory.fromStreamWithHeaders(dataInputStream)) {
+			int rows = 0;
+			for (SpreadsheetRecord row : dataSource) {
+				Assertions.assertEquals(expectedDates, row.getList("dates", Date.class));
+				Assertions.assertEquals(List.of(true, false, true), row.getList("flags", Boolean.class));
+				rows++;
+			}
+			Assertions.assertEquals(1, rows);
+		}
+
+		// a parser set on the config reaches the list handler too
+		SingleUseDataInputStream secondInputStream = SingleUseDataInputStream.from(new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8)), "test.csv");
+		CSVSourceConfig config = CSVSourceConfig.from(secondInputStream);
+		config.withHeaders().withBooleanParser(s -> "1".equals(s));
+		try (CSVSource dataSource = CSVSource.withConfig(config)) {
+			for (SpreadsheetRecord row : dataSource) {
+				Assertions.assertEquals(List.of(false, false, true), row.getList("flags", Boolean.class));
+			}
 		}
 	}
 

--- a/zulia-data/src/test/java/io/zulia/data/test/DelimitedListParsingTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/DelimitedListParsingTest.java
@@ -1,0 +1,363 @@
+package io.zulia.data.test;
+
+import io.zulia.data.input.SingleUseDataInputStream;
+import io.zulia.data.source.spreadsheet.CellParsers;
+import io.zulia.data.source.spreadsheet.DefaultDelimitedListHandler;
+import io.zulia.data.source.spreadsheet.DelimitedListHandler;
+import io.zulia.data.source.spreadsheet.csv.CSVSource;
+import io.zulia.data.source.spreadsheet.csv.CSVSourceConfig;
+import io.zulia.data.source.spreadsheet.excel.DefaultExcelCellHandler;
+import io.zulia.data.source.spreadsheet.excel.ExcelRecord;
+import io.zulia.data.source.spreadsheet.excel.ExcelSource;
+import io.zulia.data.source.spreadsheet.excel.ExcelSourceConfig;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Row;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.function.Function;
+
+import static io.zulia.data.test.SpreadsheetTestFiles.csvStream;
+import static io.zulia.data.test.SpreadsheetTestFiles.header;
+import static io.zulia.data.test.SpreadsheetTestFiles.workbook;
+
+/**
+ * Delimited lists inside a cell parse Date and Boolean elements with the same parsers the source config uses for whole cells.
+ * The Excel side is covered through real workbooks because Excel cells hold lists as strings while typed cells go through the cell handler.
+ */
+public class DelimitedListParsingTest {
+
+	private static final String DATE_LIST = "2024-12-18T08:00:00Z[Etc/UTC]; 2024-12-19T00:00:00Z";
+	private static final List<Date> EXPECTED_DATES = List.of(Date.from(Instant.parse("2024-12-18T08:00:00Z")), Date.from(Instant.parse("2024-12-19T00:00:00Z")));
+
+	// a parser for yyyyMMdd that is distinguishable from the ISO default
+	private static final Function<String, Date> COMPACT_DATE_PARSER = s -> Date.from(
+			LocalDate.parse(s, DateTimeFormatter.BASIC_ISO_DATE).atStartOfDay(ZoneOffset.UTC).toInstant());
+	private static final Function<String, Boolean> ONE_IS_TRUE = s -> "1".equals(s);
+
+	// ---- Excel through the real source
+
+	@Test
+	void excelListsOfDatesAndBooleansParseWithDefaults() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "dates", "flags", "numbers", "words");
+			Row row = sheet.createRow(1);
+			row.createCell(0).setCellValue(DATE_LIST);
+			row.createCell(1).setCellValue("true;no;1");
+			row.createCell(2).setCellValue("1;2;3");
+			row.createCell(3).setCellValue("a;;b");
+		});
+
+		try (ExcelSource source = ExcelSource.withConfig(ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders())) {
+			ExcelRecord record = source.iterator().next();
+			Assertions.assertEquals(EXPECTED_DATES, record.getList("dates", Date.class));
+			Assertions.assertEquals(EXPECTED_DATES, record.getList(0, Date.class));
+			Assertions.assertEquals(List.of(true, false, true), record.getList("flags", Boolean.class));
+			Assertions.assertEquals(List.of(true, false, true), record.getList(1, Boolean.class));
+			// the previously supported element types are untouched, including blank string elements
+			Assertions.assertEquals(List.of(1L, 2L, 3L), record.getList("numbers", Long.class));
+			Assertions.assertEquals(List.of(1, 2, 3), record.getList("numbers", Integer.class));
+			Assertions.assertEquals(List.of("a", "", "b"), record.getList("words", String.class));
+		}
+	}
+
+	@Test
+	void excelConfigParsersReachTheListHandler() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "dates", "flags");
+			Row row = sheet.createRow(1);
+			row.createCell(0).setCellValue("20241218;20241219");
+			row.createCell(1).setCellValue("true;1");
+		});
+
+		ExcelSourceConfig config = ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders();
+		config.withDateParser(COMPACT_DATE_PARSER).withBooleanParser(ONE_IS_TRUE);
+		Assertions.assertSame(COMPACT_DATE_PARSER, config.getDateParser());
+		Assertions.assertSame(ONE_IS_TRUE, config.getBooleanParser());
+
+		try (ExcelSource source = ExcelSource.withConfig(config)) {
+			ExcelRecord record = source.iterator().next();
+			Assertions.assertEquals(List.of(Date.from(Instant.parse("2024-12-18T00:00:00Z")), Date.from(Instant.parse("2024-12-19T00:00:00Z"))),
+					record.getList("dates", Date.class));
+			// "true" is not "1" for the custom parser
+			Assertions.assertEquals(List.of(false, true), record.getList("flags", Boolean.class));
+		}
+	}
+
+	@Test
+	void excelDelimiterChangeKeepsTheParsersInEitherOrder() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "dates");
+			sheet.createRow(1).createCell(0).setCellValue("20241218|20241219");
+		});
+		List<Date> expected = List.of(Date.from(Instant.parse("2024-12-18T00:00:00Z")), Date.from(Instant.parse("2024-12-19T00:00:00Z")));
+
+		ExcelSourceConfig parserFirst = ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders();
+		parserFirst.withDateParser(COMPACT_DATE_PARSER).withListDelimiter('|');
+		try (ExcelSource source = ExcelSource.withConfig(parserFirst)) {
+			Assertions.assertEquals(expected, source.iterator().next().getList("dates", Date.class));
+		}
+
+		ExcelSourceConfig delimiterFirst = ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders();
+		delimiterFirst.withListDelimiter('|').withDateParser(COMPACT_DATE_PARSER);
+		try (ExcelSource source = ExcelSource.withConfig(delimiterFirst)) {
+			Assertions.assertEquals(expected, source.iterator().next().getList("dates", Date.class));
+		}
+	}
+
+	@Test
+	void excelCustomListHandlerIsNotReplacedByAParserChange() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "anything");
+			sheet.createRow(1).createCell(0).setCellValue("ignored");
+		});
+		DelimitedListHandler fixed = new FixedListHandler();
+
+		ExcelSourceConfig config = ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders();
+		config.withDelimitedListHandler(fixed).withDateParser(COMPACT_DATE_PARSER).withBooleanParser(ONE_IS_TRUE);
+		Assertions.assertSame(fixed, config.getDelimitedListHandler());
+
+		try (ExcelSource source = ExcelSource.withConfig(config)) {
+			Assertions.assertEquals(List.of("fixed"), source.iterator().next().getList("anything", String.class));
+		}
+
+		// a later delimiter change deliberately goes back to the default handler, as it did before
+		config.withListDelimiter('|');
+		Assertions.assertInstanceOf(DefaultDelimitedListHandler.class, config.getDelimitedListHandler());
+	}
+
+	@Test
+	void excelTypedCellsStillGoThroughTheCellHandler() throws IOException {
+		Date typedDate = Date.from(Instant.parse("2024-12-18T00:00:00Z"));
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "date", "flag");
+			Row row = sheet.createRow(1);
+			CellStyle dateStyle = sheet.getWorkbook().createCellStyle();
+			dateStyle.setDataFormat(sheet.getWorkbook().getCreationHelper().createDataFormat().getFormat("yyyy-mm-dd"));
+			row.createCell(0).setCellValue(typedDate);
+			row.getCell(0).setCellStyle(dateStyle);
+			row.createCell(1).setCellValue(true);
+		});
+
+		// a config parser that would fail on anything must not be consulted for typed cells
+		ExcelSourceConfig config = ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders();
+		config.withDateParser(s -> {
+			throw new IllegalStateException("cell parser used for a typed cell");
+		}).withBooleanParser(s -> {
+			throw new IllegalStateException("cell parser used for a typed cell");
+		});
+
+		try (ExcelSource source = ExcelSource.withConfig(config)) {
+			ExcelRecord record = source.iterator().next();
+			Assertions.assertEquals(typedDate, record.getDate("date"));
+			Assertions.assertEquals(Boolean.TRUE, record.getBoolean("flag"));
+		}
+	}
+
+	@Test
+	void excelTextCellsUseTheConfigParsers() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "date", "flag");
+			Row row = sheet.createRow(1);
+			row.createCell(0).setCellValue("20241218");
+			row.createCell(1).setCellValue("1");
+			Row blank = sheet.createRow(2);
+			blank.createCell(0).setCellValue("   ");
+			blank.createCell(1).setCellValue("");
+		});
+
+		ExcelSourceConfig config = ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders();
+		config.withDateParser(COMPACT_DATE_PARSER).withBooleanParser(ONE_IS_TRUE);
+
+		try (ExcelSource source = ExcelSource.withConfig(config)) {
+			var iterator = source.iterator();
+			ExcelRecord record = iterator.next();
+			Assertions.assertEquals(Date.from(Instant.parse("2024-12-18T00:00:00Z")), record.getDate("date"));
+			Assertions.assertEquals(Boolean.TRUE, record.getBoolean("flag"));
+			// blank text is null for both, the parsers are not consulted
+			ExcelRecord blank = iterator.next();
+			Assertions.assertNull(blank.getDate("date"));
+			Assertions.assertNull(blank.getBoolean("flag"));
+		}
+	}
+
+	@Test
+	void excelTextDateCellsParseWithTheDefaultParser() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "date");
+			sheet.createRow(1).createCell(0).setCellValue("2024-12-18T08:00:00Z[Etc/UTC]");
+			sheet.createRow(2).createCell(0).setCellValue("Wed Dec 18 08:00:00 UTC 2024");
+		});
+
+		try (ExcelSource source = ExcelSource.withConfig(ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders())) {
+			var iterator = source.iterator();
+			Assertions.assertEquals(Date.from(Instant.parse("2024-12-18T08:00:00Z")), iterator.next().getDate("date"));
+			ExcelRecord bad = iterator.next();
+			Assertions.assertThrows(DateTimeParseException.class, () -> bad.getDate("date"));
+		}
+	}
+
+	@Test
+	void excelCustomCellHandlerIsNotReplacedByAParserChange() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "flag");
+			sheet.createRow(1).createCell(0).setCellValue("anything");
+		});
+
+		ExcelSourceConfig config = ExcelSourceConfig.from(SingleUseDataInputStream.from(xlsx, "test.xlsx")).withHeaders();
+		config.withExcelCellHandler(new DefaultExcelCellHandler() {
+			@Override
+			public Boolean cellToBoolean(Cell cell) {
+				return Boolean.TRUE;
+			}
+		}).withBooleanParser(s -> {
+			throw new IllegalStateException("config parser used with an explicit cell handler");
+		});
+
+		try (ExcelSource source = ExcelSource.withConfig(config)) {
+			Assertions.assertEquals(Boolean.TRUE, source.iterator().next().getBoolean("flag"));
+		}
+	}
+
+	@Test
+	void excelBadDateElementThrowsInsteadOfReturningStrings() throws IOException {
+		byte[] xlsx = workbook(sheet -> {
+			header(sheet, "dates");
+			sheet.createRow(1).createCell(0).setCellValue("2024-12-18T00:00:00Z;Wed Dec 18 08:00:00 UTC 2024");
+		});
+		try (ExcelSource source = ExcelSource.withDefaults(SingleUseDataInputStream.from(xlsx, "test.xlsx"))) {
+			ExcelRecord record = source.iterator().next();
+			Assertions.assertThrows(DateTimeParseException.class, () -> record.getList(0, Date.class));
+		}
+	}
+
+	// ---- CSV mirrors of the config interactions
+
+	@Test
+	void csvDelimiterChangeKeepsTheParsersInEitherOrder() throws IOException {
+		String csv = "dates\n20241218|20241219\n";
+		List<Date> expected = List.of(Date.from(Instant.parse("2024-12-18T00:00:00Z")), Date.from(Instant.parse("2024-12-19T00:00:00Z")));
+
+		CSVSourceConfig parserFirst = CSVSourceConfig.from(csvStream(csv));
+		parserFirst.withHeaders().withDateParser(COMPACT_DATE_PARSER).withListDelimiter('|');
+		try (CSVSource source = CSVSource.withConfig(parserFirst)) {
+			Assertions.assertEquals(expected, source.iterator().next().getList("dates", Date.class));
+		}
+
+		CSVSourceConfig delimiterFirst = CSVSourceConfig.from(csvStream(csv));
+		delimiterFirst.withHeaders().withListDelimiter('|').withDateParser(COMPACT_DATE_PARSER);
+		try (CSVSource source = CSVSource.withConfig(delimiterFirst)) {
+			Assertions.assertEquals(expected, source.iterator().next().getList("dates", Date.class));
+		}
+	}
+
+	@Test
+	void csvCustomListHandlerIsNotReplacedByAParserChange() throws IOException {
+		DelimitedListHandler fixed = new FixedListHandler();
+		CSVSourceConfig config = CSVSourceConfig.from(csvStream("anything\nignored\n"));
+		config.withHeaders().withDelimitedListHandler(fixed).withDateParser(COMPACT_DATE_PARSER).withBooleanParser(ONE_IS_TRUE);
+		Assertions.assertSame(fixed, config.getDelimitedListHandler());
+		try (CSVSource source = CSVSource.withConfig(config)) {
+			Assertions.assertEquals(List.of("fixed"), source.iterator().next().getList("anything", String.class));
+		}
+	}
+
+	@Test
+	void csvWholeCellAndListElementParseTheSameWay() throws IOException {
+		// the single date column and the list column hold the same text, so getDate and getList must agree
+		String csv = "single,list\n2024-12-18T08:00:00Z[Etc/UTC],2024-12-18T08:00:00Z[Etc/UTC]\n";
+		CSVSourceConfig config = CSVSourceConfig.from(csvStream(csv));
+		config.withHeaders();
+		try (CSVSource source = CSVSource.withConfig(config)) {
+			var record = source.iterator().next();
+			Assertions.assertEquals(List.of(record.getDate("single")), record.getList("list", Date.class));
+		}
+	}
+
+	// ---- handler on its own
+
+	@Test
+	void handlerKeepsBlankElementsAsNullPlaceholders() {
+		DefaultDelimitedListHandler handler = new DefaultDelimitedListHandler(';');
+		Assertions.assertEquals(Arrays.asList(null, true, null), handler.cellValueToList(Boolean.class, " ; true ; "));
+		Assertions.assertEquals(Arrays.asList(null, null), handler.cellValueToList(Date.class, " ; "));
+		Assertions.assertEquals(Arrays.asList(1L, null, 2L), handler.cellValueToList(Long.class, "1;;2"));
+		Assertions.assertEquals(List.of(1, 2), handler.cellValueToList(Integer.class, " 1 ; 2 "));
+		Assertions.assertEquals(Arrays.asList(null, 1.5d), handler.cellValueToList(Double.class, "; 1.5"));
+		// a blank whole cell is an empty list, not a single placeholder
+		Assertions.assertEquals(List.of(), handler.cellValueToList(Long.class, ""));
+		Assertions.assertEquals(List.of(), handler.cellValueToList(Date.class, "   "));
+		// string lists are untouched
+		Assertions.assertEquals(List.of("", "a", ""), handler.cellValueToList(String.class, ";a;"));
+		Assertions.assertThrows(NumberFormatException.class, () -> handler.cellValueToList(Long.class, "1;x;2"));
+		// the writer turns the placeholders back into blanks
+		Assertions.assertEquals("1;;2", handler.collectionToCellValue(Arrays.asList(1L, null, 2L)));
+	}
+
+	@Test
+	void handlerUsesTheSupplierParsersAndReportsUnknownBooleansAsNull() {
+		DefaultDelimitedListHandler defaults = new DefaultDelimitedListHandler(';');
+		Assertions.assertEquals(Arrays.asList(true, null, false), defaults.cellValueToList(Boolean.class, "Y;maybe;F"));
+		Assertions.assertEquals(EXPECTED_DATES, defaults.cellValueToList(Date.class, DATE_LIST));
+
+		DefaultDelimitedListHandler custom = new DefaultDelimitedListHandler(',', CellParsers.defaults().withDateParser(COMPACT_DATE_PARSER).withBooleanParser(ONE_IS_TRUE));
+		Assertions.assertEquals(List.of(Date.from(Instant.parse("2024-12-18T00:00:00Z"))), custom.cellValueToList(Date.class, "20241218"));
+		Assertions.assertEquals(List.of(true, false), custom.cellValueToList(Boolean.class, "1,true"));
+	}
+
+	@Test
+	void handlerNullCellAndUnsupportedClassBehaveAsBefore() {
+		DefaultDelimitedListHandler handler = new DefaultDelimitedListHandler(';');
+		Assertions.assertNull(handler.cellValueToList(Date.class, null));
+		Assertions.assertNull(handler.cellValueToList(Boolean.class, null));
+		Assertions.assertThrows(IllegalArgumentException.class, () -> handler.cellValueToList(Object.class, "x"));
+		Assertions.assertThrows(DateTimeParseException.class, () -> handler.cellValueToList(Date.class, "not a date"));
+	}
+
+	@Test
+	void sharedDefaultsMatchTheWholeCellRules() {
+		CellParsers defaults = CellParsers.defaults();
+		Assertions.assertEquals(Boolean.TRUE, defaults.booleanParser().apply("Yes"));
+		Assertions.assertNull(defaults.booleanParser().apply("maybe"));
+		Assertions.assertEquals(Date.from(Instant.parse("2024-12-18T08:00:00Z")), defaults.dateParser().apply("2024-12-18T08:00:00Z[Etc/UTC]"));
+		// a zone-less value is read in the zone the parser was built for
+		Assertions.assertEquals(Date.from(Instant.parse("2024-12-18T08:00:00Z")), CellParsers.isoDateParser(ZoneOffset.UTC).apply("2024-12-18T08:00:00"));
+	}
+
+	@Test
+	void cellParsersAreImmutableAndReplaceOneParserAtATime() {
+		CellParsers defaults = CellParsers.defaults();
+		CellParsers dates = defaults.withDateParser(COMPACT_DATE_PARSER);
+		Assertions.assertSame(COMPACT_DATE_PARSER, dates.dateParser());
+		Assertions.assertSame(defaults.booleanParser(), dates.booleanParser());
+		Assertions.assertSame(defaults, CellParsers.defaults(), "defaults are shared, not rebuilt");
+		Assertions.assertThrows(NullPointerException.class, () -> defaults.withBooleanParser(null));
+		Assertions.assertThrows(NullPointerException.class, () -> new CellParsers(ONE_IS_TRUE, null));
+	}
+
+	// ---- helpers
+
+	private static final class FixedListHandler implements DelimitedListHandler {
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> List<T> cellValueToList(Class<T> clazz, String cellValue) {
+			return (List<T>) List.of("fixed");
+		}
+
+		@Override
+		public String collectionToCellValue(Collection<?> collection) {
+			return "fixed";
+		}
+	}
+}

--- a/zulia-data/src/test/java/io/zulia/data/test/SpreadsheetRoundTripTest.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/SpreadsheetRoundTripTest.java
@@ -1,0 +1,82 @@
+package io.zulia.data.test;
+
+import io.zulia.data.input.SingleUseDataInputStream;
+import io.zulia.data.output.SingleUseDataOutputStream;
+import io.zulia.data.source.spreadsheet.SpreadsheetRecord;
+import io.zulia.data.source.spreadsheet.SpreadsheetSource;
+import io.zulia.data.source.spreadsheet.SpreadsheetSourceFactory;
+import io.zulia.data.target.spreadsheet.SpreadsheetTargetFactory;
+import org.apache.poi.util.LocaleUtil;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.TimeZone;
+
+/**
+ * What a target writes with its defaults, the matching source reads back with its defaults: whole cells and delimited lists of
+ * dates, booleans and numbers, with null list elements kept as placeholders.
+ */
+public class SpreadsheetRoundTripTest {
+
+	private static final List<String> HEADERS = List.of("date", "flag", "count", "amount", "dates", "flags", "counts");
+	private static final Date DATE = Date.from(Instant.parse("2024-12-18T08:00:00Z"));
+	private static final List<Date> DATES = List.of(DATE, Date.from(Instant.parse("2025-01-02T00:00:00Z")));
+	private static final List<Boolean> FLAGS = List.of(true, false);
+	private static final List<Long> COUNTS = Arrays.asList(1L, null, 3L);
+
+	@ParameterizedTest
+	@ValueSource(strings = { "test.csv", "test.tsv", "test.xlsx" })
+	void targetDefaultsReadBackThroughSourceDefaults(String fileName) throws IOException {
+		byte[] bytes = write(fileName);
+
+		SingleUseDataInputStream in = SingleUseDataInputStream.from(new ByteArrayInputStream(bytes), fileName);
+		try (SpreadsheetSource<?> source = SpreadsheetSourceFactory.fromStreamWithHeaders(in)) {
+			SpreadsheetRecord row = source.iterator().next();
+			Assertions.assertEquals(DATE, row.getDate("date"));
+			Assertions.assertEquals(Boolean.TRUE, row.getBoolean("flag"));
+			Assertions.assertEquals(42L, row.getLong("count"));
+			Assertions.assertEquals(1.5d, row.getDouble("amount"));
+			Assertions.assertEquals(DATES, row.getList("dates", Date.class));
+			Assertions.assertEquals(FLAGS, row.getList("flags", Boolean.class));
+			Assertions.assertEquals(COUNTS, row.getList("counts", Long.class));
+		}
+	}
+
+	/**
+	 * The Excel writer and reader both use POI's thread local time zone. Whatever the calling thread had set, a typed date
+	 * must come back unchanged.
+	 */
+	@ParameterizedTest
+	@ValueSource(strings = { "America/New_York", "Asia/Tokyo" })
+	void excelTypedDatesSurviveTheCallingThreadTimeZone(String zone) throws IOException {
+		TimeZone previous = LocaleUtil.getUserTimeZone();
+		try {
+			LocaleUtil.setUserTimeZone(TimeZone.getTimeZone(zone));
+			byte[] bytes = write("test.xlsx");
+			LocaleUtil.setUserTimeZone(TimeZone.getTimeZone(zone));
+			SingleUseDataInputStream in = SingleUseDataInputStream.from(new ByteArrayInputStream(bytes), "test.xlsx");
+			try (SpreadsheetSource<?> source = SpreadsheetSourceFactory.fromStreamWithHeaders(in)) {
+				Assertions.assertEquals(DATE, source.iterator().next().getDate("date"));
+			}
+		}
+		finally {
+			LocaleUtil.setUserTimeZone(previous);
+		}
+	}
+
+	private static byte[] write(String fileName) throws IOException {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		try (var target = SpreadsheetTargetFactory.fromStreamWithHeaders(SingleUseDataOutputStream.from(bytes, fileName), HEADERS)) {
+			target.writeRow(DATE, true, 42L, 1.5d, DATES, FLAGS, COUNTS);
+		}
+		return bytes.toByteArray();
+	}
+}

--- a/zulia-data/src/test/java/io/zulia/data/test/SpreadsheetTestFiles.java
+++ b/zulia-data/src/test/java/io/zulia/data/test/SpreadsheetTestFiles.java
@@ -1,0 +1,51 @@
+package io.zulia.data.test;
+
+import io.zulia.data.input.SingleUseDataInputStream;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.util.LocaleUtil;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.TimeZone;
+import java.util.function.Consumer;
+
+/**
+ * Builds small spreadsheet files in memory for the source tests.
+ */
+final class SpreadsheetTestFiles {
+
+	private SpreadsheetTestFiles() {
+	}
+
+	/**
+	 * Writes a one sheet workbook. ExcelSource reads dates in UTC through POI's thread local time zone, so the workbook is written
+	 * in UTC as well, otherwise a typed date cell round-trips shifted by the test machine's offset.
+	 */
+	static byte[] workbook(Consumer<Sheet> sheetConsumer) throws IOException {
+		TimeZone previous = LocaleUtil.getUserTimeZone();
+		LocaleUtil.setUserTimeZone(LocaleUtil.TIMEZONE_UTC);
+		try (XSSFWorkbook wb = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			sheetConsumer.accept(wb.createSheet("Sheet1"));
+			wb.write(out);
+			return out.toByteArray();
+		}
+		finally {
+			LocaleUtil.setUserTimeZone(previous);
+		}
+	}
+
+	static void header(Sheet sheet, String... names) {
+		Row row = sheet.createRow(0);
+		for (int i = 0; i < names.length; i++) {
+			row.createCell(i).setCellValue(names[i]);
+		}
+	}
+
+	static SingleUseDataInputStream csvStream(String csv) throws IOException {
+		return SingleUseDataInputStream.from(new ByteArrayInputStream(csv.getBytes(StandardCharsets.UTF_8)), "test.csv");
+	}
+}


### PR DESCRIPTION
# Parse Date and Boolean list elements and read blank cells as null
## Targets write what sources read
- `ExcelTarget` sets POI's thread local time zone to UTC the way `ExcelSource` does, and `ExcelSource` now sets it in the constructor as well as the static block, so a typed date written on a non-UTC machine reads back unchanged.
- `CellParsers` gains a `dateFormatter`, the inverse of the date parser, and `collectionToCellValue` writes Date elements with it.
- A list of dates used to be joined with `Date.toString()`, which no source could read. Null elements are written as blanks and numbers and booleans keep `toString`, which the parsers read.

## One parser definition for cells and list elements
- New `CellParsers` record holds the boolean and date parsers that `DelimitedSourceConfig` used to build inline.
- New `DelimitedListSettings` owns the list delimiter, the parsers and the list handler for both source configs.
- `DefaultDelimitedListHandler` takes `CellParsers` and converts Date and Boolean elements with them.
- `DefaultExcelCellHandler` takes `CellParsers` and uses them for text cells read with `getBoolean` and `getDate`.
- `ExcelSourceConfig` builds the default cell handler from its parsers unless one was set explicitly, and gains `withDateParser` and `withBooleanParser`. Typed cells are still read from the cell type.

## Blank cells and elements read as null or are skipped

- `SpreadsheetRecord.parseFromString` and the four Excel numeric readers trim the text and return null when it is blank.
- `cellValueToList` trims each element and reads a blank one as a null placeholder for every class but String, so `1;;3` as a Long list reads `[1, null, 3]`, positions line up with sibling list columns, and `collectionToCellValue` writes it back as `1;;3`. A blank whole cell reads as an empty list. String lists keep blank elements as text.